### PR TITLE
Fix logic to determine the physical processor count on windows

### DIFF
--- a/modules/juce_core/native/juce_win32_SystemStats.cpp
+++ b/modules/juce_core/native/juce_win32_SystemStats.cpp
@@ -100,7 +100,8 @@ static int findNumberOfPhysicalCores() noexcept
     int numPhysicalCores = 0;
     DWORD bufferSize = 0;
 
-    if (GetLogicalProcessorInformation (nullptr, &bufferSize))
+    // We expect this to fail, but to indicate the required buffer size
+    if (!GetLogicalProcessorInformation (nullptr, &bufferSize))
     {
         const size_t numBuffers = (size_t) (bufferSize / sizeof (SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
         HeapBlock<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buffer (numBuffers);


### PR DESCRIPTION
The demo SystemInfo tab was showing the incorrect number of physical CPUs under Windows. The existing logic was failing, dropping through, and using the logical CPU count instead, so was only visible with hyperthreading enabled.

This now correctly reports the physical CPUs on my test box.