### PR TITLE
Added dynamic paint support to ProJucer

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/documents/jucer_ComponentDocument.cpp
+++ b/extras/Projucer/Source/ComponentEditor/documents/jucer_ComponentDocument.cpp
@@ -93,6 +93,11 @@ bool ComponentDocument::loadFromXml (const XmlElement& xml)
     return false;
 }
 
+void ComponentDocument::applyCustomPaintSnippets (StringArray& snippets)
+{
+    backgroundGraphics->applyCustomPaintSnippets (snippets);
+}
+
 //==============================================================================
 class NormalTestComponent   : public Component
 {

--- a/extras/Projucer/Source/ComponentEditor/documents/jucer_ComponentDocument.h
+++ b/extras/Projucer/Source/ComponentEditor/documents/jucer_ComponentDocument.h
@@ -53,6 +53,7 @@ public:
     bool loadFromXml (const XmlElement& xml);
 
     void fillInGeneratedCode (GeneratedCode& code) const;
+    void applyCustomPaintSnippets (StringArray&);
 
 private:
     ScopedPointer<ComponentLayout> components;

--- a/extras/Projucer/Source/ComponentEditor/jucer_GeneratedCode.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_GeneratedCode.cpp
@@ -294,7 +294,8 @@ static void copyAcrossUserSections (String& dest, const String& src)
                 {
                     StringArray sourceLines;
 
-                    if (getUserSection (srcLines, tag, sourceLines))
+                    if (tag != "UserPaintCustomArguments" &&
+                        getUserSection (srcLines, tag, sourceLines))
                     {
                         for (int j = endLine - i; --j > 0;)
                             dstLines.remove (i + 1);

--- a/extras/Projucer/Source/ComponentEditor/jucer_JucerDocument.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_JucerDocument.h
@@ -135,6 +135,9 @@ public:
     void setTemplateFile (const String&);
 
     static bool shouldUseTransMacro() noexcept                              { return true; }
+    
+    //==============================================================================
+    void refreshCustomCodeFromDocument();
 
 protected:
     SourceCodeDocument* cpp;
@@ -152,6 +155,8 @@ protected:
 
     virtual void fillInGeneratedCode (GeneratedCode&) const;
     virtual void fillInPaintCode (GeneratedCode&) const;
+    
+    virtual void applyCustomPaintSnippets (StringArray&) {}
 
     static void addMethod (const String& base, const String& returnVal,
                            const String& method, const String& initialContent,
@@ -172,6 +177,7 @@ private:
     void codeDocumentTextDeleted (int startIndex, int endIndex) override;
     void userEditedCpp();
     bool documentAboutToClose (OpenDocumentManager::Document*) override;
+    void extractCustomPaintSnippetsFromCppFile (const String& cpp);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (JucerDocument)
 };

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
@@ -582,3 +582,9 @@ void PaintRoutine::fillInGeneratedCode (GeneratedCode& code, String& paintMethod
     for (int i = 0; i < elements.size(); ++i)
         elements[i]->fillInGeneratedCode (code, paintMethodCode);
 }
+
+void PaintRoutine::applyCustomPaintSnippets (StringArray& snippets)
+{
+    for (int i = 0; i < elements.size(); ++i)
+        elements[i]->applyCustomPaintSnippets (snippets);
+}

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
@@ -103,6 +103,8 @@ public:
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) const;
 
+    void applyCustomPaintSnippets (StringArray&);
+    
     //==============================================================================
 private:
     OwnedArray <PaintElement> elements;

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_FillType.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_FillType.h
@@ -116,21 +116,51 @@ public:
                                                mode == radialGradient));
         }
     }
