### PR TITLE
Added comparison operators to Uuid following standard IETF and ITU conventions.

### DIFF
--- a/modules/juce_core/misc/juce_Uuid.cpp
+++ b/modules/juce_core/misc/juce_Uuid.cpp
@@ -53,8 +53,38 @@ Uuid& Uuid::operator= (const Uuid& other) noexcept
     return *this;
 }
 
+int Uuid::getTimeLow (const Uuid& uuid) noexcept                    { return ((int) uuid.uuid[15] << 24) + ((int) uuid.uuid[14] << 16) + ((int) uuid.uuid[13] << 8) + (int) uuid.uuid[12]; }
+int16 Uuid::getTimeMid (const Uuid& uuid) noexcept                  { return ((int16) uuid.uuid[11] << 8) + (int16) uuid.uuid[10]; }
+int16 Uuid::getTimeHiAndVersion (const Uuid& uuid) noexcept         { return ((int16) uuid.uuid[9] << 8) + (int16) uuid.uuid[8]; }
+uint8 Uuid::getClockSeqHiAndReserved (const Uuid& uuid) noexcept    { return uuid.uuid[9]; }
+uint8 Uuid::getClockLow (const Uuid& uuid) noexcept                 { return uuid.uuid[8]; }
+
+int Uuid::compare (const Uuid& a, const Uuid& b) noexcept
+{
+    if (int r = check<int, getTimeLow> (a, b))                      return r;
+    if (int16 r = check<int16, getTimeMid> (a, b))                  return r;
+    if (int16 r = check<int16, getTimeHiAndVersion> (a, b))         return r;
+    if (uint8 r = check<uint8, getClockSeqHiAndReserved> (a, b))    return r;
+    if (uint8 r = check<uint8, getClockLow> (a, b))                 return r;
+
+    for (size_t i = 0; i <= 6; ++i)
+    {
+        if (a.uuid[i] < b.uuid[i])
+            return -1;
+
+        if (a.uuid[i] > b.uuid[i])
+            return 1;
+    }
+
+    return 0;
+}
+
 bool Uuid::operator== (const Uuid& other) const noexcept    { return memcmp (uuid, other.uuid, sizeof (uuid)) == 0; }
 bool Uuid::operator!= (const Uuid& other) const noexcept    { return ! operator== (other); }
+bool Uuid::operator< (const Uuid& other) const noexcept     { return compare (*this, other) < 0; }
+bool Uuid::operator<= (const Uuid& other) const noexcept    { return compare (*this, other) <= 0; }
+bool Uuid::operator> (const Uuid& other) const noexcept     { return compare (*this, other) > 0; }
+bool Uuid::operator>= (const Uuid& other) const noexcept    { return compare (*this, other) >= 0; }
 
 Uuid Uuid::null() noexcept
 {

--- a/modules/juce_core/misc/juce_Uuid.h
+++ b/modules/juce_core/misc/juce_Uuid.h
@@ -66,6 +66,10 @@ public:
 
     bool operator== (const Uuid&) const noexcept;
     bool operator!= (const Uuid&) const noexcept;
+    bool operator< (const Uuid&) const noexcept;
+    bool operator<= (const Uuid&) const noexcept;
+    bool operator> (const Uuid&) const noexcept;
+    bool operator>= (const Uuid&) const noexcept;
 
     //==============================================================================
     /** Returns a stringified version of this UUID.
@@ -114,6 +118,28 @@ private:
     //==============================================================================
     uint8 uuid[16];
     String getHexRegion (int, int) const;
+
+    /** Compare using the standard IETF and ITU conventions.
+        @returns -1 if a is less-than b, 0 if they're equal, and 1 if b is greater-than a.
+    */
+    static int compare (const Uuid& a, const Uuid& b) noexcept;
+    static int getTimeLow (const Uuid&) noexcept;
+    static int16 getTimeMid (const Uuid&) noexcept;
+    static int16 getTimeHiAndVersion (const Uuid&) noexcept;
+    static uint8 getClockSeqHiAndReserved (const Uuid&) noexcept;
+    static uint8 getClockLow (const Uuid&) noexcept;
+
+    template<typename ReturnType, ReturnType (*ComponentGetter) (const Uuid&) noexcept>
+    static uint8 check (const Uuid& a, const Uuid& b) noexcept
+    {
+        const ReturnType x = ComponentGetter (a);
+        const ReturnType y = ComponentGetter (b);
+
+        if (x != y)
+            return x < y ? -1 : 1;
+
+        return 0;
+    }
 
     JUCE_LEAK_DETECTOR (Uuid)
 };


### PR DESCRIPTION
Sources and inspiration:

- https://www.ietf.org/rfc/rfc4122.txt
- http://oid-info.com/get/2.25
- http://www.boost.org/doc/libs/1_61_0/libs/uuid/uuid.html
- http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/util/UUID.java

Forum post: https://forum.juce.com/t/uuid-comparison-operator-improvements/22005