### PR TITLE
Disable adding internal filters twice

### DIFF
--- a/examples/audio plugin host/Source/FilterGraph.cpp
+++ b/examples/audio plugin host/Source/FilterGraph.cpp
@@ -77,6 +77,15 @@ const AudioProcessorGraph::Node::Ptr FilterGraph::getNodeForId (const uint32 uid
     return graph.getNodeForId (uid);
 }
 
+bool FilterGraph::hasFilter(const String name)
+{
+    for (int i = 0; i < graph.getNumNodes(); i++) {
+        if (graph.getNode(i)->getProcessor()->getName().equalsIgnoreCase(name))
+            return true;
+    }
+    return false;
+}
+
 void FilterGraph::addFilter (const PluginDescription* desc, double x, double y)
 {
     if (desc != nullptr)

--- a/examples/audio plugin host/Source/FilterGraph.h
+++ b/examples/audio plugin host/Source/FilterGraph.h
@@ -49,6 +49,8 @@ public:
     const AudioProcessorGraph::Node::Ptr getNode (const int index) const noexcept;
     const AudioProcessorGraph::Node::Ptr getNodeForId (const uint32 uid) const noexcept;
 
+    bool hasFilter(const String name);
+        
     void addFilter (const PluginDescription* desc, double x, double y);
 
     void addFilterCallback (AudioPluginInstance* instance, const String& error, double x, double y);

--- a/examples/audio plugin host/Source/MainHostWindow.cpp
+++ b/examples/audio plugin host/Source/MainHostWindow.cpp
@@ -319,8 +319,13 @@ void MainHostWindow::createPlugin (const PluginDescription* desc, int x, int y)
 
 void MainHostWindow::addPluginsToMenu (PopupMenu& m) const
 {
-    for (int i = 0; i < internalTypes.size(); ++i)
-        m.addItem (i + 1, internalTypes.getUnchecked(i)->name);
+    GraphDocumentComponent* const graphEditor = getGraphEditor();
+
+    for (int i = 0; i < internalTypes.size(); ++i) {
+        String name = internalTypes.getUnchecked(i)->name;
+		// add new menu item, but disable if this filter altready exists
+        m.addItem(i + 1, name, !graphEditor->graph->hasFilter(name));
+    }
 
     m.addSeparator();
 

--- a/examples/audio plugin host/Source/MainHostWindow.cpp
+++ b/examples/audio plugin host/Source/MainHostWindow.cpp
@@ -323,7 +323,7 @@ void MainHostWindow::addPluginsToMenu (PopupMenu& m) const
 
     for (int i = 0; i < internalTypes.size(); ++i) {
         String name = internalTypes.getUnchecked(i)->name;
-		// add new menu item, but disable if this filter altready exists
+        // add new menu item, but disable if this filter altready exists
         m.addItem(i + 1, name, !graphEditor->graph->hasFilter(name));
     }
 


### PR DESCRIPTION
Disable adding same internal filters twice, as all internal filters can be configured once and to one I/O only.
So imho it makes no sense adding them twice.
A transparent and intuitive solution to the user is disabling the already added filters in the menus.
Added a new method `hasFilter` to achieve this.