-
-    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) const
+    
+    String generateVariablesCode (String type) const
+    {
+        String s;
+        switch (mode)
+        {
+            case solidColour:
+                s << "Colour " << type << "Colour = " << CodeHelpers::colourToCode (colour) << ";\n";
+                break;
+                
+            case linearGradient:
+            case radialGradient:
+            {
+                s << "Colour " << type << "Colour1 = " << CodeHelpers::colourToCode (gradCol1) << ", " << type << "Colour2 = " << CodeHelpers::colourToCode (gradCol2) << ";\n";
+                break;
+            }
+                
+            case imageBrush:
+            {
+                break;
+            }
+                
+            default:
+                jassertfalse;
+                break;
+        }
+        
+        return s;
+    }
+    
+    void fillInGeneratedCode (String type, RelativePositionedRectangle relativeTo, GeneratedCode& code, String& paintMethodCode) const
     {
         String s;
 
         switch (mode)
         {
         case solidColour:
-            s << "g.setColour (" << CodeHelpers::colourToCode (colour) << ");\n";
+            s << "g.setColour (" << type << "Colour);\n";
             break;
 
         case linearGradient:
         case radialGradient:
             {
-                String x1, y1, w, h, x2, y2;
+                String x0, y0, x1, y1, w, h, x2, y2;
+                positionToCode (relativeTo, code.document->getComponentLayout(), x0, y0, w, h);
                 positionToCode (gradPos1, code.document->getComponentLayout(), x1, y1, w, h);
                 positionToCode (gradPos2, code.document->getComponentLayout(), x2, y2, w, h);
 
@@ -138,10 +168,12 @@ public:
 
                 const String indent (String::repeatedString (" ", s.length()));
 
-                s << CodeHelpers::colourToCode (gradCol1) << ",\n"
-                  << indent << castToFloat (x1) << ", " << castToFloat (y1) << ",\n"
-                  << indent << CodeHelpers::colourToCode (gradCol2) << ",\n"
-                  << indent << castToFloat (x2) << ", " << castToFloat (y2) << ",\n"
+                s << type << "Colour1,\n"
+                  << indent << castToFloat (x1) << " - " << castToFloat (x0) << " + x,\n"
+                  << indent << castToFloat (y1) << " - " << castToFloat (y0) << " + y,\n"
+                  << indent << type << "Colour2,\n"
+                  << indent << castToFloat (x2) << " - " << castToFloat (x0) << " + x,\n"
+                  << indent << castToFloat (y2) << " - " << castToFloat (y0) << " + y,\n"
                   << indent << CodeHelpers::boolLiteral (mode == radialGradient) << "));\n";
                 break;
             }
@@ -152,15 +184,17 @@ public:
 
                 code.addImageResourceLoader (imageVariable, imageResourceName);
 
-                String x, y, w, h;
-                positionToCode (imageAnchor, code.document->getComponentLayout(), x, y, w, h);
+                String x0, y0, x1, y1, w, h;
+                positionToCode (relativeTo, code.document->getComponentLayout(), x0, y0, w, h);
+                positionToCode (imageAnchor, code.document->getComponentLayout(), x1, y1, w, h);
 
                 s << "g.setTiledImageFill (";
 
                 const String indent (String::repeatedString (" ", s.length()));
 
                 s << imageVariable << ",\n"
-                  << indent << x << ", " << y << ",\n"
+                  << indent << x1 << " - " << x0 << " + x,\n"
+                  << indent << y1 << " - " << y0 << " + y,\n"
                   << indent << CodeHelpers::floatLiteral (imageOpacity, 4) << ");\n";
 
                 break;

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
@@ -94,6 +94,8 @@ public:
     void changeListenerCallback (ChangeBroadcaster*);
     void parentHierarchyChanged();
 
+    virtual void applyCustomPaintSnippets (StringArray&) {}
+
     int borderThickness;
 
 protected:
@@ -159,7 +161,7 @@ public:
     void changeListenerCallback (ChangeBroadcaster*)
     {
         jassert (propToRefresh != nullptr);
-        if (propToRefresh != nullptr)
+        if (propToRefresh != nullptr && owner != nullptr)
             propToRefresh->refresh();
     }
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
@@ -62,38 +62,56 @@ public:
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
     {
+        if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
+            return;
+        
+        String x, y, w, h, s;
+        positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
+        s << "{\n"
+          << "    float x = " << castToFloat (x) << ", y = " << castToFloat (y) << ", "
+          <<           "width = " << castToFloat (w) << ", height = " << castToFloat (h) << ";\n";
         if (! fillType.isInvisible())
         {
-            String x, y, w, h, s;
-            positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
-
-            fillType.fillInGeneratedCode (code, paintMethodCode);
-            s << "g.fillEllipse ("
-              << castToFloat (x) << ", "
-              << castToFloat (y) << ", "
-              << castToFloat (w) << ", "
-              << castToFloat (h) << ");\n\n";
-
-            paintMethodCode += s;
+            s << "    " << fillType.generateVariablesCode ("fill");
+        }
+        if (isStrokePresent && ! strokeType.isInvisible())
+        {
+            s << "    " << strokeType.fill.generateVariablesCode ("stroke");
+        }
+        s << "    //[UserPaintCustomArguments] Customize the painting arguments here..\n"
+          << customPaintCode
+          << "    //[/UserPaintCustomArguments]\n";
+        
+        if (! fillType.isInvisible())
+        {
+            s << "    ";
+            fillType.fillInGeneratedCode ("fill", position, code, s);
+            s << "    g.fillEllipse (x, y, width, height);\n";
         }
 
         if (isStrokePresent && ! strokeType.isInvisible())
         {
-            String x, y, w, h, s;
-            positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
-
-            strokeType.fill.fillInGeneratedCode (code, paintMethodCode);
-            s << "g.drawEllipse ("
-              << castToFloat (x) << ", "
-              << castToFloat (y) << ", "
-              << castToFloat (w) << ", "
-              << castToFloat (h) << ", "
-              << CodeHelpers::floatLiteral (strokeType.stroke.getStrokeThickness(), 3) << ");\n\n";
-
-            paintMethodCode += s;
+            s << "    ";
+            strokeType.fill.fillInGeneratedCode ("stroke", position, code, s);
+            s << "    g.drawEllipse (x, y, width, height, " << CodeHelpers::floatLiteral (strokeType.stroke.getStrokeThickness(), 3) << ");\n";
         }
+        
+        s << "}\n\n";
+        
+        paintMethodCode += s;
     }
 
+    void applyCustomPaintSnippets (StringArray& snippets)
+    {
+        customPaintCode.clear();
+        
+        if (! snippets.isEmpty() && (! fillType.isInvisible() || (isStrokePresent && ! strokeType.isInvisible())))
+        {
+            customPaintCode = snippets[0];
+            snippets.remove(0);
+        }
+    }
+    
     static const char* getTagName() noexcept        { return "ELLIPSE"; }
 
     XmlElement* createXml() const
@@ -131,6 +149,8 @@ public:
     }
 
 private:
+    String customPaintCode;
+ 
     //==============================================================================
     class ShapeToPathProperty  : public ButtonPropertyComponent
     {

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
@@ -209,6 +209,14 @@ public:
         return false;
     }
 
+    void applyCustomPaintSnippets (StringArray& snippets)
+    {
+        for (int i = 0; i < subElements.size(); ++i)
+        {
+            subElements.getUnchecked(i)->applyCustomPaintSnippets(snippets);
+        }
+    }
+    
 private:
     OwnedArray <PaintElement> subElements;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
@@ -95,10 +95,16 @@ public:
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
     {
-        String r;
-
         if (opacity > 0)
         {
+            String x, y, w, h, r;
+            positionToCode (position, getDocument()->getComponentLayout(), x, y, w, h);
+            r << "{\n"
+              << "    int x = " << x << ", y = " << y << ", width = " << w << ", height = " << h << ";\n"
+              << "    //[UserPaintCustomArguments] Customize the painting arguments here..\n"
+              << customPaintCode
+              << "    //[/UserPaintCustomArguments]\n";
+            
             if (dynamic_cast<const DrawableImage*> (getDrawable()) != 0)
             {
                 const String imageVariable ("cachedImage_" + resourceName.replace ("::", "_") + "_" + String (code.getUniqueSuffix()));
@@ -106,36 +112,32 @@ public:
                 code.addImageResourceLoader (imageVariable, resourceName);
 
                 if (opacity >= 254.0 / 255.0)
-                    r << "g.setColour (Colours::black);\n";
+                    r << "    g.setColour (Colours::black);\n";
                 else
-                    r << "g.setColour (Colours::black.withAlpha (" << CodeHelpers::floatLiteral (opacity, 3) << "));\n";
+                    r << "    g.setColour (Colours::black.withAlpha (" << CodeHelpers::floatLiteral (opacity, 3) << "));\n";
 
-                String x, y, w, h;
-                positionToCode (position, getDocument()->getComponentLayout(), x, y, w, h);
 
                 if (mode == stretched)
                 {
-                    r << "g.drawImage (" << imageVariable << ",\n             "
-                      << x << ", " << y << ", " << w << ", " << h
-                      << ",\n             0, 0, "
-                      << imageVariable << ".getWidth(), "
-                      << imageVariable << ".getHeight());\n\n";
+                    r << "    g.drawImage (" << imageVariable << ",\n"
+                      << "                 x, y, width, height,\n"
+                      << "                 0, 0, " << imageVariable << ".getWidth(), " << imageVariable << ".getHeight());\n";
                 }
                 else
                 {
-                    r << "g.drawImageWithin (" << imageVariable << ",\n                   "
-                      << x << ", " << y << ", " << w << ", " << h
-                      << ",\n                   ";
+                    r << "    g.drawImageWithin (" << imageVariable << ",\n"
+                      << "                       x, y, width, height,\n"
+                      << "                       ";
 
                     if (mode == proportionalReducingOnly)
                         r << "RectanglePlacement::centred | RectanglePlacement::onlyReduceInSize";
                     else
                         r << "RectanglePlacement::centred";
 
-                    r << ",\n                   false);\n\n";
+                    r << ",\n"
+                      << "                       false);\n";
                 }
 
-                paintMethodCode += r;
             }
             else
             {
@@ -154,28 +156,35 @@ public:
                         << imageVariable << " = nullptr;\n";
 
                     if (opacity >= 254.0 / 255.0)
-                        r << "g.setColour (Colours::black);\n";
+                        r << "    g.setColour (Colours::black);\n";
                     else
-                        r << "g.setColour (Colours::black.withAlpha (" << CodeHelpers::floatLiteral (opacity, 3) << "));\n";
+                        r << "    g.setColour (Colours::black.withAlpha (" << CodeHelpers::floatLiteral (opacity, 3) << "));\n";
 
-                    String x, y, w, h;
-                    positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
-
-                    r << "jassert (" << imageVariable << " != 0);\n"
-                      << "if (" << imageVariable << " != 0)\n    "
-                      << imageVariable  << "->drawWithin (g, Rectangle<float> ("
-                      << x << ", " << y << ", " << w << ", " << h
-                      << "),\n"
-                      << String::repeatedString (" ", imageVariable.length() + 18)
+                    r << "    jassert (" << imageVariable << " != 0);\n"
+                      << "    if (" << imageVariable << " != 0)\n"
+                      << "        " << imageVariable  << "->drawWithin (g, Rectangle<float> (x, y, width, height),\n"
+                      << "    " << String::repeatedString (" ", imageVariable.length() + 18)
                       << (mode == stretched ? "RectanglePlacement::stretchToFit"
                                             : (mode == proportionalReducingOnly ? "RectanglePlacement::centred | RectanglePlacement::onlyReduceInSize"
                                                                                 : "RectanglePlacement::centred"))
-                      << ", " << CodeHelpers::floatLiteral (opacity, 3)
-                      << ");\n\n";
-
-                    paintMethodCode += r;
+                      << ", " << CodeHelpers::floatLiteral (opacity, 3) << ");\n";
                 }
             }
+            
+            r << "}\n\n";
+            
+            paintMethodCode += r;
+        }
+    }
+
+    void applyCustomPaintSnippets (StringArray& snippets)
+    {
+        customPaintCode.clear();
+        
+        if (! snippets.isEmpty() && opacity > 0)
+        {
+            customPaintCode = snippets[0];
+            snippets.remove(0);
         }
     }
 
