### PR TITLE
Drawable's copy constructor Fix

### DIFF
--- a/modules/juce_gui_basics/drawables/juce_Drawable.cpp
+++ b/modules/juce_gui_basics/drawables/juce_Drawable.cpp
@@ -1,4 +1,4 @@
-/*
+D/*
   ==============================================================================
 
    This file is part of the JUCE library.
@@ -29,8 +29,9 @@ Drawable::Drawable()
 }
 
 Drawable::Drawable (const Drawable& other)
-    : Component (other.getName())
+    : Drawable()
 {
+    setName(other.getName());
     setComponentID (other.getComponentID());
     setTransform (other.getTransform());
 }


### PR DESCRIPTION
Once **Drawable** is copied, two attributes related to **Component** gets reset to its default state. 
`setInterceptsMouseClicks()` and `setPaintingisUnclipped(), `are now set appropriately.