### PR TITLE
Fix crash in Projucer's Android exporter

### DIFF
--- a/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Android.h
+++ b/extras/Projucer/Source/Project Saving/jucer_ProjectExport_Android.h
@@ -790,6 +790,9 @@ private:
 
     void initialiseDependencyPathValues()
     {
+        vst3Path.referTo (Value (new DependencyPathValueSource (getSetting (Ids::vst3Folder),
+                                                                Ids::vst3Path, TargetOS::getThisOS())));
+
         sdkPath.referTo (Value (new DependencyPathValueSource (getSetting (Ids::androidSDKPath),
                                                                Ids::androidSDKPath, TargetOS::getThisOS())));
 


### PR DESCRIPTION
Steps to reproduce:
 - create gui app project,
 - set JUCE_PLUGINHOST_VST3 property enabled,
 - add Android exporter and try to select it