@@ -385,6 +394,7 @@ private:
     String resourceName;
     double opacity;
     StretchMode mode;
+    String customPaintCode;
 
     //==============================================================================
     class ImageElementResourceProperty    : public ImageResourceProperty <PaintElementImage>

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
@@ -101,6 +101,7 @@ public:
     void getEditableProperties (Array<PropertyComponent*>& props);
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode);
+    void applyCustomPaintSnippets (StringArray& snippets);
 
     //==============================================================================
     static const char* getTagName() noexcept                            { return "PATH"; }
@@ -132,6 +133,7 @@ private:
     mutable Rectangle<int> lastPathBounds;
     int mouseDownOnSegment;
     bool mouseDownSelectSegmentStatus;
+    String customPaintCode;
 
     String pathToString() const;
     void restorePathFromString (const String& s);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
@@ -116,37 +116,53 @@ public:
     //==============================================================================
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
     {
+        if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
+            return;
+        
+        String x, y, w, h, s;
+        positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
+        s << "{\n"
+          << "    float x = " << castToFloat (x) << ", y = " << castToFloat (y) << ", "
+          <<           "width = " << castToFloat (w) << ", height = " << castToFloat (h) << ";\n";
         if (! fillType.isInvisible())
         {
-            String x, y, w, h, s;
-            positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
-
-            fillType.fillInGeneratedCode (code, paintMethodCode);
-            s << "g.fillRoundedRectangle ("
-              << castToFloat (x) << ", "
-              << castToFloat (y) << ", "
-              << castToFloat (w) << ", "
-              << castToFloat (h) << ", "
-              << CodeHelpers::floatLiteral (cornerSize, 3) << ");\n\n";
-
-            paintMethodCode += s;
+            s << "    " << fillType.generateVariablesCode ("fill");
+        }
+        if (isStrokePresent && ! strokeType.isInvisible())
+        {
+            s << "    " << strokeType.fill.generateVariablesCode ("stroke");
+        }
+        s << "    //[UserPaintCustomArguments] Customize the painting arguments here..\n"
+          << customPaintCode
+          << "    //[/UserPaintCustomArguments]\n";
+  
+        if (! fillType.isInvisible())
+        {
+            s << "    ";
+            fillType.fillInGeneratedCode ("fill", position, code, s);
+            s << "    g.fillRoundedRectangle (x, y, width, height, " << CodeHelpers::floatLiteral (cornerSize, 3)  << ");\n";
         }
 
         if (isStrokePresent && ! strokeType.isInvisible())
         {
-            String x, y, w, h, s;
-            positionToCode (position, code.document->getComponentLayout(), x, y, w, h);
+            s << "    ";
+            strokeType.fill.fillInGeneratedCode ("stroke", position, code, s);
+            s << "    g.drawRoundedRectangle (x, y, width, height, " << CodeHelpers::floatLiteral (cornerSize, 3)  << ", " << CodeHelpers::floatLiteral (strokeType.stroke.getStrokeThickness(), 3) << ");\n";
+        }
+        
+        s << "}\n\n";
+        
+        paintMethodCode += s;
+    }
 
