### PR TITLE
check for return value of writeMessage and writeBundle in OSC send

### DIFF
--- a/modules/juce_osc/osc/juce_OSCSender.cpp
+++ b/modules/juce_osc/osc/juce_OSCSender.cpp
@@ -231,14 +231,16 @@ struct OSCSender::Pimpl
     bool send (const OSCMessage& message, const String& hostName, int portNumber)
     {
         OSCOutputStream outStream;
-        outStream.writeMessage (message);
+        if (!outStream.writeMessage (message))
+            return false;
         return sendOutputStream (outStream, hostName, portNumber);
     }
 
     bool send (const OSCBundle& bundle, const String& hostName, int portNumber)
     {
         OSCOutputStream outStream;
-        outStream.writeBundle (bundle);
+        if (!outStream.writeBundle (bundle))
+            return false;
         return sendOutputStream (outStream, hostName, portNumber);
     }
 


### PR DESCRIPTION
writeMessage and writeBundle can fail for various reasons (~3 as seen in the source code).
In OSC send, their return value is not yet checked.
I think it would be safer to check it.