### PR TITLE
Fixed build error in VS2015 debug config

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -688,7 +688,9 @@ void AudioProcessor::addParameter (AudioProcessorParameter* p)
     auto paramId = getParameterID (p->parameterIndex);
 
     for (auto q : managedParameters)
+    {
         jassert (q == nullptr || q == p || paramId != getParameterID (q->parameterIndex));
+    }
    #endif
 }
 


### PR DESCRIPTION
Error details:
juce_AudioProcessor.cpp(691): error C2059: syntax error: '}'