-            strokeType.fill.fillInGeneratedCode (code, paintMethodCode);
-            s << "g.drawRoundedRectangle ("
-              << castToFloat (x) << ", "
-              << castToFloat (y) << ", "
-              << castToFloat (w) << ", "
-              << castToFloat (h) << ", "
-              << CodeHelpers::floatLiteral (cornerSize, 3) << ", "
-              << CodeHelpers::floatLiteral (strokeType.stroke.getStrokeThickness(), 3) << ");\n\n";
-
-            paintMethodCode += s;
+    void applyCustomPaintSnippets (StringArray& snippets)
+    {
+        customPaintCode.clear();
+        
+        if (! snippets.isEmpty() && (! fillType.isInvisible() || (isStrokePresent && ! strokeType.isInvisible())))
+        {
+            customPaintCode = snippets[0];
+            snippets.remove(0);
         }
     }
 
@@ -191,7 +207,8 @@ public:
 
 private:
     double cornerSize;
-
+    String customPaintCode;
+    
     //==============================================================================
     class CornerSizeProperty  : public SliderPropertyComponent,
                                 public ChangeListener

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
@@ -316,9 +316,19 @@ static SourceCodeEditor* createCodeEditor (const File& file, SourceCodeDocument&
 }
 
 //==============================================================================
+JucerDocumentTabs::JucerDocumentTabs(JucerDocument* const doc) : TabbedComponent(TabbedButtonBar::TabsAtTop), document(doc)
+{
+}
+
+void JucerDocumentTabs::currentTabChanged (const int, const String&)
+{
+    document->refreshCustomCodeFromDocument();
+}
+
+//==============================================================================
 JucerDocumentEditor::JucerDocumentEditor (JucerDocument* const doc)
     : document (doc),
-      tabbedComponent (TabbedButtonBar::TabsAtTop),
+      tabbedComponent (doc),
       compLayoutPanel (0),
       lastViewportX (0),
       lastViewportY (0),

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.h
@@ -35,6 +35,17 @@
 //==============================================================================
 /**
 */
+class JucerDocumentTabs : public TabbedComponent
+{
+public:
+    JucerDocumentTabs(JucerDocument* const);
+    
+    void currentTabChanged (const int, const String&);
+    
+private:
+    JucerDocument* const document;
+};
+
 class JucerDocumentEditor   : public Component,
                               public ApplicationCommandTarget,
                               public ChangeListener
@@ -73,7 +84,7 @@ public:
 
 private:
     ScopedPointer<JucerDocument> document;
-    TabbedComponent tabbedComponent;
+    JucerDocumentTabs tabbedComponent;
     ComponentLayoutPanel* compLayoutPanel;
 
     bool isSomethingSelected() const;

--- a/extras/Projucer/Source/Utility/jucer_CodeHelpers.cpp
+++ b/extras/Projucer/Source/Utility/jucer_CodeHelpers.cpp
@@ -46,6 +46,28 @@ namespace CodeHelpers
             String s (lines[i].trimEnd());
             if (s.isNotEmpty())
                 s = space + s;
+            
+            lines.set (i, s);
+        }
+        
+        return lines.joinIntoString (newLine);
+    }
+    
+    String unindent (const String& code, const int numSpaces)
+    {
+        if (numSpaces == 0)
+            return code;
+
+        const String space (String::repeatedString (" ", numSpaces));
+
+        StringArray lines;
+        lines.addLines (code);
+
+        for (int i = 0; i < lines.size(); ++i)
+        {
+            String s (lines[i].trimEnd());
+            if (s.startsWith(space))
+                s = s.substring(space.length());
 
             lines.set (i, s);
         }

--- a/extras/Projucer/Source/Utility/jucer_CodeHelpers.h
+++ b/extras/Projucer/Source/Utility/jucer_CodeHelpers.h
@@ -31,6 +31,7 @@
 namespace CodeHelpers
 {
     String indent (const String& code, const int numSpaces, bool indentFirstLine);
+    String unindent (const String& code, const int numSpaces);
     String makeValidIdentifier (String s, bool capitalise, bool removeColons, bool allowTemplates);
     String createIncludeStatement (const File& includedFile, const File& targetFile);
     String createIncludeStatement (const String& includePath);


### PR DESCRIPTION
This adds support for dynamic paint code

The code generated by the paint objects, now generates variables for x, y, width, height, text and the different colors. These are put together with the paint code in a dedicated block for an isolation scope. After the variables declaration and definition, a comment is insert that allows developers to modify the values of those variables. Since there's an arbitrary number of comment blocks possible, they're handled differently from the other ProJucer comments, in that the same name is reused. The individual comment is identified by the order of occurrence, which matches the order of the paint objects. When the code is parsed, the paint objects receive a copy of the customization code, allowing it to be included when the code is generated. The standard way of copying over code inside comment blocks from an previous version, now has a bypass condition that make it ignore these new comments.