### PR TITLE
Changes to Projucer Component Editor and Graphics element editor in o…

### DIFF
--- a/extras/Projucer/Builds/MacOSX/Projucer.xcodeproj/project.pbxproj
+++ b/extras/Projucer/Builds/MacOSX/Projucer.xcodeproj/project.pbxproj
@@ -6,759 +6,1044 @@
 	objectVersion = 46;
 	objects = {
 
-		A6A9D7624D002544ECB81D82 = {isa = PBXBuildFile; fileRef = 09DE066936CF037E9709ADB1; };
-		A578EAD4BB55680E8097BE0F = {isa = PBXBuildFile; fileRef = 80D62B907248523E6943298B; };
-		C1B9334AE849F93FB3C56B34 = {isa = PBXBuildFile; fileRef = 5A75806B34E4EA6598A6024A; };
-		8B4A593B3869815BBAC3EF93 = {isa = PBXBuildFile; fileRef = 7B3F7ECF6DBF8C8EE5C2CB86; };
-		A14C2C2725DA3CA7995D2815 = {isa = PBXBuildFile; fileRef = 210CD22F25F2C22F9CEEB025; };
-		1E76E36772355E2A43CF4961 = {isa = PBXBuildFile; fileRef = D00F311BFC3C2625C457CB9B; };
-		241F29FCBB7A17BB44A0B10C = {isa = PBXBuildFile; fileRef = D1F9B0E9F5D54FE48BEB46EA; };
-		9359F9401D59B4517F75C39C = {isa = PBXBuildFile; fileRef = 728FE25157E9874D50BBECB2; };
-		091A57B4B9CE623E75E9A756 = {isa = PBXBuildFile; fileRef = E983E6DDE3318B872EBE347F; };
-		FAB47E69F7D9DCE1F906AA07 = {isa = PBXBuildFile; fileRef = 8F7BE18698ADCEF51CDE4A5C; };
-		0E884E47A637D6C65154699A = {isa = PBXBuildFile; fileRef = 842427CFE565F3FCE5B99174; };
-		49C22786B54C5DC94E4654B8 = {isa = PBXBuildFile; fileRef = E96597BBC6A98255B51B94DC; };
-		CDEF9FF2D119476D707305DF = {isa = PBXBuildFile; fileRef = 431D30038CBF67F80E8B3A13; };
-		96EC6315E1B3F1A109F84BAF = {isa = PBXBuildFile; fileRef = 9F01BA9942D038EA8B5289A8; };
-		11D42F7EC6E6539D79A7F4B1 = {isa = PBXBuildFile; fileRef = E5D6C36496F5BC84D7213BE8; };
-		B980464FA2761CCD64B1FAD6 = {isa = PBXBuildFile; fileRef = CF6C8BD0DA3D8CD4E99EBADA; };
-		2610F357881240ACBF612F48 = {isa = PBXBuildFile; fileRef = 6678E9B3EEACAD47F438B264; };
-		1321E6C1C6170B6C898AD09D = {isa = PBXBuildFile; fileRef = 951128CA33CCDEF570436B1C; };
-		357A6AA6960EF95D92929BEE = {isa = PBXBuildFile; fileRef = 441CFEA771BAA50E187342E9; };
-		6DD9DA1677A6CF789CDAB478 = {isa = PBXBuildFile; fileRef = 0D4D508C638BC74943B9976D; };
-		954A036F5DDB375DB23FFB3E = {isa = PBXBuildFile; fileRef = 0400CB0E056A1D840304D2DE; };
-		3EB3D569250C4BA4CA9AF578 = {isa = PBXBuildFile; fileRef = C7608A3967D9AB9481848F2B; };
-		636D21BF846031A6A1A7476A = {isa = PBXBuildFile; fileRef = 11EB44786085029106099D01; };
-		95B44E6C74B1DED31DBE37EB = {isa = PBXBuildFile; fileRef = 8C52A3DDA62A746AA7A68535; };
-		AA9D0B8E23F3D87A23DE9F8A = {isa = PBXBuildFile; fileRef = 9069981E414A631B036CC9AC; };
-		244BA1BDA5FAA465EA3F9C6D = {isa = PBXBuildFile; fileRef = 2247EE920DF0610CAF9F4513; };
-		6FD0752A5CADCF60D79FDBB7 = {isa = PBXBuildFile; fileRef = 51CBE59779A36D1B80B26974; };
-		85B5E65F8DD80938BFBDCE61 = {isa = PBXBuildFile; fileRef = A1333F975410DD3DBBE2841F; };
-		D805169E01D7F90B01C11769 = {isa = PBXBuildFile; fileRef = 635290DEB1D564927D7A450C; };
-		FCE6F604C00039A32649CB69 = {isa = PBXBuildFile; fileRef = 2E680E2C65684A4272AE079A; };
-		9BF773500BA51A8B5C6C7348 = {isa = PBXBuildFile; fileRef = 65C498761CE166072A202AA0; };
-		57B1F32A372143B4D3B1C517 = {isa = PBXBuildFile; fileRef = 3E03B7C7A19E63A724EB79F4; };
-		3DC282564876B1FC88AAA9B3 = {isa = PBXBuildFile; fileRef = 662C76394C5D1B56766FAFD9; };
-		C49E1D32A9DCE3D59BC48B1D = {isa = PBXBuildFile; fileRef = 93B419190CCE92ACAB1ED25B; };
-		E1268E019B434F6B5E9317DC = {isa = PBXBuildFile; fileRef = 1C216FE9B7A5209C5CCF2517; };
-		CE91112DADB97C573C3C674D = {isa = PBXBuildFile; fileRef = 0169ACAA0FAE70CCEEE4F650; };
-		A70F0274076C0D44ED71C980 = {isa = PBXBuildFile; fileRef = EF30A74B566A461A171BBF83; };
-		BD1E0CBE74DDD2F303978E1F = {isa = PBXBuildFile; fileRef = 4E191CDCE7565DB726CF7065; };
-		8C1CC0E7A772D66635BA482F = {isa = PBXBuildFile; fileRef = 98F42686D9DAC974F2514217; };
-		A69BF71FA90E5A66B6EB2E0F = {isa = PBXBuildFile; fileRef = 9C7FA58D223674C4C2AC6595; };
-		D68DE111AFBD82F0D44A3B69 = {isa = PBXBuildFile; fileRef = B15E33E7342F6EB4F95C9B1D; };
-		EC6A34EC9A9D454BF26AAD32 = {isa = PBXBuildFile; fileRef = 16203C6791259C9718A04C3A; };
-		8AD28823205783E6F676F254 = {isa = PBXBuildFile; fileRef = DF725A596B7BCD7520CC0A9F; };
-		34716A3539FD288C09CBA38A = {isa = PBXBuildFile; fileRef = 921752D9B004A15973DDF56F; };
-		45A53AF13B0D663050632E8C = {isa = PBXBuildFile; fileRef = 9EF583A6201DBC813C2F63C4; };
-		C2A85091A28C907A4E1E1687 = {isa = PBXBuildFile; fileRef = 133F1E428260C5ADDF496DF9; };
-		83431B7234A78ECFB3C15F63 = {isa = PBXBuildFile; fileRef = 78D0DBC4798FF040FDB90F6D; };
-		209FCCC2155A1FCB7E11E20D = {isa = PBXBuildFile; fileRef = 269A454F1FF081DA67FFD578; };
-		C93569F47B4AC1A8E37992ED = {isa = PBXBuildFile; fileRef = 9D7689451732AF8333402B3A; };
-		1B988E139004D8E2850EB656 = {isa = PBXBuildFile; fileRef = C187718F7B9EBA88584B43F3; };
-		3D777382FE212D59BAF871FD = {isa = PBXBuildFile; fileRef = DCBB17488227A2CA7D3D3947; };
-		3FCA61C401007B243E2E9035 = {isa = PBXBuildFile; fileRef = F797071D88542C813CF7222A; };
-		30B921C38DCEE787B294B746 = {isa = PBXBuildFile; fileRef = BAC43B20E14A340CCF14119C; };
-		1F37544891EC8DBB5E500C1C = {isa = PBXBuildFile; fileRef = F71AF6D2DF3E652F8B51EBAB; };
-		0C5F43C262695A3EB7A9E1C0 = {isa = PBXBuildFile; fileRef = 14A24BB4AB7B81D40EF062E5; };
-		110221CD5578153B528AD2BE = {isa = PBXBuildFile; fileRef = D10D51A0A2D63F38B4D86A60; };
-		CD4F7B119CE718BCE78D61F4 = {isa = PBXBuildFile; fileRef = 9B9CAD20E1243B4351B4C8D8; };
-		78CB463DD98A55313A543859 = {isa = PBXBuildFile; fileRef = 1729AEDC34001C31B8CC357C; };
-		1499DF2E85B05AC1BF423773 = {isa = PBXBuildFile; fileRef = CF21D9DB3AEC0A4DCAB36A99; };
-		123810DAF8AF758928916ECE = {isa = PBXBuildFile; fileRef = 47DD50A5A9091F9900E0EAD9; };
-		C9F11BA62D6D092A300363F7 = {isa = PBXBuildFile; fileRef = 0F249640243FBD5717F6ADD9; };
-		9EAF9BE59FFE0BD49410B10E = {isa = PBXBuildFile; fileRef = 87414819D9DE343EA28E0AAD; };
-		4A1DB797F1356E85110FF871 = {isa = PBXBuildFile; fileRef = 20FAAE9F3A7B96C2D8C75BB2; };
-		F6635694A01FFBF5EF0968DB = {isa = PBXBuildFile; fileRef = 631983AA62673015F8D7453B; };
-		518DD443B6F17A5AFD707263 = {isa = PBXBuildFile; fileRef = A69024A225F2AC31F17B1314; };
-		B7EBA1A83575F48CD08140B9 = {isa = PBXBuildFile; fileRef = 4B083E951ECB62217C46CB01; };
-		3C5267E06A897B0DC0F7EA50 = {isa = PBXBuildFile; fileRef = 472F9A90F685220D730EBF6C; };
-		5DD883699B85E4C492CAD065 = {isa = PBXBuildFile; fileRef = DB9C8E35DF815B803CB4A9CF; };
-		D5C9125F65493CA481F18E53 = {isa = PBXBuildFile; fileRef = D766BB9D8C32B5560F0493F3; };
-		02E8F35A8E0D4A0DF6F38D60 = {isa = PBXBuildFile; fileRef = 1DE5BBC777FB64798D823002; };
-		234B6BA2952CBC7C61EF70EF = {isa = PBXBuildFile; fileRef = 5867DC4E39DF8539B54C0D59; };
-		254A7C08594A152C2C646334 = {isa = PBXBuildFile; fileRef = 1B9B5A37F079FE3B3CF8FAB6; };
-		F15F0512666FF8CDC0D08905 = {isa = PBXBuildFile; fileRef = 0462692BAA9CD1BE6DFBCC33; };
-		B18248959DDC44EF4E85320A = {isa = PBXBuildFile; fileRef = AECE3914F5119A3D586A5635; };
-		0075C5208947159AF2802F3B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AudioPluginEditorTemplate.cpp"; path = "../../Source/BinaryData/jucer_AudioPluginEditorTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		008C8B2C2328CFBB9375397D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComboBoxHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ComboBoxHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		0169ACAA0FAE70CCEEE4F650 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_PaintElementPath.cpp"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp"; sourceTree = "SOURCE_ROOT"; };
-		03D3053EDE47FED1919C6674 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_AudioPluginFilterTemplate.h"; path = "../../Source/BinaryData/jucer_AudioPluginFilterTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		0400CB0E056A1D840304D2DE = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_CommandLine.cpp"; path = "../../Source/Application/jucer_CommandLine.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0462692BAA9CD1BE6DFBCC33 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_gui_basics.mm"; path = "../../JuceLibraryCode/include_juce_gui_basics.mm"; sourceTree = "SOURCE_ROOT"; };
-		04C1267B2BD11A6ECCCA654C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentBooleanProperty.h"; path = "../../Source/ComponentEditor/properties/jucer_ComponentBooleanProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		05076CDF1511A5F8A8E18F1D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExport_Make.h"; path = "../../Source/Project Saving/jucer_ProjectExport_Make.h"; sourceTree = "SOURCE_ROOT"; };
-		05D67B5A8D64947C067C0945 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_GUIApp.h"; path = "../../Source/Wizards/jucer_ProjectWizard_GUIApp.h"; sourceTree = "SOURCE_ROOT"; };
-		084C0070BC67BC893B967EF1 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ToggleButtonHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ToggleButtonHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		087CB3A961CD3C7434D660A4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewProjectWizard.h"; path = "../../Source/Wizards/jucer_NewProjectWizard.h"; sourceTree = "SOURCE_ROOT"; };
-		09DE066936CF037E9709ADB1 = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Projucer.app; sourceTree = "BUILT_PRODUCTS_DIR"; };
-		0B24F292A357ABFD9BCC6D7F = {isa = PBXFileReference; lastKnownFileType = file; name = gradlew; path = ../../Source/BinaryData/gradle/gradlew; sourceTree = "SOURCE_ROOT"; };
-		0C2AD2FC0C196F440C3FF994 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_DependencyPathPropertyComponent.h"; path = "../../Source/Project/jucer_DependencyPathPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		0C6B1A14D37958E405448B8D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ErrorListComponent.h"; path = "../../Source/LiveBuildEngine/projucer_ErrorListComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		0D4D508C638BC74943B9976D = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AutoUpdater.cpp"; path = "../../Source/Application/jucer_AutoUpdater.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0DB0A9E30EEDDEA720BC5A03 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_StaticLibrary.svg"; path = "../../Source/BinaryData/wizard_StaticLibrary.svg"; sourceTree = "SOURCE_ROOT"; };
-		0F01067432AC314EAC213C1C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_Blank.h"; path = "../../Source/Wizards/jucer_ProjectWizard_Blank.h"; sourceTree = "SOURCE_ROOT"; };
-		0F249640243FBD5717F6ADD9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MiscUtilities.cpp"; path = "../../Source/Utility/jucer_MiscUtilities.cpp"; sourceTree = "SOURCE_ROOT"; };
-		0FF1C6905150EAAB1AE081A7 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ButtonHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ButtonHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		1125D1B2AE54AEF2EB3D51C0 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JucerDocumentEditor.h"; path = "../../Source/ComponentEditor/ui/jucer_JucerDocumentEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		11DC04468BC6023671017EBF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewFileWizard.h"; path = "../../Source/Wizards/jucer_NewFileWizard.h"; sourceTree = "SOURCE_ROOT"; };
-		11EB44786085029106099D01 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_DownloadCompileEngineThread.cpp"; path = "../../Source/Application/jucer_DownloadCompileEngineThread.cpp"; sourceTree = "SOURCE_ROOT"; };
-		129F2DE0FEF154F8F8C7A74E = {isa = PBXFileReference; lastKnownFileType = file.jar; name = "gradle-wrapper.jar"; path = "../../Source/BinaryData/gradle/gradle-wrapper.jar"; sourceTree = "SOURCE_ROOT"; };
-		133F1E428260C5ADDF496DF9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentLayout.cpp"; path = "../../Source/ComponentEditor/jucer_ComponentLayout.cpp"; sourceTree = "SOURCE_ROOT"; };
-		14A24BB4AB7B81D40EF062E5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ProjectSaver.cpp"; path = "../../Source/Project Saving/jucer_ProjectSaver.cpp"; sourceTree = "SOURCE_ROOT"; };
-		16203C6791259C9718A04C3A = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_PaintRoutinePanel.cpp"; path = "../../Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1729AEDC34001C31B8CC357C = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_FileHelpers.cpp"; path = "../../Source/Utility/jucer_FileHelpers.cpp"; sourceTree = "SOURCE_ROOT"; };
-		188D03A4247F4BC0539F5C49 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Colours.h"; path = "../../Source/Utility/jucer_Colours.h"; sourceTree = "SOURCE_ROOT"; };
-		18D9EBA1DAE45EEF81FD5C8F = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MainConsoleAppTemplate.cpp"; path = "../../Source/BinaryData/jucer_MainConsoleAppTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1AF7EFBE4961C7B6C834BF54 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PresetIDs.h"; path = "../../Source/Utility/jucer_PresetIDs.h"; sourceTree = "SOURCE_ROOT"; };
-		1B9B5A37F079FE3B3CF8FAB6 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_graphics.mm"; path = "../../JuceLibraryCode/include_juce_graphics.mm"; sourceTree = "SOURCE_ROOT"; };
-		1C216FE9B7A5209C5CCF2517 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_PaintElement.cpp"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElement.cpp"; sourceTree = "SOURCE_ROOT"; };
-		1C73D7591E63E8018E279716 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "export_android.svg"; path = "../../Source/BinaryData/export_android.svg"; sourceTree = "SOURCE_ROOT"; };
-		1D3D6A19A60F0B03DE2F1C14 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementPath.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementPath.h"; sourceTree = "SOURCE_ROOT"; };
-		1D99EA99F946D665FE583414 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_Highlight.svg"; path = "../../Source/BinaryData/wizard_Highlight.svg"; sourceTree = "SOURCE_ROOT"; };
-		1DE5BBC777FB64798D823002 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_data_structures.mm"; path = "../../JuceLibraryCode/include_juce_data_structures.mm"; sourceTree = "SOURCE_ROOT"; };
-		1F421199C40092BFEE0658C2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_RelativePath.h"; path = "../../Source/Utility/jucer_RelativePath.h"; sourceTree = "SOURCE_ROOT"; };
-		1F9BBDFA52513AD34D906D2A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_HyperlinkButtonHandler.h"; path = "../../Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		1FA92F8F2B26C6CEC8B1D737 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ButtonDocument.h"; path = "../../Source/ComponentEditor/documents/jucer_ButtonDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		20FAAE9F3A7B96C2D8C75BB2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_SlidingPanelComponent.cpp"; path = "../../Source/Utility/jucer_SlidingPanelComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		210CD22F25F2C22F9CEEB025 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
-		21F4833C5B5C17B159B956F3 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_events"; path = "../../../../modules/juce_events"; sourceTree = "SOURCE_ROOT"; };
-		223C4209F18A221EB183A056 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_AppearanceSettings.h"; path = "../../Source/Application/jucer_AppearanceSettings.h"; sourceTree = "SOURCE_ROOT"; };
-		2247EE920DF0610CAF9F4513 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_OpenDocumentManager.cpp"; path = "../../Source/Application/jucer_OpenDocumentManager.cpp"; sourceTree = "SOURCE_ROOT"; };
-		23A8DE16C0CDB8EED18B008B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_CommandIDs.h"; path = "../../Source/Application/jucer_CommandIDs.h"; sourceTree = "SOURCE_ROOT"; };
-		24C34D0578AE6C7A3EA18781 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_InlineComponentTemplate.h"; path = "../../Source/BinaryData/jucer_InlineComponentTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		263D9041F9B7D6A79DC38CD6 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentLayoutEditor.h"; path = "../../Source/ComponentEditor/ui/jucer_ComponentLayoutEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		269A454F1FF081DA67FFD578 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_JucerDocument.cpp"; path = "../../Source/ComponentEditor/jucer_JucerDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		27A2B025813B7E54E0862642 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementUndoableAction.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementUndoableAction.h"; sourceTree = "SOURCE_ROOT"; };
-		295A9B126C98FE15F5A8B81E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FilePropertyComponent.h"; path = "../../Source/ComponentEditor/properties/jucer_FilePropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		2C7CDA71ACB5829BC616A353 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ComponentListComp.h"; path = "../../Source/LiveBuildEngine/projucer_ComponentListComp.h"; sourceTree = "SOURCE_ROOT"; };
-		2CD34A70B4032C0426F7AA10 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_MainWindow.h"; path = "../../Source/Application/jucer_MainWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		2E680E2C65684A4272AE079A = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_SourceCodeEditor.cpp"; path = "../../Source/Code Editor/jucer_SourceCodeEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		2EEB1C074162F363C6599282 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_CommandLine.h"; path = "../../Source/Application/jucer_CommandLine.h"; sourceTree = "SOURCE_ROOT"; };
-		301592EBAC0FFF6F5B268E99 = {isa = PBXFileReference; lastKnownFileType = image.png; name = "background_tile.png"; path = "../../Source/BinaryData/background_tile.png"; sourceTree = "SOURCE_ROOT"; };
-		313BC56B30B05119686B1E99 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ProjectBuildInfo.h"; path = "../../Source/LiveBuildEngine/projucer_ProjectBuildInfo.h"; sourceTree = "SOURCE_ROOT"; };
-		32C81E19D3D68B9DDF870FE9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectTab.h"; path = "../../Source/Project/jucer_ProjectTab.h"; sourceTree = "SOURCE_ROOT"; };
-		3514E78B58A08F4C98F54C5A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentLayoutPanel.h"; path = "../../Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		358DA8CCDC8FA5B0D62D6CA3 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_Openfile.svg"; path = "../../Source/BinaryData/wizard_Openfile.svg"; sourceTree = "SOURCE_ROOT"; };
-		35A36102EAD2D2620EE99E7E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FilePathPropertyComponent.h"; path = "../../Source/Utility/jucer_FilePathPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		35CB48D497F35BF3F6998F5D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExporter.h"; path = "../../Source/Project Saving/jucer_ProjectExporter.h"; sourceTree = "SOURCE_ROOT"; };
-		35E6EE1E98DD7050DDFECD9B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ContentCompTemplate.h"; path = "../../Source/BinaryData/jucer_ContentCompTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		364D1A9B113320407A7E57B9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JuceHeader.h; path = ../../JuceLibraryCode/JuceHeader.h; sourceTree = "SOURCE_ROOT"; };
-		375AFDF06A908D89DEC5205F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectTree_Base.h"; path = "../../Source/Project/jucer_ProjectTree_Base.h"; sourceTree = "SOURCE_ROOT"; };
-		3A5B5DC92BE6D22CA15B9671 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_SnapGridPainter.h"; path = "../../Source/ComponentEditor/ui/jucer_SnapGridPainter.h"; sourceTree = "SOURCE_ROOT"; };
-		3C95FA2AA91EBA19ADDD5C29 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_Animated.h"; path = "../../Source/Wizards/jucer_ProjectWizard_Animated.h"; sourceTree = "SOURCE_ROOT"; };
-		3E03B7C7A19E63A724EB79F4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ButtonDocument.cpp"; path = "../../Source/ComponentEditor/documents/jucer_ButtonDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		3F00C034B140193B3754969B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ImageResourceProperty.h"; path = "../../Source/ComponentEditor/paintelements/jucer_ImageResourceProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		3F9D4C7F6E5779D4E4AE655D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentLayout.h"; path = "../../Source/ComponentEditor/jucer_ComponentLayout.h"; sourceTree = "SOURCE_ROOT"; };
-		400E4C67ABCDDB1D49EBB85E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TabbedComponentHandler.h"; path = "../../Source/ComponentEditor/components/jucer_TabbedComponentHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		4073A12E196BDDADE211E19F = {isa = PBXFileReference; lastKnownFileType = text.txt; name = "projucer_EULA.txt"; path = "../../Source/BinaryData/projucer_EULA.txt"; sourceTree = "SOURCE_ROOT"; };
-		41105E536155E394E54BDD35 = {isa = PBXFileReference; lastKnownFileType = file.xml; name = "colourscheme_dark.xml"; path = "../../Source/BinaryData/colourscheme_dark.xml"; sourceTree = "SOURCE_ROOT"; };
-		41CA95403E264AA7457A61F4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementRoundedRectangle.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		431D30038CBF67F80E8B3A13 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
-		43C068B8D98821C09492AB29 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ActivityListComponent.h"; path = "../../Source/LiveBuildEngine/projucer_ActivityListComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		441CFEA771BAA50E187342E9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AppearanceSettings.cpp"; path = "../../Source/Application/jucer_AppearanceSettings.cpp"; sourceTree = "SOURCE_ROOT"; };
-		468BFFBE4DA7835DD40C5FE8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AnimatedComponentTemplate.cpp"; path = "../../Source/BinaryData/jucer_AnimatedComponentTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		46CDD8C3C86FD61741B88A69 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LiveBuildTab.h"; path = "../../Source/Project/jucer_LiveBuildTab.h"; sourceTree = "SOURCE_ROOT"; };
-		471C7B0A8B92320AF0C80839 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_StaticLibrary.h"; path = "../../Source/Wizards/jucer_ProjectWizard_StaticLibrary.h"; sourceTree = "SOURCE_ROOT"; };
-		472F9A90F685220D730EBF6C = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryData.cpp; path = ../../JuceLibraryCode/BinaryData.cpp; sourceTree = "SOURCE_ROOT"; };
-		47B49049B85EED74D29C9906 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectTree_File.h"; path = "../../Source/Project/jucer_ProjectTree_File.h"; sourceTree = "SOURCE_ROOT"; };
-		47DD50A5A9091F9900E0EAD9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_JucerTreeViewBase.cpp"; path = "../../Source/Utility/jucer_JucerTreeViewBase.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4856DA6706D794E2D89DAB63 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GlobalSearchPathsWindowComponent.h"; path = "../../Source/Utility/jucer_GlobalSearchPathsWindowComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		4A035FB6A8D93BF154C08C3F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_BuildTabStatusComp.h"; path = "../../Source/LiveBuildEngine/projucer_BuildTabStatusComp.h"; sourceTree = "SOURCE_ROOT"; };
-		4A41FD3066D0979DB48691E5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_MiscUtilities.h"; path = "../../Source/Utility/jucer_MiscUtilities.h"; sourceTree = "SOURCE_ROOT"; };
-		4A4EBDAD8D098F72CE053235 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_AudioPlugin.h"; path = "../../Source/Wizards/jucer_ProjectWizard_AudioPlugin.h"; sourceTree = "SOURCE_ROOT"; };
-		4B083E951ECB62217C46CB01 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_NewProjectWizardClasses.cpp"; path = "../../Source/Wizards/jucer_NewProjectWizardClasses.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4C2093BCD3528ACEDC7A2B33 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ImageButtonHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ImageButtonHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		4D698BF12BCD6B0896BCDF17 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_AutoUpdater.h"; path = "../../Source/Application/jucer_AutoUpdater.h"; sourceTree = "SOURCE_ROOT"; };
-		4E191CDCE7565DB726CF7065 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentOverlayComponent.cpp"; path = "../../Source/ComponentEditor/ui/jucer_ComponentOverlayComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		4E60769DE992CA7FC1A4A486 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintRoutineEditor.h"; path = "../../Source/ComponentEditor/ui/jucer_PaintRoutineEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		4E8FE9B1B8C90FC28D56523B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementEllipse.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h"; sourceTree = "SOURCE_ROOT"; };
-		4F6365A0D2D51337151D85C3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectTree_Group.h"; path = "../../Source/Project/jucer_ProjectTree_Group.h"; sourceTree = "SOURCE_ROOT"; };
-		4F687965FBE86EAFDB3ACFEC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BinaryData.h; path = ../../JuceLibraryCode/BinaryData.h; sourceTree = "SOURCE_ROOT"; };
-		50498FF6EA3901CBD58223B3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ObjectTypes.h"; path = "../../Source/ComponentEditor/jucer_ObjectTypes.h"; sourceTree = "SOURCE_ROOT"; };
-		5091B14CC87C6238CF044258 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ElementSiblingComponent.h"; path = "../../Source/ComponentEditor/paintelements/jucer_ElementSiblingComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		515FF6E74826E3E3F7273621 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Icons.h"; path = "../../Source/Utility/jucer_Icons.h"; sourceTree = "SOURCE_ROOT"; };
-		51CBE59779A36D1B80B26974 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_LicenseController.cpp"; path = "../../Source/Licenses/jucer_LicenseController.cpp"; sourceTree = "SOURCE_ROOT"; };
-		53151B683E11F420203E61C2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewCppFileTemplate.h"; path = "../../Source/BinaryData/jucer_NewCppFileTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		5432B7B9B2CF2EAEC8B66D5C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_UtilityFunctions.h"; path = "../../Source/ComponentEditor/jucer_UtilityFunctions.h"; sourceTree = "SOURCE_ROOT"; };
-		546593F6EA70EABF708772FE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TranslationToolComponent.h"; path = "../../Source/Utility/jucer_TranslationToolComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		553725A0E3A391651ED1731E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FileHelpers.h"; path = "../../Source/Utility/jucer_FileHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		563091B0916AD9AAA36C7DC5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_OpenDocumentManager.h"; path = "../../Source/Application/jucer_OpenDocumentManager.h"; sourceTree = "SOURCE_ROOT"; };
-		56C3CA379E90628CCB5BC37C = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "export_visualStudio.svg"; path = "../../Source/BinaryData/export_visualStudio.svg"; sourceTree = "SOURCE_ROOT"; };
-		576A92E1E0D8F453EC0FEB34 = {isa = PBXFileReference; lastKnownFileType = file.bat; name = gradlew.bat; path = ../../Source/BinaryData/gradle/gradlew.bat; sourceTree = "SOURCE_ROOT"; };
-		576D62C0C9C1BA4B7A514721 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PositionPropertyBase.h"; path = "../../Source/ComponentEditor/properties/jucer_PositionPropertyBase.h"; sourceTree = "SOURCE_ROOT"; };
-		58139D8D454051C59E77609B = {isa = PBXFileReference; lastKnownFileType = file.nib; name = RecentFilesMenuTemplate.nib; path = ../../Source/BinaryData/RecentFilesMenuTemplate.nib; sourceTree = "SOURCE_ROOT"; };
-		5867DC4E39DF8539B54C0D59 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_events.mm"; path = "../../JuceLibraryCode/include_juce_events.mm"; sourceTree = "SOURCE_ROOT"; };
-		5A75806B34E4EA6598A6024A = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		5C7636E577B8DBB1D3133022 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ActivityList.h"; path = "../../Source/LiveBuildEngine/projucer_ActivityList.h"; sourceTree = "SOURCE_ROOT"; };
-		5D9E7814B713670624F0028F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentTypeHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ComponentTypeHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		5F1C141139AA646EABD72145 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "juce-logo-with-text.svg"; path = "../../Source/BinaryData/juce-logo-with-text.svg"; sourceTree = "SOURCE_ROOT"; };
-		5F6584B675E30761521A9F42 = {isa = PBXFileReference; lastKnownFileType = file.xml; name = "colourscheme_light.xml"; path = "../../Source/BinaryData/colourscheme_light.xml"; sourceTree = "SOURCE_ROOT"; };
-		61BE37E2B26C25056D9E8FE2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_NewComponentTemplate.cpp"; path = "../../Source/BinaryData/jucer_NewComponentTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		631983AA62673015F8D7453B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_StoredSettings.cpp"; path = "../../Source/Utility/jucer_StoredSettings.cpp"; sourceTree = "SOURCE_ROOT"; };
-		635290DEB1D564927D7A450C = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "projucer_CompileEngineServer.cpp"; path = "../../Source/LiveBuildEngine/projucer_CompileEngineServer.cpp"; sourceTree = "SOURCE_ROOT"; };
-		641B57E5FAE6BEFDB6462921 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ResourceEditorPanel.h"; path = "../../Source/ComponentEditor/ui/jucer_ResourceEditorPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		65C498761CE166072A202AA0 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentTypeHandler.cpp"; path = "../../Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp"; sourceTree = "SOURCE_ROOT"; };
-		65F4749184C84C2FDBB4C305 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AudioPluginFilterTemplate.cpp"; path = "../../Source/BinaryData/jucer_AudioPluginFilterTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		662C76394C5D1B56766FAFD9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentDocument.cpp"; path = "../../Source/ComponentEditor/documents/jucer_ComponentDocument.cpp"; sourceTree = "SOURCE_ROOT"; };
-		6678E9B3EEACAD47F438B264 = {isa = PBXFileReference; lastKnownFileType = file.nib; name = RecentFilesMenuTemplate.nib; path = RecentFilesMenuTemplate.nib; sourceTree = "SOURCE_ROOT"; };
-		66B49F08C5EC3E4974825FF8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintRoutine.h"; path = "../../Source/ComponentEditor/jucer_PaintRoutine.h"; sourceTree = "SOURCE_ROOT"; };
-		66DEA1923FE5B9A614C7E9DC = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "huckleberry_icon.svg"; path = "../../Source/BinaryData/huckleberry_icon.svg"; sourceTree = "SOURCE_ROOT"; };
-		69555CEFC6ED613AA3949298 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_data_structures"; path = "../../../../modules/juce_data_structures"; sourceTree = "SOURCE_ROOT"; };
-		6A337C69A928E3CE79C55457 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentChoiceProperty.h"; path = "../../Source/ComponentEditor/properties/jucer_ComponentChoiceProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		6AC88EFC247C225CC5C11A43 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_BinaryResources.h"; path = "../../Source/ComponentEditor/jucer_BinaryResources.h"; sourceTree = "SOURCE_ROOT"; };
-		6DA8A2AEF943230FF7DB510B = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "export_linux.svg"; path = "../../Source/BinaryData/export_linux.svg"; sourceTree = "SOURCE_ROOT"; };
-		6E6140969908E7619F858740 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_CommonHeaders.h"; path = "../../Source/Application/jucer_CommonHeaders.h"; sourceTree = "SOURCE_ROOT"; };
-		6E7353DFEA8825B515049ABB = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExport_Android.h"; path = "../../Source/Project Saving/jucer_ProjectExport_Android.h"; sourceTree = "SOURCE_ROOT"; };
-		714267352CE5C4357ADBC231 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_StartPageComponent.h"; path = "../../Source/Wizards/jucer_StartPageComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		7211101FFA28400ADBB1D47A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Module.h"; path = "../../Source/Project/jucer_Module.h"; sourceTree = "SOURCE_ROOT"; };
-		7256D1C79741E66E2C002EE2 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_DLL.svg"; path = "../../Source/BinaryData/wizard_DLL.svg"; sourceTree = "SOURCE_ROOT"; };
-		728FE25157E9874D50BBECB2 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
-		73B9F17FE55A02C2BB87E008 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_OpenGLComponentTemplate.cpp"; path = "../../Source/BinaryData/jucer_OpenGLComponentTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		786BAF436828865F45314440 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElement.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElement.h"; sourceTree = "SOURCE_ROOT"; };
-		78CA0E0F336229E2E2F111B0 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_SourceCodeEditor.h"; path = "../../Source/Code Editor/jucer_SourceCodeEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		78D0DBC4798FF040FDB90F6D = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_GeneratedCode.cpp"; path = "../../Source/ComponentEditor/jucer_GeneratedCode.cpp"; sourceTree = "SOURCE_ROOT"; };
-		790F6302B9A0620F23F8A6C1 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LicenseThread.h"; path = "../../Source/Licenses/jucer_LicenseThread.h"; sourceTree = "SOURCE_ROOT"; };
-		79E58813D1B414AF49DD9598 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LiveBuildCodeEditor.h"; path = "../../Source/Code Editor/jucer_LiveBuildCodeEditor.h"; sourceTree = "SOURCE_ROOT"; };
-		7A3E96D22F1C9EB4C739834F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PointComponent.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PointComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		7AB7640968FAAC73072FBD10 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_gui_basics"; path = "../../../../modules/juce_gui_basics"; sourceTree = "SOURCE_ROOT"; };
-		7B3F7ECF6DBF8C8EE5C2CB86 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
-		7B4E33B1E04139F359FB484B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ConfigTree_Exporter.h"; path = "../../Source/Project/jucer_ConfigTree_Exporter.h"; sourceTree = "SOURCE_ROOT"; };
-		7B6E461262D8822132135F56 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_AnimatedApp.svg"; path = "../../Source/BinaryData/wizard_AnimatedApp.svg"; sourceTree = "SOURCE_ROOT"; };
-		7CA44FF0BA319517C6E39651 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_Application.cpp"; path = "../../Source/Application/jucer_Application.cpp"; sourceTree = "SOURCE_ROOT"; };
-		7F29F77B1C00A9704E6D0859 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_UTF8Component.h"; path = "../../Source/Utility/jucer_UTF8Component.h"; sourceTree = "SOURCE_ROOT"; };
-		8090981F07A76E465DAAADF4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ValueSourceHelpers.h"; path = "../../Source/Utility/jucer_ValueSourceHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		80D62B907248523E6943298B = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		8138A55052E9FC27284B74DD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FontPropertyComponent.h"; path = "../../Source/ComponentEditor/properties/jucer_FontPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		820291543BF93243B718F0EE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JucerTreeViewBase.h"; path = "../../Source/Utility/jucer_JucerTreeViewBase.h"; sourceTree = "SOURCE_ROOT"; };
-		842427CFE565F3FCE5B99174 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiscRecording.framework; path = System/Library/Frameworks/DiscRecording.framework; sourceTree = SDKROOT; };
-		86E468DE6556BB2AD76A3D80 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ProjectContentComponent.cpp"; path = "../../Source/Project/jucer_ProjectContentComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		86E8A40E5A83781A8478454D = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MainTemplate_Window.cpp"; path = "../../Source/BinaryData/jucer_MainTemplate_Window.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8702F43110E4CCA5E5F827F5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppConfig.h; path = ../../JuceLibraryCode/AppConfig.h; sourceTree = "SOURCE_ROOT"; };
-		87414819D9DE343EA28E0AAD = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ProjucerLookAndFeel.cpp"; path = "../../Source/Utility/jucer_ProjucerLookAndFeel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8A825FDDC00DD253F44D2C3A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_AudioApp.h"; path = "../../Source/Wizards/jucer_ProjectWizard_AudioApp.h"; sourceTree = "SOURCE_ROOT"; };
-		8BD8E9DA627D6EF9BA10FB9E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewProjectWizardComponent.h"; path = "../../Source/Wizards/jucer_NewProjectWizardComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		8C281F2F8EA3AD614ADF7955 = {isa = PBXFileReference; lastKnownFileType = text.html; name = offlinepage.html; path = ../../Source/BinaryData/offlinepage.html; sourceTree = "SOURCE_ROOT"; };
-		8C52A3DDA62A746AA7A68535 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_Main.cpp"; path = "../../Source/Application/jucer_Main.cpp"; sourceTree = "SOURCE_ROOT"; };
-		8C67B567CF362A163D24B3B1 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TranslationHelpers.h"; path = "../../Source/Utility/jucer_TranslationHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		8DBD2FBBC7B523D1F8AF1E54 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_HeaderComponent.h"; path = "../../Source/Project/jucer_HeaderComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		8F30A53C7FE4BC65171FB3E2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JucerDocument.h"; path = "../../Source/ComponentEditor/jucer_JucerDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		8F7BE18698ADCEF51CDE4A5C = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMIDI.framework; path = System/Library/Frameworks/CoreMIDI.framework; sourceTree = SDKROOT; };
-		8F8BF1A7130D858E0A239F9E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ConfigTree_Base.h"; path = "../../Source/Project/jucer_ConfigTree_Base.h"; sourceTree = "SOURCE_ROOT"; };
-		9069981E414A631B036CC9AC = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MainWindow.cpp"; path = "../../Source/Application/jucer_MainWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		90E05EF7005D9C0712FA7662 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_DiagnosticMessage.h"; path = "../../Source/LiveBuildEngine/projucer_DiagnosticMessage.h"; sourceTree = "SOURCE_ROOT"; };
-		914ADDB50ED7365F08BA91F9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_CodeHelpers.h"; path = "../../Source/Utility/jucer_CodeHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		921752D9B004A15973DDF56F = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_TestComponent.cpp"; path = "../../Source/ComponentEditor/ui/jucer_TestComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		92F91DC29B64AD85B1F508BD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GenericComponentHandler.h"; path = "../../Source/ComponentEditor/components/jucer_GenericComponentHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		934C3778397D89F8C535E417 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ApplicationUsageDataWindowComponent.h"; path = "../../Source/Utility/jucer_ApplicationUsageDataWindowComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		93B419190CCE92ACAB1ED25B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ColouredElement.cpp"; path = "../../Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp"; sourceTree = "SOURCE_ROOT"; };
-		951128CA33CCDEF570436B1C = {isa = PBXFileReference; lastKnownFileType = file.icns; name = Icon.icns; path = Icon.icns; sourceTree = "SOURCE_ROOT"; };
-		963E0740B7B4D59EF2D16740 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentTemplate.h"; path = "../../Source/BinaryData/jucer_ComponentTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		9683B04CA3BD7F73E8236FE2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ContentCompTemplate.cpp"; path = "../../Source/BinaryData/jucer_ContentCompTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		974B862C51DA9A16CBBB3A29 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExport_XCode.h"; path = "../../Source/Project Saving/jucer_ProjectExport_XCode.h"; sourceTree = "SOURCE_ROOT"; };
-		97E75A598791645465FEDCE1 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_EditingPanelBase.h"; path = "../../Source/ComponentEditor/ui/jucer_EditingPanelBase.h"; sourceTree = "SOURCE_ROOT"; };
-		98E6D61BFF7D85F0E00F0FBF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LicenseWebview.h"; path = "../../Source/Licenses/jucer_LicenseWebview.h"; sourceTree = "SOURCE_ROOT"; };
-		98F42686D9DAC974F2514217 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_EditingPanelBase.cpp"; path = "../../Source/ComponentEditor/ui/jucer_EditingPanelBase.cpp"; sourceTree = "SOURCE_ROOT"; };
-		996E472B82A75531875A5E38 = {isa = PBXFileReference; lastKnownFileType = file; name = LICENSE; path = ../../Source/BinaryData/gradle/LICENSE; sourceTree = "SOURCE_ROOT"; };
-		9992E6950C64322A11E39ADF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_DLL.h"; path = "../../Source/Wizards/jucer_ProjectWizard_DLL.h"; sourceTree = "SOURCE_ROOT"; };
-		9B9CAD20E1243B4351B4C8D8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_CodeHelpers.cpp"; path = "../../Source/Utility/jucer_CodeHelpers.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9BC8AE609A07657CEF587548 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_StoredSettings.h"; path = "../../Source/Utility/jucer_StoredSettings.h"; sourceTree = "SOURCE_ROOT"; };
-		9C04F9680F82BF279D528688 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectSaver.h"; path = "../../Source/Project Saving/jucer_ProjectSaver.h"; sourceTree = "SOURCE_ROOT"; };
-		9C51394634F102DEBBE6C9EB = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementText.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementText.h"; sourceTree = "SOURCE_ROOT"; };
-		9C7FA58D223674C4C2AC6595 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_JucerDocumentEditor.cpp"; path = "../../Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9C803826E5E3FDB1B37660D5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentDocument.h"; path = "../../Source/ComponentEditor/documents/jucer_ComponentDocument.h"; sourceTree = "SOURCE_ROOT"; };
-		9D7689451732AF8333402B3A = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ObjectTypes.cpp"; path = "../../Source/ComponentEditor/jucer_ObjectTypes.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9EA541503DBADC5FFDEB0282 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TreeItemTypes.h"; path = "../../Source/Project/jucer_TreeItemTypes.h"; sourceTree = "SOURCE_ROOT"; };
-		9EF583A6201DBC813C2F63C4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_BinaryResources.cpp"; path = "../../Source/ComponentEditor/jucer_BinaryResources.cpp"; sourceTree = "SOURCE_ROOT"; };
-		9F01BA9942D038EA8B5289A8 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
-		9F41F3338BF00D0FC74C6390 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TestComponent.h"; path = "../../Source/ComponentEditor/ui/jucer_TestComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		9F75811FE7B5F8D1321BEC69 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ConfigTree_Modules.h"; path = "../../Source/Project/jucer_ConfigTree_Modules.h"; sourceTree = "SOURCE_ROOT"; };
-		A085174413736ACC8D7D42A2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_openGL.h"; path = "../../Source/Wizards/jucer_ProjectWizard_openGL.h"; sourceTree = "SOURCE_ROOT"; };
-		A0951828C3BF47FA7E1E52F8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ViewportHandler.h"; path = "../../Source/ComponentEditor/components/jucer_ViewportHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		A1333F975410DD3DBBE2841F = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "projucer_CompileEngineClient.cpp"; path = "../../Source/LiveBuildEngine/projucer_CompileEngineClient.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A32FE0EBE29FABE58E664E67 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_AboutWindowComponent.h"; path = "../../Source/Utility/jucer_AboutWindowComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		A44A774EFC020D3D046A9249 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectWizard_Console.h"; path = "../../Source/Wizards/jucer_ProjectWizard_Console.h"; sourceTree = "SOURCE_ROOT"; };
-		A4D275622A4B115AABE190A4 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_OpenGL.svg"; path = "../../Source/BinaryData/wizard_OpenGL.svg"; sourceTree = "SOURCE_ROOT"; };
-		A69024A225F2AC31F17B1314 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_NewFileWizard.cpp"; path = "../../Source/Wizards/jucer_NewFileWizard.cpp"; sourceTree = "SOURCE_ROOT"; };
-		A973D33C0CE829AD293E035B = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "projucer_login_bg.svg"; path = "../../Source/BinaryData/projucer_login_bg.svg"; sourceTree = "SOURCE_ROOT"; };
-		AA1C44E89D792DDC4867B2C8 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_cryptography"; path = "../../../../modules/juce_cryptography"; sourceTree = "SOURCE_ROOT"; };
-		AA8EED79F095953D2B5923B8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentColourProperty.h"; path = "../../Source/ComponentEditor/properties/jucer_ComponentColourProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		AE1BC6DCCFC1A18E2ACE23F1 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MainTemplate_NoWindow.cpp"; path = "../../Source/BinaryData/jucer_MainTemplate_NoWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		AECE3914F5119A3D586A5635 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_gui_extra.mm"; path = "../../JuceLibraryCode/include_juce_gui_extra.mm"; sourceTree = "SOURCE_ROOT"; };
-		AF57278F8F46D86B4EBA449E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_CompileEngineServer.h"; path = "../../Source/LiveBuildEngine/projucer_CompileEngineServer.h"; sourceTree = "SOURCE_ROOT"; };
-		AFEBD8423B07599B1DE175A3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ModulesPanel.h"; path = "../../Source/Project/jucer_ModulesPanel.h"; sourceTree = "SOURCE_ROOT"; };
-		AFF72BA2B130F3F9AC029080 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_AudioPluginEditorTemplate.h"; path = "../../Source/BinaryData/jucer_AudioPluginEditorTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		B00F60201606F195058BB575 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ColourPropertyComponent.h"; path = "../../Source/ComponentEditor/properties/jucer_ColourPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		B06C7C053DB0660CDA8B5C2C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintRoutinePanel.h"; path = "../../Source/ComponentEditor/ui/jucer_PaintRoutinePanel.h"; sourceTree = "SOURCE_ROOT"; };
-		B0D2198D1261755918CD454D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_SVGPathDataComponent.h"; path = "../../Source/Utility/jucer_SVGPathDataComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		B15E33E7342F6EB4F95C9B1D = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_PaintRoutineEditor.cpp"; path = "../../Source/ComponentEditor/ui/jucer_PaintRoutineEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		B1963F0D8C0046E54FD9E023 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ColouredElement.h"; path = "../../Source/ComponentEditor/paintelements/jucer_ColouredElement.h"; sourceTree = "SOURCE_ROOT"; };
-		B3FA8ADA3F66D5EE0C0E5CBE = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "export_xcode.svg"; path = "../../Source/BinaryData/export_xcode.svg"; sourceTree = "SOURCE_ROOT"; };
-		B483D960309FAFC193F9CDA2 = {isa = PBXFileReference; lastKnownFileType = image.png; name = "juce_icon.png"; path = "../../Source/BinaryData/juce_icon.png"; sourceTree = "SOURCE_ROOT"; };
-		B5CB69026BC4E8F439355CDC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_SourceCodeRange.h"; path = "../../Source/LiveBuildEngine/projucer_SourceCodeRange.h"; sourceTree = "SOURCE_ROOT"; };
-		B6F2905330EA5C560D527209 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_graphics"; path = "../../../../modules/juce_graphics"; sourceTree = "SOURCE_ROOT"; };
-		B7307A82D9EB1EDBA91EE43D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_DownloadCompileEngineThread.h"; path = "../../Source/Application/jucer_DownloadCompileEngineThread.h"; sourceTree = "SOURCE_ROOT"; };
-		B73B25AD624B88B29EA0589C = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "export_codeBlocks.svg"; path = "../../Source/BinaryData/export_codeBlocks.svg"; sourceTree = "SOURCE_ROOT"; };
-		B741170E45D74F30B7D5CDDF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentNameProperty.h"; path = "../../Source/ComponentEditor/components/jucer_ComponentNameProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		B8385E9A644BD3CD94876448 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectType.h"; path = "../../Source/Project/jucer_ProjectType.h"; sourceTree = "SOURCE_ROOT"; };
-		BA159A3B7D129771F5C15EA3 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_core"; path = "../../../../modules/juce_core"; sourceTree = "SOURCE_ROOT"; };
-		BAC43B20E14A340CCF14119C = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_Project.cpp"; path = "../../Source/Project/jucer_Project.cpp"; sourceTree = "SOURCE_ROOT"; };
-		BB187CD608EB6368B29EC335 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LicenseController.h"; path = "../../Source/Licenses/jucer_LicenseController.h"; sourceTree = "SOURCE_ROOT"; };
-		BB9C1E6E54A16F795908C469 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "background_logo.svg"; path = "../../Source/BinaryData/background_logo.svg"; sourceTree = "SOURCE_ROOT"; };
-		BCB819DDDD2AC13632CA502F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjucerLookAndFeel.h"; path = "../../Source/Utility/jucer_ProjucerLookAndFeel.h"; sourceTree = "SOURCE_ROOT"; };
-		BCCFDFB2C02C4AA436C0ECF8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_SliderHandler.h"; path = "../../Source/ComponentEditor/components/jucer_SliderHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		BD2BC2395BF27FD40259F14F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ErrorList.h"; path = "../../Source/LiveBuildEngine/projucer_ErrorList.h"; sourceTree = "SOURCE_ROOT"; };
-		BF3CEF080FA013E2778DCE90 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Project.h"; path = "../../Source/Project/jucer_Project.h"; sourceTree = "SOURCE_ROOT"; };
-		C00793A0D4A59BDADC62EEF7 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_CompileEngineClient.h"; path = "../../Source/LiveBuildEngine/projucer_CompileEngineClient.h"; sourceTree = "SOURCE_ROOT"; };
-		C094F3B6A65A79A6DF87C9C2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementGroup.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h"; sourceTree = "SOURCE_ROOT"; };
-		C09BBB58CA45B66D693E8C31 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TemplateThumbnailsComponent.h"; path = "../../Source/Wizards/jucer_TemplateThumbnailsComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C15220EDA1A8315DA3255E87 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_EditorColourSchemeWindowComponent.h"; path = "../../Source/Utility/jucer_EditorColourSchemeWindowComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C187718F7B9EBA88584B43F3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_PaintRoutine.cpp"; path = "../../Source/ComponentEditor/jucer_PaintRoutine.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C22791DB75870C4F102AA8A3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_SlidingPanelComponent.h"; path = "../../Source/Utility/jucer_SlidingPanelComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C2990A8D054BC230E7C637C3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewProjectWizardClasses.h"; path = "../../Source/Wizards/jucer_NewProjectWizardClasses.h"; sourceTree = "SOURCE_ROOT"; };
-		C63233C27ED46CECF10EC7C3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_MessageIDs.h"; path = "../../Source/LiveBuildEngine/projucer_MessageIDs.h"; sourceTree = "SOURCE_ROOT"; };
-		C714153DB8056CAC5BC69FAF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ClassDatabase.h"; path = "../../Source/LiveBuildEngine/projucer_ClassDatabase.h"; sourceTree = "SOURCE_ROOT"; };
-		C7608A3967D9AB9481848F2B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_DocumentEditorComponent.cpp"; path = "../../Source/Application/jucer_DocumentEditorComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		C7B47372A9D5970E3D9A5400 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GroupInformationComponent.h"; path = "../../Source/Project/jucer_GroupInformationComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		C8A229ACD244F402C57286CD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExport_MSVC.h"; path = "../../Source/Project Saving/jucer_ProjectExport_MSVC.h"; sourceTree = "SOURCE_ROOT"; };
-		C9616830BB2474066AC8C910 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ResourceFile.h"; path = "../../Source/Project Saving/jucer_ResourceFile.h"; sourceTree = "SOURCE_ROOT"; };
-		CB147AFB52BD5FC0816C0EEE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_LiveCodeBuilderDLL.h"; path = "../../Source/LiveBuildEngine/projucer_LiveCodeBuilderDLL.h"; sourceTree = "SOURCE_ROOT"; };
-		CCEF7B4C6667DDE5D32FD219 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_CompileEngineDLL.h"; path = "../../Source/LiveBuildEngine/projucer_CompileEngineDLL.h"; sourceTree = "SOURCE_ROOT"; };
-		CEF0436C145DA86ACE2CA5E3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_ClientServerMessages.h"; path = "../../Source/LiveBuildEngine/projucer_ClientServerMessages.h"; sourceTree = "SOURCE_ROOT"; };
-		CF21D9DB3AEC0A4DCAB36A99 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_Icons.cpp"; path = "../../Source/Utility/jucer_Icons.cpp"; sourceTree = "SOURCE_ROOT"; };
-		CF6C8BD0DA3D8CD4E99EBADA = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		CF8011B3C67B609032974DA5 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_NewCppFileTemplate.cpp"; path = "../../Source/BinaryData/jucer_NewCppFileTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D00F311BFC3C2625C457CB9B = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
-		D05BD91B6105827B010E1C20 = {isa = PBXFileReference; lastKnownFileType = file; name = "juce_gui_extra"; path = "../../../../modules/juce_gui_extra"; sourceTree = "SOURCE_ROOT"; };
-		D0D8B580D0689FFF4B9B823B = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_StrokeType.h"; path = "../../Source/ComponentEditor/paintelements/jucer_StrokeType.h"; sourceTree = "SOURCE_ROOT"; };
-		D10D51A0A2D63F38B4D86A60 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ResourceFile.cpp"; path = "../../Source/Project Saving/jucer_ResourceFile.cpp"; sourceTree = "SOURCE_ROOT"; };
-		D1F9B0E9F5D54FE48BEB46EA = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
-		D374DC78AAC02504576AA9B3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GroupComponentHandler.h"; path = "../../Source/ComponentEditor/components/jucer_GroupComponentHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		D4444EC6342A2A7BC4F7BC46 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentTextProperty.h"; path = "../../Source/ComponentEditor/properties/jucer_ComponentTextProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		D526C38D581425949BA0E4AC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FilePreviewComponent.h"; path = "../../Source/Application/jucer_FilePreviewComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		D766BB9D8C32B5560F0493F3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_cryptography.mm"; path = "../../JuceLibraryCode/include_juce_cryptography.mm"; sourceTree = "SOURCE_ROOT"; };
-		D87FC8F6834E9DC9C8E88B94 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JustificationProperty.h"; path = "../../Source/ComponentEditor/properties/jucer_JustificationProperty.h"; sourceTree = "SOURCE_ROOT"; };
-		D92A6E9404A30EED32DCE4ED = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_RelativePositionedRectangle.h"; path = "../../Source/ComponentEditor/ui/jucer_RelativePositionedRectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		DA345D5B9DABD049F90DC96F = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GeneratedCode.h"; path = "../../Source/ComponentEditor/jucer_GeneratedCode.h"; sourceTree = "SOURCE_ROOT"; };
-		DAF84A553D264705FA6EB6FF = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TreeViewHandler.h"; path = "../../Source/ComponentEditor/components/jucer_TreeViewHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		DB9C8E35DF815B803CB4A9CF = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = "include_juce_core.mm"; path = "../../JuceLibraryCode/include_juce_core.mm"; sourceTree = "SOURCE_ROOT"; };
-		DBE0CDE1B017190ABBFF557C = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectExport_CodeBlocks.h"; path = "../../Source/Project Saving/jucer_ProjectExport_CodeBlocks.h"; sourceTree = "SOURCE_ROOT"; };
-		DC922C6A65D260C18E888E49 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentTemplate.cpp"; path = "../../Source/BinaryData/jucer_ComponentTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DCBB17488227A2CA7D3D3947 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_DependencyPathPropertyComponent.cpp"; path = "../../Source/Project/jucer_DependencyPathPropertyComponent.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DF725A596B7BCD7520CC0A9F = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ResourceEditorPanel.cpp"; path = "../../Source/ComponentEditor/ui/jucer_ResourceEditorPanel.cpp"; sourceTree = "SOURCE_ROOT"; };
-		DF78EF6242D82F912534A277 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ColourPropertyComponent.h"; path = "../../Source/Utility/jucer_ColourPropertyComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		E0F9CA57E44F7F7E7E217E47 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentUndoableAction.h"; path = "../../Source/ComponentEditor/components/jucer_ComponentUndoableAction.h"; sourceTree = "SOURCE_ROOT"; };
-		E1D8CCD9F4ACBE1EC1D5BEA0 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_AudioApp.svg"; path = "../../Source/BinaryData/wizard_AudioApp.svg"; sourceTree = "SOURCE_ROOT"; };
-		E2374E15D65425C4101237E2 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewComponentTemplate.h"; path = "../../Source/BinaryData/jucer_NewComponentTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		E266DE67FF319D56F63193A6 = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-App.plist"; path = "Info-App.plist"; sourceTree = "SOURCE_ROOT"; };
-		E382C78A1D837DD98916E86A = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FloatingToolWindow.h"; path = "../../Source/Utility/jucer_FloatingToolWindow.h"; sourceTree = "SOURCE_ROOT"; };
-		E3B56C5718D87CA0EFCB2662 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_AudioComponentTemplate.cpp"; path = "../../Source/BinaryData/jucer_AudioComponentTemplate.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E4BB22E27C5AA4B666F265BD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TextButtonHandler.h"; path = "../../Source/ComponentEditor/components/jucer_TextButtonHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		E4BD4C43370651B49F75855B = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_MainTemplate_SimpleWindow.cpp"; path = "../../Source/BinaryData/jucer_MainTemplate_SimpleWindow.cpp"; sourceTree = "SOURCE_ROOT"; };
-		E5D6C36496F5BC84D7213BE8 = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		E60E28D1B7491047DEA236AE = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ProjectContentComponent.h"; path = "../../Source/Project/jucer_ProjectContentComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		E65A820D34BF39478B7C5925 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_DocumentEditorComponent.h"; path = "../../Source/Application/jucer_DocumentEditorComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		E96597BBC6A98255B51B94DC = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		E983E6DDE3318B872EBE347F = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioKit.framework; path = System/Library/Frameworks/CoreAudioKit.framework; sourceTree = SDKROOT; };
-		EB71BA07D6F667E69721E577 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_GradientPointComponent.h"; path = "../../Source/ComponentEditor/paintelements/jucer_GradientPointComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		EE690110171E1648FF2118B8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Application.h"; path = "../../Source/Application/jucer_Application.h"; sourceTree = "SOURCE_ROOT"; };
-		EF30A74B566A461A171BBF83 = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ComponentLayoutEditor.cpp"; path = "../../Source/ComponentEditor/ui/jucer_ComponentLayoutEditor.cpp"; sourceTree = "SOURCE_ROOT"; };
-		EFA8CF715611D845AB284500 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JucerComponentHandler.h"; path = "../../Source/ComponentEditor/components/jucer_JucerComponentHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		F03E2BDD36E6F4F53AB767A8 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_Headers.h"; path = "../../Source/jucer_Headers.h"; sourceTree = "SOURCE_ROOT"; };
-		F18AE75F1831D13FF53A8CCC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementRectangle.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h"; sourceTree = "SOURCE_ROOT"; };
-		F4B63624DBF543082235F821 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_GUI.svg"; path = "../../Source/BinaryData/wizard_GUI.svg"; sourceTree = "SOURCE_ROOT"; };
-		F5885B5AAF46864D562D5B83 = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_AudioPlugin.svg"; path = "../../Source/BinaryData/wizard_AudioPlugin.svg"; sourceTree = "SOURCE_ROOT"; };
-		F59077841FC17DD07060A2A9 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_TextEditorHandler.h"; path = "../../Source/ComponentEditor/components/jucer_TextEditorHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		F6D3F208B6EE2A50CE1F0A18 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_JucerCommandIDs.h"; path = "../../Source/ComponentEditor/ui/jucer_JucerCommandIDs.h"; sourceTree = "SOURCE_ROOT"; };
-		F71AF6D2DF3E652F8B51EBAB = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_ProjectExporter.cpp"; path = "../../Source/Project Saving/jucer_ProjectExporter.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F797071D88542C813CF7222A = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "jucer_Module.cpp"; path = "../../Source/Project/jucer_Module.cpp"; sourceTree = "SOURCE_ROOT"; };
-		F7CAB5BC15EE351949D3F2C3 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_NewInlineComponentTemplate.h"; path = "../../Source/BinaryData/jucer_NewInlineComponentTemplate.h"; sourceTree = "SOURCE_ROOT"; };
-		FA04E39EE7E83D445AF9E406 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_FillType.h"; path = "../../Source/ComponentEditor/paintelements/jucer_FillType.h"; sourceTree = "SOURCE_ROOT"; };
-		FA70084EC51835082E67D261 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "projucer_CppHelpers.h"; path = "../../Source/LiveBuildEngine/projucer_CppHelpers.h"; sourceTree = "SOURCE_ROOT"; };
-		FB61FEC24C6C031EB0455B0A = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "wizard_ConsoleApp.svg"; path = "../../Source/BinaryData/wizard_ConsoleApp.svg"; sourceTree = "SOURCE_ROOT"; };
-		FBBDD70D47163D341B2F0A8D = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_ComponentOverlayComponent.h"; path = "../../Source/ComponentEditor/ui/jucer_ComponentOverlayComponent.h"; sourceTree = "SOURCE_ROOT"; };
-		FF11D6B512FDC5D887E06F66 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_PaintElementImage.h"; path = "../../Source/ComponentEditor/paintelements/jucer_PaintElementImage.h"; sourceTree = "SOURCE_ROOT"; };
-		FF94FF5C4BEC605E56149EFC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "jucer_LabelHandler.h"; path = "../../Source/ComponentEditor/components/jucer_LabelHandler.h"; sourceTree = "SOURCE_ROOT"; };
-		48618F36B2E3C15A7B0F63AC = {isa = PBXGroup; children = (
-					441CFEA771BAA50E187342E9,
-					223C4209F18A221EB183A056,
-					7CA44FF0BA319517C6E39651,
-					EE690110171E1648FF2118B8,
-					0D4D508C638BC74943B9976D,
-					4D698BF12BCD6B0896BCDF17,
-					23A8DE16C0CDB8EED18B008B,
-					0400CB0E056A1D840304D2DE,
-					2EEB1C074162F363C6599282,
-					6E6140969908E7619F858740,
-					C7608A3967D9AB9481848F2B,
-					E65A820D34BF39478B7C5925,
-					11EB44786085029106099D01,
-					B7307A82D9EB1EDBA91EE43D,
-					D526C38D581425949BA0E4AC,
-					F03E2BDD36E6F4F53AB767A8,
-					8C52A3DDA62A746AA7A68535,
-					9069981E414A631B036CC9AC,
-					2CD34A70B4032C0426F7AA10,
-					2247EE920DF0610CAF9F4513,
-					563091B0916AD9AAA36C7DC5, ); name = Application; sourceTree = "<group>"; };
-		DD016058D39CAFA2C86BAF40 = {isa = PBXGroup; children = (
-					51CBE59779A36D1B80B26974,
-					BB187CD608EB6368B29EC335,
-					790F6302B9A0620F23F8A6C1,
-					98E6D61BFF7D85F0E00F0FBF, ); name = Licenses; sourceTree = "<group>"; };
-		82B98DB2654A087911E8157F = {isa = PBXGroup; children = (
-					5C7636E577B8DBB1D3133022,
-					43C068B8D98821C09492AB29,
-					4A035FB6A8D93BF154C08C3F,
-					C714153DB8056CAC5BC69FAF,
-					CEF0436C145DA86ACE2CA5E3,
-					A1333F975410DD3DBBE2841F,
-					C00793A0D4A59BDADC62EEF7,
-					CCEF7B4C6667DDE5D32FD219,
-					635290DEB1D564927D7A450C,
-					AF57278F8F46D86B4EBA449E,
-					2C7CDA71ACB5829BC616A353,
-					FA70084EC51835082E67D261,
-					90E05EF7005D9C0712FA7662,
-					BD2BC2395BF27FD40259F14F,
-					0C6B1A14D37958E405448B8D,
-					CB147AFB52BD5FC0816C0EEE,
-					C63233C27ED46CECF10EC7C3,
-					313BC56B30B05119686B1E99,
-					B5CB69026BC4E8F439355CDC, ); name = LiveBuildEngine; sourceTree = "<group>"; };
-		142DEF17A4C953926833D7F8 = {isa = PBXGroup; children = (
-					79E58813D1B414AF49DD9598,
-					2E680E2C65684A4272AE079A,
-					78CA0E0F336229E2E2F111B0, ); name = "Code Editor"; sourceTree = "<group>"; };
-		6CE6335290CF9C26FBE93D7C = {isa = PBXGroup; children = (
-					0FF1C6905150EAAB1AE081A7,
-					008C8B2C2328CFBB9375397D,
-					B741170E45D74F30B7D5CDDF,
-					65C498761CE166072A202AA0,
-					5D9E7814B713670624F0028F,
-					E0F9CA57E44F7F7E7E217E47,
-					92F91DC29B64AD85B1F508BD,
-					D374DC78AAC02504576AA9B3,
-					1F9BBDFA52513AD34D906D2A,
-					4C2093BCD3528ACEDC7A2B33,
-					EFA8CF715611D845AB284500,
-					FF94FF5C4BEC605E56149EFC,
-					BCCFDFB2C02C4AA436C0ECF8,
-					400E4C67ABCDDB1D49EBB85E,
-					E4BB22E27C5AA4B666F265BD,
-					F59077841FC17DD07060A2A9,
-					084C0070BC67BC893B967EF1,
-					DAF84A553D264705FA6EB6FF,
-					A0951828C3BF47FA7E1E52F8, ); name = components; sourceTree = "<group>"; };
-		7CF8A12404899178DC6EBF9C = {isa = PBXGroup; children = (
-					3E03B7C7A19E63A724EB79F4,
-					1FA92F8F2B26C6CEC8B1D737,
-					662C76394C5D1B56766FAFD9,
-					9C803826E5E3FDB1B37660D5, ); name = documents; sourceTree = "<group>"; };
-		105940C80EB9807392E04AB9 = {isa = PBXGroup; children = (
-					93B419190CCE92ACAB1ED25B,
-					B1963F0D8C0046E54FD9E023,
-					5091B14CC87C6238CF044258,
-					FA04E39EE7E83D445AF9E406,
-					EB71BA07D6F667E69721E577,
-					3F00C034B140193B3754969B,
-					1C216FE9B7A5209C5CCF2517,
-					786BAF436828865F45314440,
-					4E8FE9B1B8C90FC28D56523B,
-					C094F3B6A65A79A6DF87C9C2,
-					FF11D6B512FDC5D887E06F66,
-					0169ACAA0FAE70CCEEE4F650,
-					1D3D6A19A60F0B03DE2F1C14,
-					F18AE75F1831D13FF53A8CCC,
-					41CA95403E264AA7457A61F4,
-					9C51394634F102DEBBE6C9EB,
-					27A2B025813B7E54E0862642,
-					7A3E96D22F1C9EB4C739834F,
-					D0D8B580D0689FFF4B9B823B, ); name = paintelements; sourceTree = "<group>"; };
-		BD7D64D86872DEDFCAF1CC39 = {isa = PBXGroup; children = (
-					B00F60201606F195058BB575,
-					04C1267B2BD11A6ECCCA654C,
-					6A337C69A928E3CE79C55457,
-					AA8EED79F095953D2B5923B8,
-					D4444EC6342A2A7BC4F7BC46,
-					295A9B126C98FE15F5A8B81E,
-					8138A55052E9FC27284B74DD,
-					D87FC8F6834E9DC9C8E88B94,
-					576D62C0C9C1BA4B7A514721, ); name = properties; sourceTree = "<group>"; };
-		976B9E06EE94AA45594FEAF6 = {isa = PBXGroup; children = (
-					EF30A74B566A461A171BBF83,
-					263D9041F9B7D6A79DC38CD6,
-					3514E78B58A08F4C98F54C5A,
-					4E191CDCE7565DB726CF7065,
-					FBBDD70D47163D341B2F0A8D,
-					98F42686D9DAC974F2514217,
-					97E75A598791645465FEDCE1,
-					F6D3F208B6EE2A50CE1F0A18,
-					9C7FA58D223674C4C2AC6595,
-					1125D1B2AE54AEF2EB3D51C0,
-					B15E33E7342F6EB4F95C9B1D,
-					4E60769DE992CA7FC1A4A486,
-					16203C6791259C9718A04C3A,
-					B06C7C053DB0660CDA8B5C2C,
-					D92A6E9404A30EED32DCE4ED,
-					DF725A596B7BCD7520CC0A9F,
-					641B57E5FAE6BEFDB6462921,
-					3A5B5DC92BE6D22CA15B9671,
-					921752D9B004A15973DDF56F,
-					9F41F3338BF00D0FC74C6390, ); name = ui; sourceTree = "<group>"; };
-		78FDC751FE3D97F79839DBC6 = {isa = PBXGroup; children = (
-					6CE6335290CF9C26FBE93D7C,
-					7CF8A12404899178DC6EBF9C,
-					105940C80EB9807392E04AB9,
-					BD7D64D86872DEDFCAF1CC39,
-					976B9E06EE94AA45594FEAF6,
-					9EF583A6201DBC813C2F63C4,
-					6AC88EFC247C225CC5C11A43,
-					133F1E428260C5ADDF496DF9,
-					3F9D4C7F6E5779D4E4AE655D,
-					78D0DBC4798FF040FDB90F6D,
-					DA345D5B9DABD049F90DC96F,
-					269A454F1FF081DA67FFD578,
-					8F30A53C7FE4BC65171FB3E2,
-					9D7689451732AF8333402B3A,
-					50498FF6EA3901CBD58223B3,
-					C187718F7B9EBA88584B43F3,
-					66B49F08C5EC3E4974825FF8,
-					5432B7B9B2CF2EAEC8B66D5C, ); name = ComponentEditor; sourceTree = "<group>"; };
-		524339C1BD702C610F2A7DAB = {isa = PBXGroup; children = (
-					8F8BF1A7130D858E0A239F9E,
-					7B4E33B1E04139F359FB484B,
-					9F75811FE7B5F8D1321BEC69,
-					DCBB17488227A2CA7D3D3947,
-					0C2AD2FC0C196F440C3FF994,
-					C7B47372A9D5970E3D9A5400,
-					8DBD2FBBC7B523D1F8AF1E54,
-					46CDD8C3C86FD61741B88A69,
-					F797071D88542C813CF7222A,
-					7211101FFA28400ADBB1D47A,
-					AFEBD8423B07599B1DE175A3,
-					BAC43B20E14A340CCF14119C,
-					BF3CEF080FA013E2778DCE90,
-					86E468DE6556BB2AD76A3D80,
-					E60E28D1B7491047DEA236AE,
-					32C81E19D3D68B9DDF870FE9,
-					375AFDF06A908D89DEC5205F,
-					47B49049B85EED74D29C9906,
-					4F6365A0D2D51337151D85C3,
-					B8385E9A644BD3CD94876448,
-					9EA541503DBADC5FFDEB0282, ); name = Project; sourceTree = "<group>"; };
-		EB15E4BA49763AC74CE29FDE = {isa = PBXGroup; children = (
-					6E7353DFEA8825B515049ABB,
-					DBE0CDE1B017190ABBFF557C,
-					05076CDF1511A5F8A8E18F1D,
-					C8A229ACD244F402C57286CD,
-					974B862C51DA9A16CBBB3A29,
-					F71AF6D2DF3E652F8B51EBAB,
-					35CB48D497F35BF3F6998F5D,
-					14A24BB4AB7B81D40EF062E5,
-					9C04F9680F82BF279D528688,
-					D10D51A0A2D63F38B4D86A60,
-					C9616830BB2474066AC8C910, ); name = "Project Saving"; sourceTree = "<group>"; };
-		6580E53C420AA794542CC8D7 = {isa = PBXGroup; children = (
-					A32FE0EBE29FABE58E664E67,
-					934C3778397D89F8C535E417,
-					9B9CAD20E1243B4351B4C8D8,
-					914ADDB50ED7365F08BA91F9,
-					DF78EF6242D82F912534A277,
-					188D03A4247F4BC0539F5C49,
-					C15220EDA1A8315DA3255E87,
-					1729AEDC34001C31B8CC357C,
-					553725A0E3A391651ED1731E,
-					35A36102EAD2D2620EE99E7E,
-					E382C78A1D837DD98916E86A,
-					4856DA6706D794E2D89DAB63,
-					CF21D9DB3AEC0A4DCAB36A99,
-					515FF6E74826E3E3F7273621,
-					47DD50A5A9091F9900E0EAD9,
-					820291543BF93243B718F0EE,
-					0F249640243FBD5717F6ADD9,
-					4A41FD3066D0979DB48691E5,
-					1AF7EFBE4961C7B6C834BF54,
-					87414819D9DE343EA28E0AAD,
-					BCB819DDDD2AC13632CA502F,
-					1F421199C40092BFEE0658C2,
-					20FAAE9F3A7B96C2D8C75BB2,
-					C22791DB75870C4F102AA8A3,
-					631983AA62673015F8D7453B,
-					9BC8AE609A07657CEF587548,
-					B0D2198D1261755918CD454D,
-					8C67B567CF362A163D24B3B1,
-					546593F6EA70EABF708772FE,
-					7F29F77B1C00A9704E6D0859,
-					8090981F07A76E465DAAADF4, ); name = Utility; sourceTree = "<group>"; };
-		C5A691BE7288ADA68DC8D39A = {isa = PBXGroup; children = (
-					A69024A225F2AC31F17B1314,
-					11DC04468BC6023671017EBF,
-					087CB3A961CD3C7434D660A4,
-					4B083E951ECB62217C46CB01,
-					C2990A8D054BC230E7C637C3,
-					8BD8E9DA627D6EF9BA10FB9E,
-					3C95FA2AA91EBA19ADDD5C29,
-					8A825FDDC00DD253F44D2C3A,
-					4A4EBDAD8D098F72CE053235,
-					0F01067432AC314EAC213C1C,
-					A44A774EFC020D3D046A9249,
-					9992E6950C64322A11E39ADF,
-					05D67B5A8D64947C067C0945,
-					A085174413736ACC8D7D42A2,
-					471C7B0A8B92320AF0C80839,
-					714267352CE5C4357ADBC231,
-					C09BBB58CA45B66D693E8C31, ); name = Wizards; sourceTree = "<group>"; };
-		645F98392B3C8E92EE64B533 = {isa = PBXGroup; children = (
-					129F2DE0FEF154F8F8C7A74E,
-					0B24F292A357ABFD9BCC6D7F,
-					576A92E1E0D8F453EC0FEB34,
-					996E472B82A75531875A5E38, ); name = gradle; sourceTree = "<group>"; };
-		C76CE0579AC77DF56E755836 = {isa = PBXGroup; children = (
-					468BFFBE4DA7835DD40C5FE8,
-					E3B56C5718D87CA0EFCB2662,
-					0075C5208947159AF2802F3B,
-					AFF72BA2B130F3F9AC029080,
-					65F4749184C84C2FDBB4C305,
-					03D3053EDE47FED1919C6674,
-					DC922C6A65D260C18E888E49,
-					963E0740B7B4D59EF2D16740,
-					9683B04CA3BD7F73E8236FE2,
-					35E6EE1E98DD7050DDFECD9B,
-					24C34D0578AE6C7A3EA18781,
-					18D9EBA1DAE45EEF81FD5C8F,
-					AE1BC6DCCFC1A18E2ACE23F1,
-					E4BD4C43370651B49F75855B,
-					86E8A40E5A83781A8478454D,
-					61BE37E2B26C25056D9E8FE2,
-					E2374E15D65425C4101237E2,
-					CF8011B3C67B609032974DA5,
-					53151B683E11F420203E61C2,
-					F7CAB5BC15EE351949D3F2C3,
-					73B9F17FE55A02C2BB87E008, ); name = templates; sourceTree = "<group>"; };
-		63EE1C3AC218E509130AF2BA = {isa = PBXGroup; children = (
-					645F98392B3C8E92EE64B533,
-					C76CE0579AC77DF56E755836,
-					BB9C1E6E54A16F795908C469,
-					301592EBAC0FFF6F5B268E99,
-					41105E536155E394E54BDD35,
-					5F6584B675E30761521A9F42,
-					1C73D7591E63E8018E279716,
-					B73B25AD624B88B29EA0589C,
-					6DA8A2AEF943230FF7DB510B,
-					56C3CA379E90628CCB5BC37C,
-					B3FA8ADA3F66D5EE0C0E5CBE,
-					66DEA1923FE5B9A614C7E9DC,
-					5F1C141139AA646EABD72145,
-					B483D960309FAFC193F9CDA2,
-					8C281F2F8EA3AD614ADF7955,
-					4073A12E196BDDADE211E19F,
-					A973D33C0CE829AD293E035B,
-					58139D8D454051C59E77609B,
-					7B6E461262D8822132135F56,
-					E1D8CCD9F4ACBE1EC1D5BEA0,
-					F5885B5AAF46864D562D5B83,
-					FB61FEC24C6C031EB0455B0A,
-					7256D1C79741E66E2C002EE2,
-					F4B63624DBF543082235F821,
-					1D99EA99F946D665FE583414,
-					358DA8CCDC8FA5B0D62D6CA3,
-					A4D275622A4B115AABE190A4,
-					0DB0A9E30EEDDEA720BC5A03, ); name = BinaryData; sourceTree = "<group>"; };
-		D3109994DA6AD871BE85C4E2 = {isa = PBXGroup; children = (
-					48618F36B2E3C15A7B0F63AC,
-					DD016058D39CAFA2C86BAF40,
-					82B98DB2654A087911E8157F,
-					142DEF17A4C953926833D7F8,
-					78FDC751FE3D97F79839DBC6,
-					524339C1BD702C610F2A7DAB,
-					EB15E4BA49763AC74CE29FDE,
-					6580E53C420AA794542CC8D7,
-					C5A691BE7288ADA68DC8D39A,
-					63EE1C3AC218E509130AF2BA, ); name = Projucer; sourceTree = "<group>"; };
-		8A24D1B6925535A868974986 = {isa = PBXGroup; children = (
-					BA159A3B7D129771F5C15EA3,
-					AA1C44E89D792DDC4867B2C8,
-					69555CEFC6ED613AA3949298,
-					21F4833C5B5C17B159B956F3,
-					B6F2905330EA5C560D527209,
-					7AB7640968FAAC73072FBD10,
-					D05BD91B6105827B010E1C20, ); name = "Juce Modules"; sourceTree = "<group>"; };
-		2C6746F66EF4444F53B3221F = {isa = PBXGroup; children = (
-					8702F43110E4CCA5E5F827F5,
-					472F9A90F685220D730EBF6C,
-					4F687965FBE86EAFDB3ACFEC,
-					DB9C8E35DF815B803CB4A9CF,
-					D766BB9D8C32B5560F0493F3,
-					1DE5BBC777FB64798D823002,
-					5867DC4E39DF8539B54C0D59,
-					1B9B5A37F079FE3B3CF8FAB6,
-					0462692BAA9CD1BE6DFBCC33,
-					AECE3914F5119A3D586A5635,
-					364D1A9B113320407A7E57B9, ); name = "Juce Library Code"; sourceTree = "<group>"; };
-		8180B5894A78501084B8F133 = {isa = PBXGroup; children = (
-					E266DE67FF319D56F63193A6,
-					6678E9B3EEACAD47F438B264,
-					951128CA33CCDEF570436B1C, ); name = Resources; sourceTree = "<group>"; };
-		0FFEF043CA89142B18C79ABE = {isa = PBXGroup; children = (
-					80D62B907248523E6943298B,
-					5A75806B34E4EA6598A6024A,
-					7B3F7ECF6DBF8C8EE5C2CB86,
-					210CD22F25F2C22F9CEEB025,
-					D00F311BFC3C2625C457CB9B,
-					D1F9B0E9F5D54FE48BEB46EA,
-					728FE25157E9874D50BBECB2,
-					E983E6DDE3318B872EBE347F,
-					8F7BE18698ADCEF51CDE4A5C,
-					842427CFE565F3FCE5B99174,
-					E96597BBC6A98255B51B94DC,
-					431D30038CBF67F80E8B3A13,
-					9F01BA9942D038EA8B5289A8,
-					E5D6C36496F5BC84D7213BE8,
-					CF6C8BD0DA3D8CD4E99EBADA, ); name = Frameworks; sourceTree = "<group>"; };
-		92ABB8016546F41128399E9D = {isa = PBXGroup; children = (
-					09DE066936CF037E9709ADB1, ); name = Products; sourceTree = "<group>"; };
-		3CC531922CC2D398E283A845 = {isa = PBXGroup; children = (
-					D3109994DA6AD871BE85C4E2,
-					8A24D1B6925535A868974986,
-					2C6746F66EF4444F53B3221F,
-					8180B5894A78501084B8F133,
-					0FFEF043CA89142B18C79ABE,
-					92ABB8016546F41128399E9D, ); name = Source; sourceTree = "<group>"; };
-		0CC6C439D038EDA0D7F10DF0 = {isa = XCBuildConfiguration; buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_LINK_OBJC_RUNTIME = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"_DEBUG=1",
-					"DEBUG=1",
-					"JUCER_XCODE_MAC_F6D2F4CF=1",
-					"JUCE_APP_VERSION=5.0.2",
-					"JUCE_APP_VERSION_HEX=0x50002",
-					"JucePlugin_Build_VST=0",
-					"JucePlugin_Build_VST3=0",
-					"JucePlugin_Build_AU=0",
-					"JucePlugin_Build_AUv3=0",
-					"JucePlugin_Build_RTAS=0",
-					"JucePlugin_Build_AAX=0",
-					"JucePlugin_Build_Standalone=0", );
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../../../modules", "$(inherited)");
-				INFOPLIST_FILE = Info-App.plist;
-				INFOPLIST_PREPROCESS = NO;
-				INSTALL_PATH = "$(HOME)/Applications";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
-				OTHER_CPLUSPLUSFLAGS = "-Wall -Wshadow -Wno-missing-field-initializers -Wshadow -Wshorten-64-to-32 -Wstrict-aliasing -Wuninitialized -Wunused-parameter -Wconversion -Wsign-compare -Wint-conversion -Woverloaded-virtual -Wreorder -Wconstant-conversion -Wsign-conversion -Wextra-semi";
-				PRODUCT_BUNDLE_IDENTIFIER = com.juce.theprojucer;
-				SDKROOT_ppc = macosx10.5;
-				USE_HEADERMAP = NO; }; name = Debug; };
-		0BC15DC2E5FE5ECFFB398D49 = {isa = XCBuildConfiguration; buildSettings = {
+/* Begin PBXBuildFile section */
+		02E8F35A8E0D4A0DF6F38D60 /* include_juce_data_structures.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1DE5BBC777FB64798D823002 /* include_juce_data_structures.mm */; };
+		091A57B4B9CE623E75E9A756 /* CoreAudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E983E6DDE3318B872EBE347F /* CoreAudioKit.framework */; };
+		0C5F43C262695A3EB7A9E1C0 /* jucer_ProjectSaver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14A24BB4AB7B81D40EF062E5 /* jucer_ProjectSaver.cpp */; };
+		0E884E47A637D6C65154699A /* DiscRecording.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 842427CFE565F3FCE5B99174 /* DiscRecording.framework */; };
+		110221CD5578153B528AD2BE /* jucer_ResourceFile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D10D51A0A2D63F38B4D86A60 /* jucer_ResourceFile.cpp */; };
+		11D42F7EC6E6539D79A7F4B1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5D6C36496F5BC84D7213BE8 /* QuartzCore.framework */; };
+		123810DAF8AF758928916ECE /* jucer_JucerTreeViewBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47DD50A5A9091F9900E0EAD9 /* jucer_JucerTreeViewBase.cpp */; };
+		1321E6C1C6170B6C898AD09D /* Icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 951128CA33CCDEF570436B1C /* Icon.icns */; };
+		1499DF2E85B05AC1BF423773 /* jucer_Icons.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CF21D9DB3AEC0A4DCAB36A99 /* jucer_Icons.cpp */; };
+		1B988E139004D8E2850EB656 /* jucer_PaintRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C187718F7B9EBA88584B43F3 /* jucer_PaintRoutine.cpp */; };
+		1E76E36772355E2A43CF4961 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00F311BFC3C2625C457CB9B /* Carbon.framework */; };
+		1F37544891EC8DBB5E500C1C /* jucer_ProjectExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F71AF6D2DF3E652F8B51EBAB /* jucer_ProjectExporter.cpp */; };
+		209FCCC2155A1FCB7E11E20D /* jucer_JucerDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 269A454F1FF081DA67FFD578 /* jucer_JucerDocument.cpp */; };
+		234B6BA2952CBC7C61EF70EF /* include_juce_events.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5867DC4E39DF8539B54C0D59 /* include_juce_events.mm */; };
+		241F29FCBB7A17BB44A0B10C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1F9B0E9F5D54FE48BEB46EA /* Cocoa.framework */; };
+		244BA1BDA5FAA465EA3F9C6D /* jucer_OpenDocumentManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2247EE920DF0610CAF9F4513 /* jucer_OpenDocumentManager.cpp */; };
+		254A7C08594A152C2C646334 /* include_juce_graphics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1B9B5A37F079FE3B3CF8FAB6 /* include_juce_graphics.mm */; };
+		2610F357881240ACBF612F48 /* RecentFilesMenuTemplate.nib in Resources */ = {isa = PBXBuildFile; fileRef = 6678E9B3EEACAD47F438B264 /* RecentFilesMenuTemplate.nib */; };
+		30B921C38DCEE787B294B746 /* jucer_Project.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BAC43B20E14A340CCF14119C /* jucer_Project.cpp */; };
+		34716A3539FD288C09CBA38A /* jucer_TestComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 921752D9B004A15973DDF56F /* jucer_TestComponent.cpp */; };
+		357A6AA6960EF95D92929BEE /* jucer_AppearanceSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 441CFEA771BAA50E187342E9 /* jucer_AppearanceSettings.cpp */; };
+		3C5267E06A897B0DC0F7EA50 /* BinaryData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 472F9A90F685220D730EBF6C /* BinaryData.cpp */; };
+		3D777382FE212D59BAF871FD /* jucer_DependencyPathPropertyComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCBB17488227A2CA7D3D3947 /* jucer_DependencyPathPropertyComponent.cpp */; };
+		3DC282564876B1FC88AAA9B3 /* jucer_ComponentDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 662C76394C5D1B56766FAFD9 /* jucer_ComponentDocument.cpp */; };
+		3EB3D569250C4BA4CA9AF578 /* jucer_DocumentEditorComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C7608A3967D9AB9481848F2B /* jucer_DocumentEditorComponent.cpp */; };
+		3FCA61C401007B243E2E9035 /* jucer_Module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F797071D88542C813CF7222A /* jucer_Module.cpp */; };
+		45A53AF13B0D663050632E8C /* jucer_BinaryResources.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9EF583A6201DBC813C2F63C4 /* jucer_BinaryResources.cpp */; };
+		49C22786B54C5DC94E4654B8 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E96597BBC6A98255B51B94DC /* IOKit.framework */; };
+		4A1DB797F1356E85110FF871 /* jucer_SlidingPanelComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20FAAE9F3A7B96C2D8C75BB2 /* jucer_SlidingPanelComponent.cpp */; };
+		518DD443B6F17A5AFD707263 /* jucer_NewFileWizard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A69024A225F2AC31F17B1314 /* jucer_NewFileWizard.cpp */; };
+		57B1F32A372143B4D3B1C517 /* jucer_ButtonDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3E03B7C7A19E63A724EB79F4 /* jucer_ButtonDocument.cpp */; };
+		5DD883699B85E4C492CAD065 /* include_juce_core.mm in Sources */ = {isa = PBXBuildFile; fileRef = DB9C8E35DF815B803CB4A9CF /* include_juce_core.mm */; };
+		636D21BF846031A6A1A7476A /* jucer_DownloadCompileEngineThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11EB44786085029106099D01 /* jucer_DownloadCompileEngineThread.cpp */; };
+		6DD9DA1677A6CF789CDAB478 /* jucer_AutoUpdater.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0D4D508C638BC74943B9976D /* jucer_AutoUpdater.cpp */; };
+		6FD0752A5CADCF60D79FDBB7 /* jucer_LicenseController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51CBE59779A36D1B80B26974 /* jucer_LicenseController.cpp */; };
+		78CB463DD98A55313A543859 /* jucer_FileHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1729AEDC34001C31B8CC357C /* jucer_FileHelpers.cpp */; };
+		83431B7234A78ECFB3C15F63 /* jucer_GeneratedCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 78D0DBC4798FF040FDB90F6D /* jucer_GeneratedCode.cpp */; };
+		85B5E65F8DD80938BFBDCE61 /* projucer_CompileEngineClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1333F975410DD3DBBE2841F /* projucer_CompileEngineClient.cpp */; };
+		8AD28823205783E6F676F254 /* jucer_ResourceEditorPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF725A596B7BCD7520CC0A9F /* jucer_ResourceEditorPanel.cpp */; };
+		8B4A593B3869815BBAC3EF93 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B3F7ECF6DBF8C8EE5C2CB86 /* AudioUnit.framework */; };
+		8C1CC0E7A772D66635BA482F /* jucer_EditingPanelBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 98F42686D9DAC974F2514217 /* jucer_EditingPanelBase.cpp */; };
+		9359F9401D59B4517F75C39C /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 728FE25157E9874D50BBECB2 /* CoreAudio.framework */; };
+		954A036F5DDB375DB23FFB3E /* jucer_CommandLine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0400CB0E056A1D840304D2DE /* jucer_CommandLine.cpp */; };
+		95B44E6C74B1DED31DBE37EB /* jucer_Main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C52A3DDA62A746AA7A68535 /* jucer_Main.cpp */; };
+		96EC6315E1B3F1A109F84BAF /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F01BA9942D038EA8B5289A8 /* QTKit.framework */; };
+		9BF773500BA51A8B5C6C7348 /* jucer_ComponentTypeHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C498761CE166072A202AA0 /* jucer_ComponentTypeHandler.cpp */; };
+		9EAF9BE59FFE0BD49410B10E /* jucer_ProjucerLookAndFeel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87414819D9DE343EA28E0AAD /* jucer_ProjucerLookAndFeel.cpp */; };
+		A14C2C2725DA3CA7995D2815 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 210CD22F25F2C22F9CEEB025 /* AVFoundation.framework */; };
+		A578EAD4BB55680E8097BE0F /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D62B907248523E6943298B /* Accelerate.framework */; };
+		A69BF71FA90E5A66B6EB2E0F /* jucer_JucerDocumentEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA58D223674C4C2AC6595 /* jucer_JucerDocumentEditor.cpp */; };
+		A70F0274076C0D44ED71C980 /* jucer_ComponentLayoutEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF30A74B566A461A171BBF83 /* jucer_ComponentLayoutEditor.cpp */; };
+		AA9D0B8E23F3D87A23DE9F8A /* jucer_MainWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9069981E414A631B036CC9AC /* jucer_MainWindow.cpp */; };
+		B18248959DDC44EF4E85320A /* include_juce_gui_extra.mm in Sources */ = {isa = PBXBuildFile; fileRef = AECE3914F5119A3D586A5635 /* include_juce_gui_extra.mm */; };
+		B7EBA1A83575F48CD08140B9 /* jucer_NewProjectWizardClasses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4B083E951ECB62217C46CB01 /* jucer_NewProjectWizardClasses.cpp */; };
+		B980464FA2761CCD64B1FAD6 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF6C8BD0DA3D8CD4E99EBADA /* WebKit.framework */; };
+		BD1E0CBE74DDD2F303978E1F /* jucer_ComponentOverlayComponent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E191CDCE7565DB726CF7065 /* jucer_ComponentOverlayComponent.cpp */; };
+		C1B9334AE849F93FB3C56B34 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A75806B34E4EA6598A6024A /* AudioToolbox.framework */; };
+		C2A85091A28C907A4E1E1687 /* jucer_ComponentLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 133F1E428260C5ADDF496DF9 /* jucer_ComponentLayout.cpp */; };
+		C49E1D32A9DCE3D59BC48B1D /* jucer_ColouredElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93B419190CCE92ACAB1ED25B /* jucer_ColouredElement.cpp */; };
+		C93569F47B4AC1A8E37992ED /* jucer_ObjectTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D7689451732AF8333402B3A /* jucer_ObjectTypes.cpp */; };
+		C9F11BA62D6D092A300363F7 /* jucer_MiscUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F249640243FBD5717F6ADD9 /* jucer_MiscUtilities.cpp */; };
+		CD4F7B119CE718BCE78D61F4 /* jucer_CodeHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9B9CAD20E1243B4351B4C8D8 /* jucer_CodeHelpers.cpp */; };
+		CDEF9FF2D119476D707305DF /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 431D30038CBF67F80E8B3A13 /* OpenGL.framework */; };
+		CE91112DADB97C573C3C674D /* jucer_PaintElementPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0169ACAA0FAE70CCEEE4F650 /* jucer_PaintElementPath.cpp */; };
+		D5C9125F65493CA481F18E53 /* include_juce_cryptography.mm in Sources */ = {isa = PBXBuildFile; fileRef = D766BB9D8C32B5560F0493F3 /* include_juce_cryptography.mm */; };
+		D68DE111AFBD82F0D44A3B69 /* jucer_PaintRoutineEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B15E33E7342F6EB4F95C9B1D /* jucer_PaintRoutineEditor.cpp */; };
+		D805169E01D7F90B01C11769 /* projucer_CompileEngineServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 635290DEB1D564927D7A450C /* projucer_CompileEngineServer.cpp */; };
+		E1268E019B434F6B5E9317DC /* jucer_PaintElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C216FE9B7A5209C5CCF2517 /* jucer_PaintElement.cpp */; };
+		EC6A34EC9A9D454BF26AAD32 /* jucer_PaintRoutinePanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16203C6791259C9718A04C3A /* jucer_PaintRoutinePanel.cpp */; };
+		F15F0512666FF8CDC0D08905 /* include_juce_gui_basics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0462692BAA9CD1BE6DFBCC33 /* include_juce_gui_basics.mm */; };
+		F6635694A01FFBF5EF0968DB /* jucer_StoredSettings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 631983AA62673015F8D7453B /* jucer_StoredSettings.cpp */; };
+		FAB47E69F7D9DCE1F906AA07 /* CoreMIDI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F7BE18698ADCEF51CDE4A5C /* CoreMIDI.framework */; };
+		FCE6F604C00039A32649CB69 /* jucer_SourceCodeEditor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E680E2C65684A4272AE079A /* jucer_SourceCodeEditor.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0075C5208947159AF2802F3B /* jucer_AudioPluginEditorTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AudioPluginEditorTemplate.cpp; path = ../../Source/BinaryData/jucer_AudioPluginEditorTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		008C8B2C2328CFBB9375397D /* jucer_ComboBoxHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComboBoxHandler.h; path = ../../Source/ComponentEditor/components/jucer_ComboBoxHandler.h; sourceTree = SOURCE_ROOT; };
+		0169ACAA0FAE70CCEEE4F650 /* jucer_PaintElementPath.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_PaintElementPath.cpp; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp; sourceTree = SOURCE_ROOT; };
+		03D3053EDE47FED1919C6674 /* jucer_AudioPluginFilterTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_AudioPluginFilterTemplate.h; path = ../../Source/BinaryData/jucer_AudioPluginFilterTemplate.h; sourceTree = SOURCE_ROOT; };
+		0400CB0E056A1D840304D2DE /* jucer_CommandLine.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_CommandLine.cpp; path = ../../Source/Application/jucer_CommandLine.cpp; sourceTree = SOURCE_ROOT; };
+		0462692BAA9CD1BE6DFBCC33 /* include_juce_gui_basics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_gui_basics.mm; path = ../../JuceLibraryCode/include_juce_gui_basics.mm; sourceTree = SOURCE_ROOT; };
+		04C1267B2BD11A6ECCCA654C /* jucer_ComponentBooleanProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentBooleanProperty.h; path = ../../Source/ComponentEditor/properties/jucer_ComponentBooleanProperty.h; sourceTree = SOURCE_ROOT; };
+		05076CDF1511A5F8A8E18F1D /* jucer_ProjectExport_Make.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExport_Make.h; path = "../../Source/Project Saving/jucer_ProjectExport_Make.h"; sourceTree = SOURCE_ROOT; };
+		05D67B5A8D64947C067C0945 /* jucer_ProjectWizard_GUIApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_GUIApp.h; path = ../../Source/Wizards/jucer_ProjectWizard_GUIApp.h; sourceTree = SOURCE_ROOT; };
+		084C0070BC67BC893B967EF1 /* jucer_ToggleButtonHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ToggleButtonHandler.h; path = ../../Source/ComponentEditor/components/jucer_ToggleButtonHandler.h; sourceTree = SOURCE_ROOT; };
+		087CB3A961CD3C7434D660A4 /* jucer_NewProjectWizard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewProjectWizard.h; path = ../../Source/Wizards/jucer_NewProjectWizard.h; sourceTree = SOURCE_ROOT; };
+		09DE066936CF037E9709ADB1 /* Projucer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Projucer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B24F292A357ABFD9BCC6D7F /* gradlew */ = {isa = PBXFileReference; lastKnownFileType = text; name = gradlew; path = ../../Source/BinaryData/gradle/gradlew; sourceTree = SOURCE_ROOT; };
+		0C2AD2FC0C196F440C3FF994 /* jucer_DependencyPathPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_DependencyPathPropertyComponent.h; path = ../../Source/Project/jucer_DependencyPathPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		0C6B1A14D37958E405448B8D /* projucer_ErrorListComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ErrorListComponent.h; path = ../../Source/LiveBuildEngine/projucer_ErrorListComponent.h; sourceTree = SOURCE_ROOT; };
+		0D4D508C638BC74943B9976D /* jucer_AutoUpdater.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AutoUpdater.cpp; path = ../../Source/Application/jucer_AutoUpdater.cpp; sourceTree = SOURCE_ROOT; };
+		0DB0A9E30EEDDEA720BC5A03 /* wizard_StaticLibrary.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_StaticLibrary.svg; path = ../../Source/BinaryData/wizard_StaticLibrary.svg; sourceTree = SOURCE_ROOT; };
+		0F01067432AC314EAC213C1C /* jucer_ProjectWizard_Blank.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_Blank.h; path = ../../Source/Wizards/jucer_ProjectWizard_Blank.h; sourceTree = SOURCE_ROOT; };
+		0F249640243FBD5717F6ADD9 /* jucer_MiscUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MiscUtilities.cpp; path = ../../Source/Utility/jucer_MiscUtilities.cpp; sourceTree = SOURCE_ROOT; };
+		0FF1C6905150EAAB1AE081A7 /* jucer_ButtonHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ButtonHandler.h; path = ../../Source/ComponentEditor/components/jucer_ButtonHandler.h; sourceTree = SOURCE_ROOT; };
+		1125D1B2AE54AEF2EB3D51C0 /* jucer_JucerDocumentEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JucerDocumentEditor.h; path = ../../Source/ComponentEditor/ui/jucer_JucerDocumentEditor.h; sourceTree = SOURCE_ROOT; };
+		11DC04468BC6023671017EBF /* jucer_NewFileWizard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewFileWizard.h; path = ../../Source/Wizards/jucer_NewFileWizard.h; sourceTree = SOURCE_ROOT; };
+		11EB44786085029106099D01 /* jucer_DownloadCompileEngineThread.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_DownloadCompileEngineThread.cpp; path = ../../Source/Application/jucer_DownloadCompileEngineThread.cpp; sourceTree = SOURCE_ROOT; };
+		129F2DE0FEF154F8F8C7A74E /* gradle-wrapper.jar */ = {isa = PBXFileReference; lastKnownFileType = file.jar; name = "gradle-wrapper.jar"; path = "../../Source/BinaryData/gradle/gradle-wrapper.jar"; sourceTree = SOURCE_ROOT; };
+		133F1E428260C5ADDF496DF9 /* jucer_ComponentLayout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentLayout.cpp; path = ../../Source/ComponentEditor/jucer_ComponentLayout.cpp; sourceTree = SOURCE_ROOT; };
+		14A24BB4AB7B81D40EF062E5 /* jucer_ProjectSaver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ProjectSaver.cpp; path = "../../Source/Project Saving/jucer_ProjectSaver.cpp"; sourceTree = SOURCE_ROOT; };
+		16203C6791259C9718A04C3A /* jucer_PaintRoutinePanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_PaintRoutinePanel.cpp; path = ../../Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp; sourceTree = SOURCE_ROOT; };
+		1729AEDC34001C31B8CC357C /* jucer_FileHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_FileHelpers.cpp; path = ../../Source/Utility/jucer_FileHelpers.cpp; sourceTree = SOURCE_ROOT; };
+		188D03A4247F4BC0539F5C49 /* jucer_Colours.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Colours.h; path = ../../Source/Utility/jucer_Colours.h; sourceTree = SOURCE_ROOT; };
+		18D9EBA1DAE45EEF81FD5C8F /* jucer_MainConsoleAppTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MainConsoleAppTemplate.cpp; path = ../../Source/BinaryData/jucer_MainConsoleAppTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		1AF7EFBE4961C7B6C834BF54 /* jucer_PresetIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PresetIDs.h; path = ../../Source/Utility/jucer_PresetIDs.h; sourceTree = SOURCE_ROOT; };
+		1B9B5A37F079FE3B3CF8FAB6 /* include_juce_graphics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_graphics.mm; path = ../../JuceLibraryCode/include_juce_graphics.mm; sourceTree = SOURCE_ROOT; };
+		1C216FE9B7A5209C5CCF2517 /* jucer_PaintElement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_PaintElement.cpp; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElement.cpp; sourceTree = SOURCE_ROOT; };
+		1C73D7591E63E8018E279716 /* export_android.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = export_android.svg; path = ../../Source/BinaryData/export_android.svg; sourceTree = SOURCE_ROOT; };
+		1D3D6A19A60F0B03DE2F1C14 /* jucer_PaintElementPath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementPath.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementPath.h; sourceTree = SOURCE_ROOT; };
+		1D99EA99F946D665FE583414 /* wizard_Highlight.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_Highlight.svg; path = ../../Source/BinaryData/wizard_Highlight.svg; sourceTree = SOURCE_ROOT; };
+		1DE5BBC777FB64798D823002 /* include_juce_data_structures.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_data_structures.mm; path = ../../JuceLibraryCode/include_juce_data_structures.mm; sourceTree = SOURCE_ROOT; };
+		1F421199C40092BFEE0658C2 /* jucer_RelativePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_RelativePath.h; path = ../../Source/Utility/jucer_RelativePath.h; sourceTree = SOURCE_ROOT; };
+		1F9BBDFA52513AD34D906D2A /* jucer_HyperlinkButtonHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_HyperlinkButtonHandler.h; path = ../../Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h; sourceTree = SOURCE_ROOT; };
+		1FA92F8F2B26C6CEC8B1D737 /* jucer_ButtonDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ButtonDocument.h; path = ../../Source/ComponentEditor/documents/jucer_ButtonDocument.h; sourceTree = SOURCE_ROOT; };
+		20FAAE9F3A7B96C2D8C75BB2 /* jucer_SlidingPanelComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_SlidingPanelComponent.cpp; path = ../../Source/Utility/jucer_SlidingPanelComponent.cpp; sourceTree = SOURCE_ROOT; };
+		210CD22F25F2C22F9CEEB025 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		21F4833C5B5C17B159B956F3 /* juce_events */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_events; path = ../../../../modules/juce_events; sourceTree = SOURCE_ROOT; };
+		223C4209F18A221EB183A056 /* jucer_AppearanceSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_AppearanceSettings.h; path = ../../Source/Application/jucer_AppearanceSettings.h; sourceTree = SOURCE_ROOT; };
+		2247EE920DF0610CAF9F4513 /* jucer_OpenDocumentManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_OpenDocumentManager.cpp; path = ../../Source/Application/jucer_OpenDocumentManager.cpp; sourceTree = SOURCE_ROOT; };
+		23A8DE16C0CDB8EED18B008B /* jucer_CommandIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_CommandIDs.h; path = ../../Source/Application/jucer_CommandIDs.h; sourceTree = SOURCE_ROOT; };
+		24C34D0578AE6C7A3EA18781 /* jucer_InlineComponentTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_InlineComponentTemplate.h; path = ../../Source/BinaryData/jucer_InlineComponentTemplate.h; sourceTree = SOURCE_ROOT; };
+		263D9041F9B7D6A79DC38CD6 /* jucer_ComponentLayoutEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentLayoutEditor.h; path = ../../Source/ComponentEditor/ui/jucer_ComponentLayoutEditor.h; sourceTree = SOURCE_ROOT; };
+		269A454F1FF081DA67FFD578 /* jucer_JucerDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_JucerDocument.cpp; path = ../../Source/ComponentEditor/jucer_JucerDocument.cpp; sourceTree = SOURCE_ROOT; };
+		27A2B025813B7E54E0862642 /* jucer_PaintElementUndoableAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementUndoableAction.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementUndoableAction.h; sourceTree = SOURCE_ROOT; };
+		295A9B126C98FE15F5A8B81E /* jucer_FilePropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FilePropertyComponent.h; path = ../../Source/ComponentEditor/properties/jucer_FilePropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		2C7CDA71ACB5829BC616A353 /* projucer_ComponentListComp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ComponentListComp.h; path = ../../Source/LiveBuildEngine/projucer_ComponentListComp.h; sourceTree = SOURCE_ROOT; };
+		2CD34A70B4032C0426F7AA10 /* jucer_MainWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_MainWindow.h; path = ../../Source/Application/jucer_MainWindow.h; sourceTree = SOURCE_ROOT; };
+		2E680E2C65684A4272AE079A /* jucer_SourceCodeEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_SourceCodeEditor.cpp; path = "../../Source/Code Editor/jucer_SourceCodeEditor.cpp"; sourceTree = SOURCE_ROOT; };
+		2EEB1C074162F363C6599282 /* jucer_CommandLine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_CommandLine.h; path = ../../Source/Application/jucer_CommandLine.h; sourceTree = SOURCE_ROOT; };
+		301592EBAC0FFF6F5B268E99 /* background_tile.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = background_tile.png; path = ../../Source/BinaryData/background_tile.png; sourceTree = SOURCE_ROOT; };
+		313BC56B30B05119686B1E99 /* projucer_ProjectBuildInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ProjectBuildInfo.h; path = ../../Source/LiveBuildEngine/projucer_ProjectBuildInfo.h; sourceTree = SOURCE_ROOT; };
+		32C81E19D3D68B9DDF870FE9 /* jucer_ProjectTab.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectTab.h; path = ../../Source/Project/jucer_ProjectTab.h; sourceTree = SOURCE_ROOT; };
+		3514E78B58A08F4C98F54C5A /* jucer_ComponentLayoutPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentLayoutPanel.h; path = ../../Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h; sourceTree = SOURCE_ROOT; };
+		358DA8CCDC8FA5B0D62D6CA3 /* wizard_Openfile.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_Openfile.svg; path = ../../Source/BinaryData/wizard_Openfile.svg; sourceTree = SOURCE_ROOT; };
+		35A36102EAD2D2620EE99E7E /* jucer_FilePathPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FilePathPropertyComponent.h; path = ../../Source/Utility/jucer_FilePathPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		35CB48D497F35BF3F6998F5D /* jucer_ProjectExporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExporter.h; path = "../../Source/Project Saving/jucer_ProjectExporter.h"; sourceTree = SOURCE_ROOT; };
+		35E6EE1E98DD7050DDFECD9B /* jucer_ContentCompTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ContentCompTemplate.h; path = ../../Source/BinaryData/jucer_ContentCompTemplate.h; sourceTree = SOURCE_ROOT; };
+		364D1A9B113320407A7E57B9 /* JuceHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JuceHeader.h; path = ../../JuceLibraryCode/JuceHeader.h; sourceTree = SOURCE_ROOT; };
+		375AFDF06A908D89DEC5205F /* jucer_ProjectTree_Base.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectTree_Base.h; path = ../../Source/Project/jucer_ProjectTree_Base.h; sourceTree = SOURCE_ROOT; };
+		3A5B5DC92BE6D22CA15B9671 /* jucer_SnapGridPainter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_SnapGridPainter.h; path = ../../Source/ComponentEditor/ui/jucer_SnapGridPainter.h; sourceTree = SOURCE_ROOT; };
+		3C95FA2AA91EBA19ADDD5C29 /* jucer_ProjectWizard_Animated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_Animated.h; path = ../../Source/Wizards/jucer_ProjectWizard_Animated.h; sourceTree = SOURCE_ROOT; };
+		3E03B7C7A19E63A724EB79F4 /* jucer_ButtonDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ButtonDocument.cpp; path = ../../Source/ComponentEditor/documents/jucer_ButtonDocument.cpp; sourceTree = SOURCE_ROOT; };
+		3F00C034B140193B3754969B /* jucer_ImageResourceProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ImageResourceProperty.h; path = ../../Source/ComponentEditor/paintelements/jucer_ImageResourceProperty.h; sourceTree = SOURCE_ROOT; };
+		3F9D4C7F6E5779D4E4AE655D /* jucer_ComponentLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentLayout.h; path = ../../Source/ComponentEditor/jucer_ComponentLayout.h; sourceTree = SOURCE_ROOT; };
+		400E4C67ABCDDB1D49EBB85E /* jucer_TabbedComponentHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TabbedComponentHandler.h; path = ../../Source/ComponentEditor/components/jucer_TabbedComponentHandler.h; sourceTree = SOURCE_ROOT; };
+		4073A12E196BDDADE211E19F /* projucer_EULA.txt */ = {isa = PBXFileReference; lastKnownFileType = text.txt; name = projucer_EULA.txt; path = ../../Source/BinaryData/projucer_EULA.txt; sourceTree = SOURCE_ROOT; };
+		41105E536155E394E54BDD35 /* colourscheme_dark.xml */ = {isa = PBXFileReference; lastKnownFileType = file.xml; name = colourscheme_dark.xml; path = ../../Source/BinaryData/colourscheme_dark.xml; sourceTree = SOURCE_ROOT; };
+		41CA95403E264AA7457A61F4 /* jucer_PaintElementRoundedRectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementRoundedRectangle.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h; sourceTree = SOURCE_ROOT; };
+		431D30038CBF67F80E8B3A13 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
+		43C068B8D98821C09492AB29 /* projucer_ActivityListComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ActivityListComponent.h; path = ../../Source/LiveBuildEngine/projucer_ActivityListComponent.h; sourceTree = SOURCE_ROOT; };
+		441CFEA771BAA50E187342E9 /* jucer_AppearanceSettings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AppearanceSettings.cpp; path = ../../Source/Application/jucer_AppearanceSettings.cpp; sourceTree = SOURCE_ROOT; };
+		468BFFBE4DA7835DD40C5FE8 /* jucer_AnimatedComponentTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AnimatedComponentTemplate.cpp; path = ../../Source/BinaryData/jucer_AnimatedComponentTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		46CDD8C3C86FD61741B88A69 /* jucer_LiveBuildTab.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LiveBuildTab.h; path = ../../Source/Project/jucer_LiveBuildTab.h; sourceTree = SOURCE_ROOT; };
+		471C7B0A8B92320AF0C80839 /* jucer_ProjectWizard_StaticLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_StaticLibrary.h; path = ../../Source/Wizards/jucer_ProjectWizard_StaticLibrary.h; sourceTree = SOURCE_ROOT; };
+		472F9A90F685220D730EBF6C /* BinaryData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BinaryData.cpp; path = ../../JuceLibraryCode/BinaryData.cpp; sourceTree = SOURCE_ROOT; };
+		47B49049B85EED74D29C9906 /* jucer_ProjectTree_File.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectTree_File.h; path = ../../Source/Project/jucer_ProjectTree_File.h; sourceTree = SOURCE_ROOT; };
+		47DD50A5A9091F9900E0EAD9 /* jucer_JucerTreeViewBase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_JucerTreeViewBase.cpp; path = ../../Source/Utility/jucer_JucerTreeViewBase.cpp; sourceTree = SOURCE_ROOT; };
+		4856DA6706D794E2D89DAB63 /* jucer_GlobalSearchPathsWindowComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GlobalSearchPathsWindowComponent.h; path = ../../Source/Utility/jucer_GlobalSearchPathsWindowComponent.h; sourceTree = SOURCE_ROOT; };
+		4A035FB6A8D93BF154C08C3F /* projucer_BuildTabStatusComp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_BuildTabStatusComp.h; path = ../../Source/LiveBuildEngine/projucer_BuildTabStatusComp.h; sourceTree = SOURCE_ROOT; };
+		4A41FD3066D0979DB48691E5 /* jucer_MiscUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_MiscUtilities.h; path = ../../Source/Utility/jucer_MiscUtilities.h; sourceTree = SOURCE_ROOT; };
+		4A4EBDAD8D098F72CE053235 /* jucer_ProjectWizard_AudioPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_AudioPlugin.h; path = ../../Source/Wizards/jucer_ProjectWizard_AudioPlugin.h; sourceTree = SOURCE_ROOT; };
+		4B083E951ECB62217C46CB01 /* jucer_NewProjectWizardClasses.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_NewProjectWizardClasses.cpp; path = ../../Source/Wizards/jucer_NewProjectWizardClasses.cpp; sourceTree = SOURCE_ROOT; };
+		4C2093BCD3528ACEDC7A2B33 /* jucer_ImageButtonHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ImageButtonHandler.h; path = ../../Source/ComponentEditor/components/jucer_ImageButtonHandler.h; sourceTree = SOURCE_ROOT; };
+		4D698BF12BCD6B0896BCDF17 /* jucer_AutoUpdater.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_AutoUpdater.h; path = ../../Source/Application/jucer_AutoUpdater.h; sourceTree = SOURCE_ROOT; };
+		4E191CDCE7565DB726CF7065 /* jucer_ComponentOverlayComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentOverlayComponent.cpp; path = ../../Source/ComponentEditor/ui/jucer_ComponentOverlayComponent.cpp; sourceTree = SOURCE_ROOT; };
+		4E60769DE992CA7FC1A4A486 /* jucer_PaintRoutineEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintRoutineEditor.h; path = ../../Source/ComponentEditor/ui/jucer_PaintRoutineEditor.h; sourceTree = SOURCE_ROOT; };
+		4E8FE9B1B8C90FC28D56523B /* jucer_PaintElementEllipse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementEllipse.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h; sourceTree = SOURCE_ROOT; };
+		4F6365A0D2D51337151D85C3 /* jucer_ProjectTree_Group.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectTree_Group.h; path = ../../Source/Project/jucer_ProjectTree_Group.h; sourceTree = SOURCE_ROOT; };
+		4F687965FBE86EAFDB3ACFEC /* BinaryData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BinaryData.h; path = ../../JuceLibraryCode/BinaryData.h; sourceTree = SOURCE_ROOT; };
+		50498FF6EA3901CBD58223B3 /* jucer_ObjectTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ObjectTypes.h; path = ../../Source/ComponentEditor/jucer_ObjectTypes.h; sourceTree = SOURCE_ROOT; };
+		5091B14CC87C6238CF044258 /* jucer_ElementSiblingComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ElementSiblingComponent.h; path = ../../Source/ComponentEditor/paintelements/jucer_ElementSiblingComponent.h; sourceTree = SOURCE_ROOT; };
+		515FF6E74826E3E3F7273621 /* jucer_Icons.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Icons.h; path = ../../Source/Utility/jucer_Icons.h; sourceTree = SOURCE_ROOT; };
+		51CBE59779A36D1B80B26974 /* jucer_LicenseController.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_LicenseController.cpp; path = ../../Source/Licenses/jucer_LicenseController.cpp; sourceTree = SOURCE_ROOT; };
+		53151B683E11F420203E61C2 /* jucer_NewCppFileTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewCppFileTemplate.h; path = ../../Source/BinaryData/jucer_NewCppFileTemplate.h; sourceTree = SOURCE_ROOT; };
+		5432B7B9B2CF2EAEC8B66D5C /* jucer_UtilityFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_UtilityFunctions.h; path = ../../Source/ComponentEditor/jucer_UtilityFunctions.h; sourceTree = SOURCE_ROOT; };
+		546593F6EA70EABF708772FE /* jucer_TranslationToolComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TranslationToolComponent.h; path = ../../Source/Utility/jucer_TranslationToolComponent.h; sourceTree = SOURCE_ROOT; };
+		553725A0E3A391651ED1731E /* jucer_FileHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FileHelpers.h; path = ../../Source/Utility/jucer_FileHelpers.h; sourceTree = SOURCE_ROOT; };
+		563091B0916AD9AAA36C7DC5 /* jucer_OpenDocumentManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_OpenDocumentManager.h; path = ../../Source/Application/jucer_OpenDocumentManager.h; sourceTree = SOURCE_ROOT; };
+		56C3CA379E90628CCB5BC37C /* export_visualStudio.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = export_visualStudio.svg; path = ../../Source/BinaryData/export_visualStudio.svg; sourceTree = SOURCE_ROOT; };
+		576A92E1E0D8F453EC0FEB34 /* gradlew.bat */ = {isa = PBXFileReference; lastKnownFileType = file.bat; name = gradlew.bat; path = ../../Source/BinaryData/gradle/gradlew.bat; sourceTree = SOURCE_ROOT; };
+		576D62C0C9C1BA4B7A514721 /* jucer_PositionPropertyBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PositionPropertyBase.h; path = ../../Source/ComponentEditor/properties/jucer_PositionPropertyBase.h; sourceTree = SOURCE_ROOT; };
+		58139D8D454051C59E77609B /* RecentFilesMenuTemplate.nib */ = {isa = PBXFileReference; lastKnownFileType = file.nib; name = RecentFilesMenuTemplate.nib; path = ../../Source/BinaryData/RecentFilesMenuTemplate.nib; sourceTree = SOURCE_ROOT; };
+		5867DC4E39DF8539B54C0D59 /* include_juce_events.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_events.mm; path = ../../JuceLibraryCode/include_juce_events.mm; sourceTree = SOURCE_ROOT; };
+		5A75806B34E4EA6598A6024A /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		5C7636E577B8DBB1D3133022 /* projucer_ActivityList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ActivityList.h; path = ../../Source/LiveBuildEngine/projucer_ActivityList.h; sourceTree = SOURCE_ROOT; };
+		5D9E7814B713670624F0028F /* jucer_ComponentTypeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentTypeHandler.h; path = ../../Source/ComponentEditor/components/jucer_ComponentTypeHandler.h; sourceTree = SOURCE_ROOT; };
+		5F1C141139AA646EABD72145 /* juce-logo-with-text.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = "juce-logo-with-text.svg"; path = "../../Source/BinaryData/juce-logo-with-text.svg"; sourceTree = SOURCE_ROOT; };
+		5F6584B675E30761521A9F42 /* colourscheme_light.xml */ = {isa = PBXFileReference; lastKnownFileType = file.xml; name = colourscheme_light.xml; path = ../../Source/BinaryData/colourscheme_light.xml; sourceTree = SOURCE_ROOT; };
+		61BE37E2B26C25056D9E8FE2 /* jucer_NewComponentTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_NewComponentTemplate.cpp; path = ../../Source/BinaryData/jucer_NewComponentTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		631983AA62673015F8D7453B /* jucer_StoredSettings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_StoredSettings.cpp; path = ../../Source/Utility/jucer_StoredSettings.cpp; sourceTree = SOURCE_ROOT; };
+		635290DEB1D564927D7A450C /* projucer_CompileEngineServer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = projucer_CompileEngineServer.cpp; path = ../../Source/LiveBuildEngine/projucer_CompileEngineServer.cpp; sourceTree = SOURCE_ROOT; };
+		641B57E5FAE6BEFDB6462921 /* jucer_ResourceEditorPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ResourceEditorPanel.h; path = ../../Source/ComponentEditor/ui/jucer_ResourceEditorPanel.h; sourceTree = SOURCE_ROOT; };
+		65C498761CE166072A202AA0 /* jucer_ComponentTypeHandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentTypeHandler.cpp; path = ../../Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp; sourceTree = SOURCE_ROOT; };
+		65F4749184C84C2FDBB4C305 /* jucer_AudioPluginFilterTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AudioPluginFilterTemplate.cpp; path = ../../Source/BinaryData/jucer_AudioPluginFilterTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		662C76394C5D1B56766FAFD9 /* jucer_ComponentDocument.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentDocument.cpp; path = ../../Source/ComponentEditor/documents/jucer_ComponentDocument.cpp; sourceTree = SOURCE_ROOT; };
+		6678E9B3EEACAD47F438B264 /* RecentFilesMenuTemplate.nib */ = {isa = PBXFileReference; lastKnownFileType = file.nib; path = RecentFilesMenuTemplate.nib; sourceTree = SOURCE_ROOT; };
+		66B49F08C5EC3E4974825FF8 /* jucer_PaintRoutine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintRoutine.h; path = ../../Source/ComponentEditor/jucer_PaintRoutine.h; sourceTree = SOURCE_ROOT; };
+		66DEA1923FE5B9A614C7E9DC /* huckleberry_icon.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = huckleberry_icon.svg; path = ../../Source/BinaryData/huckleberry_icon.svg; sourceTree = SOURCE_ROOT; };
+		69555CEFC6ED613AA3949298 /* juce_data_structures */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_data_structures; path = ../../../../modules/juce_data_structures; sourceTree = SOURCE_ROOT; };
+		6A337C69A928E3CE79C55457 /* jucer_ComponentChoiceProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentChoiceProperty.h; path = ../../Source/ComponentEditor/properties/jucer_ComponentChoiceProperty.h; sourceTree = SOURCE_ROOT; };
+		6AC88EFC247C225CC5C11A43 /* jucer_BinaryResources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_BinaryResources.h; path = ../../Source/ComponentEditor/jucer_BinaryResources.h; sourceTree = SOURCE_ROOT; };
+		6DA8A2AEF943230FF7DB510B /* export_linux.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = export_linux.svg; path = ../../Source/BinaryData/export_linux.svg; sourceTree = SOURCE_ROOT; };
+		6E6140969908E7619F858740 /* jucer_CommonHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_CommonHeaders.h; path = ../../Source/Application/jucer_CommonHeaders.h; sourceTree = SOURCE_ROOT; };
+		6E7353DFEA8825B515049ABB /* jucer_ProjectExport_Android.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExport_Android.h; path = "../../Source/Project Saving/jucer_ProjectExport_Android.h"; sourceTree = SOURCE_ROOT; };
+		714267352CE5C4357ADBC231 /* jucer_StartPageComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_StartPageComponent.h; path = ../../Source/Wizards/jucer_StartPageComponent.h; sourceTree = SOURCE_ROOT; };
+		7211101FFA28400ADBB1D47A /* jucer_Module.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Module.h; path = ../../Source/Project/jucer_Module.h; sourceTree = SOURCE_ROOT; };
+		7256D1C79741E66E2C002EE2 /* wizard_DLL.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_DLL.svg; path = ../../Source/BinaryData/wizard_DLL.svg; sourceTree = SOURCE_ROOT; };
+		728FE25157E9874D50BBECB2 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		73B9F17FE55A02C2BB87E008 /* jucer_OpenGLComponentTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_OpenGLComponentTemplate.cpp; path = ../../Source/BinaryData/jucer_OpenGLComponentTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		786BAF436828865F45314440 /* jucer_PaintElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElement.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElement.h; sourceTree = SOURCE_ROOT; };
+		78CA0E0F336229E2E2F111B0 /* jucer_SourceCodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_SourceCodeEditor.h; path = "../../Source/Code Editor/jucer_SourceCodeEditor.h"; sourceTree = SOURCE_ROOT; };
+		78D0DBC4798FF040FDB90F6D /* jucer_GeneratedCode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_GeneratedCode.cpp; path = ../../Source/ComponentEditor/jucer_GeneratedCode.cpp; sourceTree = SOURCE_ROOT; };
+		790F6302B9A0620F23F8A6C1 /* jucer_LicenseThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LicenseThread.h; path = ../../Source/Licenses/jucer_LicenseThread.h; sourceTree = SOURCE_ROOT; };
+		79E58813D1B414AF49DD9598 /* jucer_LiveBuildCodeEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LiveBuildCodeEditor.h; path = "../../Source/Code Editor/jucer_LiveBuildCodeEditor.h"; sourceTree = SOURCE_ROOT; };
+		7A3E96D22F1C9EB4C739834F /* jucer_PointComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PointComponent.h; path = ../../Source/ComponentEditor/paintelements/jucer_PointComponent.h; sourceTree = SOURCE_ROOT; };
+		7AB7640968FAAC73072FBD10 /* juce_gui_basics */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_gui_basics; path = ../../../../modules/juce_gui_basics; sourceTree = SOURCE_ROOT; };
+		7B3F7ECF6DBF8C8EE5C2CB86 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		7B4E33B1E04139F359FB484B /* jucer_ConfigTree_Exporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ConfigTree_Exporter.h; path = ../../Source/Project/jucer_ConfigTree_Exporter.h; sourceTree = SOURCE_ROOT; };
+		7B6E461262D8822132135F56 /* wizard_AnimatedApp.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_AnimatedApp.svg; path = ../../Source/BinaryData/wizard_AnimatedApp.svg; sourceTree = SOURCE_ROOT; };
+		7CA44FF0BA319517C6E39651 /* jucer_Application.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_Application.cpp; path = ../../Source/Application/jucer_Application.cpp; sourceTree = SOURCE_ROOT; };
+		7F29F77B1C00A9704E6D0859 /* jucer_UTF8Component.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_UTF8Component.h; path = ../../Source/Utility/jucer_UTF8Component.h; sourceTree = SOURCE_ROOT; };
+		8090981F07A76E465DAAADF4 /* jucer_ValueSourceHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ValueSourceHelpers.h; path = ../../Source/Utility/jucer_ValueSourceHelpers.h; sourceTree = SOURCE_ROOT; };
+		80D62B907248523E6943298B /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		8138A55052E9FC27284B74DD /* jucer_FontPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FontPropertyComponent.h; path = ../../Source/ComponentEditor/properties/jucer_FontPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		820291543BF93243B718F0EE /* jucer_JucerTreeViewBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JucerTreeViewBase.h; path = ../../Source/Utility/jucer_JucerTreeViewBase.h; sourceTree = SOURCE_ROOT; };
+		842427CFE565F3FCE5B99174 /* DiscRecording.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiscRecording.framework; path = System/Library/Frameworks/DiscRecording.framework; sourceTree = SDKROOT; };
+		86E468DE6556BB2AD76A3D80 /* jucer_ProjectContentComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ProjectContentComponent.cpp; path = ../../Source/Project/jucer_ProjectContentComponent.cpp; sourceTree = SOURCE_ROOT; };
+		86E8A40E5A83781A8478454D /* jucer_MainTemplate_Window.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MainTemplate_Window.cpp; path = ../../Source/BinaryData/jucer_MainTemplate_Window.cpp; sourceTree = SOURCE_ROOT; };
+		8702F43110E4CCA5E5F827F5 /* AppConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppConfig.h; path = ../../JuceLibraryCode/AppConfig.h; sourceTree = SOURCE_ROOT; };
+		87414819D9DE343EA28E0AAD /* jucer_ProjucerLookAndFeel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ProjucerLookAndFeel.cpp; path = ../../Source/Utility/jucer_ProjucerLookAndFeel.cpp; sourceTree = SOURCE_ROOT; };
+		8A825FDDC00DD253F44D2C3A /* jucer_ProjectWizard_AudioApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_AudioApp.h; path = ../../Source/Wizards/jucer_ProjectWizard_AudioApp.h; sourceTree = SOURCE_ROOT; };
+		8BD8E9DA627D6EF9BA10FB9E /* jucer_NewProjectWizardComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewProjectWizardComponent.h; path = ../../Source/Wizards/jucer_NewProjectWizardComponent.h; sourceTree = SOURCE_ROOT; };
+		8C281F2F8EA3AD614ADF7955 /* offlinepage.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = offlinepage.html; path = ../../Source/BinaryData/offlinepage.html; sourceTree = SOURCE_ROOT; };
+		8C52A3DDA62A746AA7A68535 /* jucer_Main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_Main.cpp; path = ../../Source/Application/jucer_Main.cpp; sourceTree = SOURCE_ROOT; };
+		8C67B567CF362A163D24B3B1 /* jucer_TranslationHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TranslationHelpers.h; path = ../../Source/Utility/jucer_TranslationHelpers.h; sourceTree = SOURCE_ROOT; };
+		8DBD2FBBC7B523D1F8AF1E54 /* jucer_HeaderComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_HeaderComponent.h; path = ../../Source/Project/jucer_HeaderComponent.h; sourceTree = SOURCE_ROOT; };
+		8F30A53C7FE4BC65171FB3E2 /* jucer_JucerDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JucerDocument.h; path = ../../Source/ComponentEditor/jucer_JucerDocument.h; sourceTree = SOURCE_ROOT; };
+		8F7BE18698ADCEF51CDE4A5C /* CoreMIDI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMIDI.framework; path = System/Library/Frameworks/CoreMIDI.framework; sourceTree = SDKROOT; };
+		8F8BF1A7130D858E0A239F9E /* jucer_ConfigTree_Base.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ConfigTree_Base.h; path = ../../Source/Project/jucer_ConfigTree_Base.h; sourceTree = SOURCE_ROOT; };
+		9069981E414A631B036CC9AC /* jucer_MainWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MainWindow.cpp; path = ../../Source/Application/jucer_MainWindow.cpp; sourceTree = SOURCE_ROOT; };
+		90E05EF7005D9C0712FA7662 /* projucer_DiagnosticMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_DiagnosticMessage.h; path = ../../Source/LiveBuildEngine/projucer_DiagnosticMessage.h; sourceTree = SOURCE_ROOT; };
+		914ADDB50ED7365F08BA91F9 /* jucer_CodeHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_CodeHelpers.h; path = ../../Source/Utility/jucer_CodeHelpers.h; sourceTree = SOURCE_ROOT; };
+		921752D9B004A15973DDF56F /* jucer_TestComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_TestComponent.cpp; path = ../../Source/ComponentEditor/ui/jucer_TestComponent.cpp; sourceTree = SOURCE_ROOT; };
+		92F91DC29B64AD85B1F508BD /* jucer_GenericComponentHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GenericComponentHandler.h; path = ../../Source/ComponentEditor/components/jucer_GenericComponentHandler.h; sourceTree = SOURCE_ROOT; };
+		934C3778397D89F8C535E417 /* jucer_ApplicationUsageDataWindowComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ApplicationUsageDataWindowComponent.h; path = ../../Source/Utility/jucer_ApplicationUsageDataWindowComponent.h; sourceTree = SOURCE_ROOT; };
+		93B419190CCE92ACAB1ED25B /* jucer_ColouredElement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ColouredElement.cpp; path = ../../Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp; sourceTree = SOURCE_ROOT; };
+		951128CA33CCDEF570436B1C /* Icon.icns */ = {isa = PBXFileReference; lastKnownFileType = file.icns; path = Icon.icns; sourceTree = SOURCE_ROOT; };
+		963E0740B7B4D59EF2D16740 /* jucer_ComponentTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentTemplate.h; path = ../../Source/BinaryData/jucer_ComponentTemplate.h; sourceTree = SOURCE_ROOT; };
+		9683B04CA3BD7F73E8236FE2 /* jucer_ContentCompTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ContentCompTemplate.cpp; path = ../../Source/BinaryData/jucer_ContentCompTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		974B862C51DA9A16CBBB3A29 /* jucer_ProjectExport_XCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExport_XCode.h; path = "../../Source/Project Saving/jucer_ProjectExport_XCode.h"; sourceTree = SOURCE_ROOT; };
+		97E75A598791645465FEDCE1 /* jucer_EditingPanelBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_EditingPanelBase.h; path = ../../Source/ComponentEditor/ui/jucer_EditingPanelBase.h; sourceTree = SOURCE_ROOT; };
+		98E6D61BFF7D85F0E00F0FBF /* jucer_LicenseWebview.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LicenseWebview.h; path = ../../Source/Licenses/jucer_LicenseWebview.h; sourceTree = SOURCE_ROOT; };
+		98F42686D9DAC974F2514217 /* jucer_EditingPanelBase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_EditingPanelBase.cpp; path = ../../Source/ComponentEditor/ui/jucer_EditingPanelBase.cpp; sourceTree = SOURCE_ROOT; };
+		996E472B82A75531875A5E38 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../../Source/BinaryData/gradle/LICENSE; sourceTree = SOURCE_ROOT; };
+		9992E6950C64322A11E39ADF /* jucer_ProjectWizard_DLL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_DLL.h; path = ../../Source/Wizards/jucer_ProjectWizard_DLL.h; sourceTree = SOURCE_ROOT; };
+		9B9CAD20E1243B4351B4C8D8 /* jucer_CodeHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_CodeHelpers.cpp; path = ../../Source/Utility/jucer_CodeHelpers.cpp; sourceTree = SOURCE_ROOT; };
+		9BC8AE609A07657CEF587548 /* jucer_StoredSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_StoredSettings.h; path = ../../Source/Utility/jucer_StoredSettings.h; sourceTree = SOURCE_ROOT; };
+		9C04F9680F82BF279D528688 /* jucer_ProjectSaver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectSaver.h; path = "../../Source/Project Saving/jucer_ProjectSaver.h"; sourceTree = SOURCE_ROOT; };
+		9C51394634F102DEBBE6C9EB /* jucer_PaintElementText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementText.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementText.h; sourceTree = SOURCE_ROOT; };
+		9C7FA58D223674C4C2AC6595 /* jucer_JucerDocumentEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_JucerDocumentEditor.cpp; path = ../../Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp; sourceTree = SOURCE_ROOT; };
+		9C803826E5E3FDB1B37660D5 /* jucer_ComponentDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentDocument.h; path = ../../Source/ComponentEditor/documents/jucer_ComponentDocument.h; sourceTree = SOURCE_ROOT; };
+		9D7689451732AF8333402B3A /* jucer_ObjectTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ObjectTypes.cpp; path = ../../Source/ComponentEditor/jucer_ObjectTypes.cpp; sourceTree = SOURCE_ROOT; };
+		9EA541503DBADC5FFDEB0282 /* jucer_TreeItemTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TreeItemTypes.h; path = ../../Source/Project/jucer_TreeItemTypes.h; sourceTree = SOURCE_ROOT; };
+		9EF583A6201DBC813C2F63C4 /* jucer_BinaryResources.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_BinaryResources.cpp; path = ../../Source/ComponentEditor/jucer_BinaryResources.cpp; sourceTree = SOURCE_ROOT; };
+		9F01BA9942D038EA8B5289A8 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = System/Library/Frameworks/QTKit.framework; sourceTree = SDKROOT; };
+		9F41F3338BF00D0FC74C6390 /* jucer_TestComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TestComponent.h; path = ../../Source/ComponentEditor/ui/jucer_TestComponent.h; sourceTree = SOURCE_ROOT; };
+		9F75811FE7B5F8D1321BEC69 /* jucer_ConfigTree_Modules.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ConfigTree_Modules.h; path = ../../Source/Project/jucer_ConfigTree_Modules.h; sourceTree = SOURCE_ROOT; };
+		A085174413736ACC8D7D42A2 /* jucer_ProjectWizard_openGL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_openGL.h; path = ../../Source/Wizards/jucer_ProjectWizard_openGL.h; sourceTree = SOURCE_ROOT; };
+		A0951828C3BF47FA7E1E52F8 /* jucer_ViewportHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ViewportHandler.h; path = ../../Source/ComponentEditor/components/jucer_ViewportHandler.h; sourceTree = SOURCE_ROOT; };
+		A1333F975410DD3DBBE2841F /* projucer_CompileEngineClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = projucer_CompileEngineClient.cpp; path = ../../Source/LiveBuildEngine/projucer_CompileEngineClient.cpp; sourceTree = SOURCE_ROOT; };
+		A32FE0EBE29FABE58E664E67 /* jucer_AboutWindowComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_AboutWindowComponent.h; path = ../../Source/Utility/jucer_AboutWindowComponent.h; sourceTree = SOURCE_ROOT; };
+		A44A774EFC020D3D046A9249 /* jucer_ProjectWizard_Console.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectWizard_Console.h; path = ../../Source/Wizards/jucer_ProjectWizard_Console.h; sourceTree = SOURCE_ROOT; };
+		A4D275622A4B115AABE190A4 /* wizard_OpenGL.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_OpenGL.svg; path = ../../Source/BinaryData/wizard_OpenGL.svg; sourceTree = SOURCE_ROOT; };
+		A69024A225F2AC31F17B1314 /* jucer_NewFileWizard.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_NewFileWizard.cpp; path = ../../Source/Wizards/jucer_NewFileWizard.cpp; sourceTree = SOURCE_ROOT; };
+		A973D33C0CE829AD293E035B /* projucer_login_bg.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = projucer_login_bg.svg; path = ../../Source/BinaryData/projucer_login_bg.svg; sourceTree = SOURCE_ROOT; };
+		AA1C44E89D792DDC4867B2C8 /* juce_cryptography */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_cryptography; path = ../../../../modules/juce_cryptography; sourceTree = SOURCE_ROOT; };
+		AA8EED79F095953D2B5923B8 /* jucer_ComponentColourProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentColourProperty.h; path = ../../Source/ComponentEditor/properties/jucer_ComponentColourProperty.h; sourceTree = SOURCE_ROOT; };
+		AE1BC6DCCFC1A18E2ACE23F1 /* jucer_MainTemplate_NoWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MainTemplate_NoWindow.cpp; path = ../../Source/BinaryData/jucer_MainTemplate_NoWindow.cpp; sourceTree = SOURCE_ROOT; };
+		AECE3914F5119A3D586A5635 /* include_juce_gui_extra.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_gui_extra.mm; path = ../../JuceLibraryCode/include_juce_gui_extra.mm; sourceTree = SOURCE_ROOT; };
+		AF57278F8F46D86B4EBA449E /* projucer_CompileEngineServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_CompileEngineServer.h; path = ../../Source/LiveBuildEngine/projucer_CompileEngineServer.h; sourceTree = SOURCE_ROOT; };
+		AFEBD8423B07599B1DE175A3 /* jucer_ModulesPanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ModulesPanel.h; path = ../../Source/Project/jucer_ModulesPanel.h; sourceTree = SOURCE_ROOT; };
+		AFF72BA2B130F3F9AC029080 /* jucer_AudioPluginEditorTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_AudioPluginEditorTemplate.h; path = ../../Source/BinaryData/jucer_AudioPluginEditorTemplate.h; sourceTree = SOURCE_ROOT; };
+		B00F60201606F195058BB575 /* jucer_ColourPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ColourPropertyComponent.h; path = ../../Source/ComponentEditor/properties/jucer_ColourPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		B06C7C053DB0660CDA8B5C2C /* jucer_PaintRoutinePanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintRoutinePanel.h; path = ../../Source/ComponentEditor/ui/jucer_PaintRoutinePanel.h; sourceTree = SOURCE_ROOT; };
+		B0D2198D1261755918CD454D /* jucer_SVGPathDataComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_SVGPathDataComponent.h; path = ../../Source/Utility/jucer_SVGPathDataComponent.h; sourceTree = SOURCE_ROOT; };
+		B15E33E7342F6EB4F95C9B1D /* jucer_PaintRoutineEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_PaintRoutineEditor.cpp; path = ../../Source/ComponentEditor/ui/jucer_PaintRoutineEditor.cpp; sourceTree = SOURCE_ROOT; };
+		B1963F0D8C0046E54FD9E023 /* jucer_ColouredElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ColouredElement.h; path = ../../Source/ComponentEditor/paintelements/jucer_ColouredElement.h; sourceTree = SOURCE_ROOT; };
+		B3FA8ADA3F66D5EE0C0E5CBE /* export_xcode.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = export_xcode.svg; path = ../../Source/BinaryData/export_xcode.svg; sourceTree = SOURCE_ROOT; };
+		B483D960309FAFC193F9CDA2 /* juce_icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = juce_icon.png; path = ../../Source/BinaryData/juce_icon.png; sourceTree = SOURCE_ROOT; };
+		B5CB69026BC4E8F439355CDC /* projucer_SourceCodeRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_SourceCodeRange.h; path = ../../Source/LiveBuildEngine/projucer_SourceCodeRange.h; sourceTree = SOURCE_ROOT; };
+		B6F2905330EA5C560D527209 /* juce_graphics */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_graphics; path = ../../../../modules/juce_graphics; sourceTree = SOURCE_ROOT; };
+		B7307A82D9EB1EDBA91EE43D /* jucer_DownloadCompileEngineThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_DownloadCompileEngineThread.h; path = ../../Source/Application/jucer_DownloadCompileEngineThread.h; sourceTree = SOURCE_ROOT; };
+		B73B25AD624B88B29EA0589C /* export_codeBlocks.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = export_codeBlocks.svg; path = ../../Source/BinaryData/export_codeBlocks.svg; sourceTree = SOURCE_ROOT; };
+		B741170E45D74F30B7D5CDDF /* jucer_ComponentNameProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentNameProperty.h; path = ../../Source/ComponentEditor/components/jucer_ComponentNameProperty.h; sourceTree = SOURCE_ROOT; };
+		B8385E9A644BD3CD94876448 /* jucer_ProjectType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectType.h; path = ../../Source/Project/jucer_ProjectType.h; sourceTree = SOURCE_ROOT; };
+		BA159A3B7D129771F5C15EA3 /* juce_core */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_core; path = ../../../../modules/juce_core; sourceTree = SOURCE_ROOT; };
+		BAC43B20E14A340CCF14119C /* jucer_Project.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_Project.cpp; path = ../../Source/Project/jucer_Project.cpp; sourceTree = SOURCE_ROOT; };
+		BB187CD608EB6368B29EC335 /* jucer_LicenseController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LicenseController.h; path = ../../Source/Licenses/jucer_LicenseController.h; sourceTree = SOURCE_ROOT; };
+		BB9C1E6E54A16F795908C469 /* background_logo.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = background_logo.svg; path = ../../Source/BinaryData/background_logo.svg; sourceTree = SOURCE_ROOT; };
+		BCB819DDDD2AC13632CA502F /* jucer_ProjucerLookAndFeel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjucerLookAndFeel.h; path = ../../Source/Utility/jucer_ProjucerLookAndFeel.h; sourceTree = SOURCE_ROOT; };
+		BCCFDFB2C02C4AA436C0ECF8 /* jucer_SliderHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_SliderHandler.h; path = ../../Source/ComponentEditor/components/jucer_SliderHandler.h; sourceTree = SOURCE_ROOT; };
+		BD2BC2395BF27FD40259F14F /* projucer_ErrorList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ErrorList.h; path = ../../Source/LiveBuildEngine/projucer_ErrorList.h; sourceTree = SOURCE_ROOT; };
+		BF3CEF080FA013E2778DCE90 /* jucer_Project.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Project.h; path = ../../Source/Project/jucer_Project.h; sourceTree = SOURCE_ROOT; };
+		C00793A0D4A59BDADC62EEF7 /* projucer_CompileEngineClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_CompileEngineClient.h; path = ../../Source/LiveBuildEngine/projucer_CompileEngineClient.h; sourceTree = SOURCE_ROOT; };
+		C094F3B6A65A79A6DF87C9C2 /* jucer_PaintElementGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementGroup.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h; sourceTree = SOURCE_ROOT; };
+		C09BBB58CA45B66D693E8C31 /* jucer_TemplateThumbnailsComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TemplateThumbnailsComponent.h; path = ../../Source/Wizards/jucer_TemplateThumbnailsComponent.h; sourceTree = SOURCE_ROOT; };
+		C15220EDA1A8315DA3255E87 /* jucer_EditorColourSchemeWindowComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_EditorColourSchemeWindowComponent.h; path = ../../Source/Utility/jucer_EditorColourSchemeWindowComponent.h; sourceTree = SOURCE_ROOT; };
+		C187718F7B9EBA88584B43F3 /* jucer_PaintRoutine.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_PaintRoutine.cpp; path = ../../Source/ComponentEditor/jucer_PaintRoutine.cpp; sourceTree = SOURCE_ROOT; };
+		C22791DB75870C4F102AA8A3 /* jucer_SlidingPanelComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_SlidingPanelComponent.h; path = ../../Source/Utility/jucer_SlidingPanelComponent.h; sourceTree = SOURCE_ROOT; };
+		C2990A8D054BC230E7C637C3 /* jucer_NewProjectWizardClasses.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewProjectWizardClasses.h; path = ../../Source/Wizards/jucer_NewProjectWizardClasses.h; sourceTree = SOURCE_ROOT; };
+		C63233C27ED46CECF10EC7C3 /* projucer_MessageIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_MessageIDs.h; path = ../../Source/LiveBuildEngine/projucer_MessageIDs.h; sourceTree = SOURCE_ROOT; };
+		C714153DB8056CAC5BC69FAF /* projucer_ClassDatabase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ClassDatabase.h; path = ../../Source/LiveBuildEngine/projucer_ClassDatabase.h; sourceTree = SOURCE_ROOT; };
+		C7608A3967D9AB9481848F2B /* jucer_DocumentEditorComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_DocumentEditorComponent.cpp; path = ../../Source/Application/jucer_DocumentEditorComponent.cpp; sourceTree = SOURCE_ROOT; };
+		C7B47372A9D5970E3D9A5400 /* jucer_GroupInformationComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GroupInformationComponent.h; path = ../../Source/Project/jucer_GroupInformationComponent.h; sourceTree = SOURCE_ROOT; };
+		C8A229ACD244F402C57286CD /* jucer_ProjectExport_MSVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExport_MSVC.h; path = "../../Source/Project Saving/jucer_ProjectExport_MSVC.h"; sourceTree = SOURCE_ROOT; };
+		C9616830BB2474066AC8C910 /* jucer_ResourceFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ResourceFile.h; path = "../../Source/Project Saving/jucer_ResourceFile.h"; sourceTree = SOURCE_ROOT; };
+		CB147AFB52BD5FC0816C0EEE /* projucer_LiveCodeBuilderDLL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_LiveCodeBuilderDLL.h; path = ../../Source/LiveBuildEngine/projucer_LiveCodeBuilderDLL.h; sourceTree = SOURCE_ROOT; };
+		CCEF7B4C6667DDE5D32FD219 /* projucer_CompileEngineDLL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_CompileEngineDLL.h; path = ../../Source/LiveBuildEngine/projucer_CompileEngineDLL.h; sourceTree = SOURCE_ROOT; };
+		CEF0436C145DA86ACE2CA5E3 /* projucer_ClientServerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_ClientServerMessages.h; path = ../../Source/LiveBuildEngine/projucer_ClientServerMessages.h; sourceTree = SOURCE_ROOT; };
+		CF21D9DB3AEC0A4DCAB36A99 /* jucer_Icons.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_Icons.cpp; path = ../../Source/Utility/jucer_Icons.cpp; sourceTree = SOURCE_ROOT; };
+		CF6C8BD0DA3D8CD4E99EBADA /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		CF8011B3C67B609032974DA5 /* jucer_NewCppFileTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_NewCppFileTemplate.cpp; path = ../../Source/BinaryData/jucer_NewCppFileTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		D00F311BFC3C2625C457CB9B /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
+		D05BD91B6105827B010E1C20 /* juce_gui_extra */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_gui_extra; path = ../../../../modules/juce_gui_extra; sourceTree = SOURCE_ROOT; };
+		D0D8B580D0689FFF4B9B823B /* jucer_StrokeType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_StrokeType.h; path = ../../Source/ComponentEditor/paintelements/jucer_StrokeType.h; sourceTree = SOURCE_ROOT; };
+		D10D51A0A2D63F38B4D86A60 /* jucer_ResourceFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ResourceFile.cpp; path = "../../Source/Project Saving/jucer_ResourceFile.cpp"; sourceTree = SOURCE_ROOT; };
+		D1F9B0E9F5D54FE48BEB46EA /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		D374DC78AAC02504576AA9B3 /* jucer_GroupComponentHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GroupComponentHandler.h; path = ../../Source/ComponentEditor/components/jucer_GroupComponentHandler.h; sourceTree = SOURCE_ROOT; };
+		D4444EC6342A2A7BC4F7BC46 /* jucer_ComponentTextProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentTextProperty.h; path = ../../Source/ComponentEditor/properties/jucer_ComponentTextProperty.h; sourceTree = SOURCE_ROOT; };
+		D526C38D581425949BA0E4AC /* jucer_FilePreviewComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FilePreviewComponent.h; path = ../../Source/Application/jucer_FilePreviewComponent.h; sourceTree = SOURCE_ROOT; };
+		D766BB9D8C32B5560F0493F3 /* include_juce_cryptography.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_cryptography.mm; path = ../../JuceLibraryCode/include_juce_cryptography.mm; sourceTree = SOURCE_ROOT; };
+		D87FC8F6834E9DC9C8E88B94 /* jucer_JustificationProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JustificationProperty.h; path = ../../Source/ComponentEditor/properties/jucer_JustificationProperty.h; sourceTree = SOURCE_ROOT; };
+		D92A6E9404A30EED32DCE4ED /* jucer_RelativePositionedRectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_RelativePositionedRectangle.h; path = ../../Source/ComponentEditor/ui/jucer_RelativePositionedRectangle.h; sourceTree = SOURCE_ROOT; };
+		DA345D5B9DABD049F90DC96F /* jucer_GeneratedCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GeneratedCode.h; path = ../../Source/ComponentEditor/jucer_GeneratedCode.h; sourceTree = SOURCE_ROOT; };
+		DAF84A553D264705FA6EB6FF /* jucer_TreeViewHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TreeViewHandler.h; path = ../../Source/ComponentEditor/components/jucer_TreeViewHandler.h; sourceTree = SOURCE_ROOT; };
+		DB9C8E35DF815B803CB4A9CF /* include_juce_core.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_core.mm; path = ../../JuceLibraryCode/include_juce_core.mm; sourceTree = SOURCE_ROOT; };
+		DBE0CDE1B017190ABBFF557C /* jucer_ProjectExport_CodeBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectExport_CodeBlocks.h; path = "../../Source/Project Saving/jucer_ProjectExport_CodeBlocks.h"; sourceTree = SOURCE_ROOT; };
+		DC922C6A65D260C18E888E49 /* jucer_ComponentTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentTemplate.cpp; path = ../../Source/BinaryData/jucer_ComponentTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		DCBB17488227A2CA7D3D3947 /* jucer_DependencyPathPropertyComponent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_DependencyPathPropertyComponent.cpp; path = ../../Source/Project/jucer_DependencyPathPropertyComponent.cpp; sourceTree = SOURCE_ROOT; };
+		DF725A596B7BCD7520CC0A9F /* jucer_ResourceEditorPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ResourceEditorPanel.cpp; path = ../../Source/ComponentEditor/ui/jucer_ResourceEditorPanel.cpp; sourceTree = SOURCE_ROOT; };
+		DF78EF6242D82F912534A277 /* jucer_ColourPropertyComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ColourPropertyComponent.h; path = ../../Source/Utility/jucer_ColourPropertyComponent.h; sourceTree = SOURCE_ROOT; };
+		E0F9CA57E44F7F7E7E217E47 /* jucer_ComponentUndoableAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentUndoableAction.h; path = ../../Source/ComponentEditor/components/jucer_ComponentUndoableAction.h; sourceTree = SOURCE_ROOT; };
+		E1D8CCD9F4ACBE1EC1D5BEA0 /* wizard_AudioApp.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_AudioApp.svg; path = ../../Source/BinaryData/wizard_AudioApp.svg; sourceTree = SOURCE_ROOT; };
+		E2374E15D65425C4101237E2 /* jucer_NewComponentTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewComponentTemplate.h; path = ../../Source/BinaryData/jucer_NewComponentTemplate.h; sourceTree = SOURCE_ROOT; };
+		E266DE67FF319D56F63193A6 /* Info-App.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-App.plist"; sourceTree = SOURCE_ROOT; };
+		E382C78A1D837DD98916E86A /* jucer_FloatingToolWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FloatingToolWindow.h; path = ../../Source/Utility/jucer_FloatingToolWindow.h; sourceTree = SOURCE_ROOT; };
+		E3B56C5718D87CA0EFCB2662 /* jucer_AudioComponentTemplate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_AudioComponentTemplate.cpp; path = ../../Source/BinaryData/jucer_AudioComponentTemplate.cpp; sourceTree = SOURCE_ROOT; };
+		E4BB22E27C5AA4B666F265BD /* jucer_TextButtonHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TextButtonHandler.h; path = ../../Source/ComponentEditor/components/jucer_TextButtonHandler.h; sourceTree = SOURCE_ROOT; };
+		E4BD4C43370651B49F75855B /* jucer_MainTemplate_SimpleWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_MainTemplate_SimpleWindow.cpp; path = ../../Source/BinaryData/jucer_MainTemplate_SimpleWindow.cpp; sourceTree = SOURCE_ROOT; };
+		E5D6C36496F5BC84D7213BE8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		E60E28D1B7491047DEA236AE /* jucer_ProjectContentComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ProjectContentComponent.h; path = ../../Source/Project/jucer_ProjectContentComponent.h; sourceTree = SOURCE_ROOT; };
+		E65A820D34BF39478B7C5925 /* jucer_DocumentEditorComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_DocumentEditorComponent.h; path = ../../Source/Application/jucer_DocumentEditorComponent.h; sourceTree = SOURCE_ROOT; };
+		E96597BBC6A98255B51B94DC /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		E983E6DDE3318B872EBE347F /* CoreAudioKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioKit.framework; path = System/Library/Frameworks/CoreAudioKit.framework; sourceTree = SDKROOT; };
+		EB71BA07D6F667E69721E577 /* jucer_GradientPointComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_GradientPointComponent.h; path = ../../Source/ComponentEditor/paintelements/jucer_GradientPointComponent.h; sourceTree = SOURCE_ROOT; };
+		EE690110171E1648FF2118B8 /* jucer_Application.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Application.h; path = ../../Source/Application/jucer_Application.h; sourceTree = SOURCE_ROOT; };
+		EF30A74B566A461A171BBF83 /* jucer_ComponentLayoutEditor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ComponentLayoutEditor.cpp; path = ../../Source/ComponentEditor/ui/jucer_ComponentLayoutEditor.cpp; sourceTree = SOURCE_ROOT; };
+		EFA8CF715611D845AB284500 /* jucer_JucerComponentHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JucerComponentHandler.h; path = ../../Source/ComponentEditor/components/jucer_JucerComponentHandler.h; sourceTree = SOURCE_ROOT; };
+		F03E2BDD36E6F4F53AB767A8 /* jucer_Headers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_Headers.h; path = ../../Source/jucer_Headers.h; sourceTree = SOURCE_ROOT; };
+		F18AE75F1831D13FF53A8CCC /* jucer_PaintElementRectangle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementRectangle.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h; sourceTree = SOURCE_ROOT; };
+		F4B63624DBF543082235F821 /* wizard_GUI.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_GUI.svg; path = ../../Source/BinaryData/wizard_GUI.svg; sourceTree = SOURCE_ROOT; };
+		F5885B5AAF46864D562D5B83 /* wizard_AudioPlugin.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_AudioPlugin.svg; path = ../../Source/BinaryData/wizard_AudioPlugin.svg; sourceTree = SOURCE_ROOT; };
+		F59077841FC17DD07060A2A9 /* jucer_TextEditorHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_TextEditorHandler.h; path = ../../Source/ComponentEditor/components/jucer_TextEditorHandler.h; sourceTree = SOURCE_ROOT; };
+		F6D3F208B6EE2A50CE1F0A18 /* jucer_JucerCommandIDs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_JucerCommandIDs.h; path = ../../Source/ComponentEditor/ui/jucer_JucerCommandIDs.h; sourceTree = SOURCE_ROOT; };
+		F71AF6D2DF3E652F8B51EBAB /* jucer_ProjectExporter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_ProjectExporter.cpp; path = "../../Source/Project Saving/jucer_ProjectExporter.cpp"; sourceTree = SOURCE_ROOT; };
+		F797071D88542C813CF7222A /* jucer_Module.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = jucer_Module.cpp; path = ../../Source/Project/jucer_Module.cpp; sourceTree = SOURCE_ROOT; };
+		F7CAB5BC15EE351949D3F2C3 /* jucer_NewInlineComponentTemplate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_NewInlineComponentTemplate.h; path = ../../Source/BinaryData/jucer_NewInlineComponentTemplate.h; sourceTree = SOURCE_ROOT; };
+		FA04E39EE7E83D445AF9E406 /* jucer_FillType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_FillType.h; path = ../../Source/ComponentEditor/paintelements/jucer_FillType.h; sourceTree = SOURCE_ROOT; };
+		FA70084EC51835082E67D261 /* projucer_CppHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = projucer_CppHelpers.h; path = ../../Source/LiveBuildEngine/projucer_CppHelpers.h; sourceTree = SOURCE_ROOT; };
+		FB61FEC24C6C031EB0455B0A /* wizard_ConsoleApp.svg */ = {isa = PBXFileReference; lastKnownFileType = file.svg; name = wizard_ConsoleApp.svg; path = ../../Source/BinaryData/wizard_ConsoleApp.svg; sourceTree = SOURCE_ROOT; };
+		FBBDD70D47163D341B2F0A8D /* jucer_ComponentOverlayComponent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_ComponentOverlayComponent.h; path = ../../Source/ComponentEditor/ui/jucer_ComponentOverlayComponent.h; sourceTree = SOURCE_ROOT; };
+		FF11D6B512FDC5D887E06F66 /* jucer_PaintElementImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_PaintElementImage.h; path = ../../Source/ComponentEditor/paintelements/jucer_PaintElementImage.h; sourceTree = SOURCE_ROOT; };
+		FF94FF5C4BEC605E56149EFC /* jucer_LabelHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = jucer_LabelHandler.h; path = ../../Source/ComponentEditor/components/jucer_LabelHandler.h; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D150288A32EE596408C2B99F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A578EAD4BB55680E8097BE0F /* Accelerate.framework in Frameworks */,
+				C1B9334AE849F93FB3C56B34 /* AudioToolbox.framework in Frameworks */,
+				8B4A593B3869815BBAC3EF93 /* AudioUnit.framework in Frameworks */,
+				A14C2C2725DA3CA7995D2815 /* AVFoundation.framework in Frameworks */,
+				1E76E36772355E2A43CF4961 /* Carbon.framework in Frameworks */,
+				241F29FCBB7A17BB44A0B10C /* Cocoa.framework in Frameworks */,
+				9359F9401D59B4517F75C39C /* CoreAudio.framework in Frameworks */,
+				091A57B4B9CE623E75E9A756 /* CoreAudioKit.framework in Frameworks */,
+				FAB47E69F7D9DCE1F906AA07 /* CoreMIDI.framework in Frameworks */,
+				0E884E47A637D6C65154699A /* DiscRecording.framework in Frameworks */,
+				49C22786B54C5DC94E4654B8 /* IOKit.framework in Frameworks */,
+				CDEF9FF2D119476D707305DF /* OpenGL.framework in Frameworks */,
+				96EC6315E1B3F1A109F84BAF /* QTKit.framework in Frameworks */,
+				11D42F7EC6E6539D79A7F4B1 /* QuartzCore.framework in Frameworks */,
+				B980464FA2761CCD64B1FAD6 /* WebKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0FFEF043CA89142B18C79ABE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				80D62B907248523E6943298B /* Accelerate.framework */,
+				5A75806B34E4EA6598A6024A /* AudioToolbox.framework */,
+				7B3F7ECF6DBF8C8EE5C2CB86 /* AudioUnit.framework */,
+				210CD22F25F2C22F9CEEB025 /* AVFoundation.framework */,
+				D00F311BFC3C2625C457CB9B /* Carbon.framework */,
+				D1F9B0E9F5D54FE48BEB46EA /* Cocoa.framework */,
+				728FE25157E9874D50BBECB2 /* CoreAudio.framework */,
+				E983E6DDE3318B872EBE347F /* CoreAudioKit.framework */,
+				8F7BE18698ADCEF51CDE4A5C /* CoreMIDI.framework */,
+				842427CFE565F3FCE5B99174 /* DiscRecording.framework */,
+				E96597BBC6A98255B51B94DC /* IOKit.framework */,
+				431D30038CBF67F80E8B3A13 /* OpenGL.framework */,
+				9F01BA9942D038EA8B5289A8 /* QTKit.framework */,
+				E5D6C36496F5BC84D7213BE8 /* QuartzCore.framework */,
+				CF6C8BD0DA3D8CD4E99EBADA /* WebKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		105940C80EB9807392E04AB9 /* paintelements */ = {
+			isa = PBXGroup;
+			children = (
+				93B419190CCE92ACAB1ED25B /* jucer_ColouredElement.cpp */,
+				B1963F0D8C0046E54FD9E023 /* jucer_ColouredElement.h */,
+				5091B14CC87C6238CF044258 /* jucer_ElementSiblingComponent.h */,
+				FA04E39EE7E83D445AF9E406 /* jucer_FillType.h */,
+				EB71BA07D6F667E69721E577 /* jucer_GradientPointComponent.h */,
+				3F00C034B140193B3754969B /* jucer_ImageResourceProperty.h */,
+				1C216FE9B7A5209C5CCF2517 /* jucer_PaintElement.cpp */,
+				786BAF436828865F45314440 /* jucer_PaintElement.h */,
+				4E8FE9B1B8C90FC28D56523B /* jucer_PaintElementEllipse.h */,
+				C094F3B6A65A79A6DF87C9C2 /* jucer_PaintElementGroup.h */,
+				FF11D6B512FDC5D887E06F66 /* jucer_PaintElementImage.h */,
+				0169ACAA0FAE70CCEEE4F650 /* jucer_PaintElementPath.cpp */,
+				1D3D6A19A60F0B03DE2F1C14 /* jucer_PaintElementPath.h */,
+				F18AE75F1831D13FF53A8CCC /* jucer_PaintElementRectangle.h */,
+				41CA95403E264AA7457A61F4 /* jucer_PaintElementRoundedRectangle.h */,
+				9C51394634F102DEBBE6C9EB /* jucer_PaintElementText.h */,
+				27A2B025813B7E54E0862642 /* jucer_PaintElementUndoableAction.h */,
+				7A3E96D22F1C9EB4C739834F /* jucer_PointComponent.h */,
+				D0D8B580D0689FFF4B9B823B /* jucer_StrokeType.h */,
+			);
+			name = paintelements;
+			sourceTree = "<group>";
+		};
+		142DEF17A4C953926833D7F8 /* Code Editor */ = {
+			isa = PBXGroup;
+			children = (
+				79E58813D1B414AF49DD9598 /* jucer_LiveBuildCodeEditor.h */,
+				2E680E2C65684A4272AE079A /* jucer_SourceCodeEditor.cpp */,
+				78CA0E0F336229E2E2F111B0 /* jucer_SourceCodeEditor.h */,
+			);
+			name = "Code Editor";
+			sourceTree = "<group>";
+		};
+		2C6746F66EF4444F53B3221F /* Juce Library Code */ = {
+			isa = PBXGroup;
+			children = (
+				8702F43110E4CCA5E5F827F5 /* AppConfig.h */,
+				472F9A90F685220D730EBF6C /* BinaryData.cpp */,
+				4F687965FBE86EAFDB3ACFEC /* BinaryData.h */,
+				DB9C8E35DF815B803CB4A9CF /* include_juce_core.mm */,
+				D766BB9D8C32B5560F0493F3 /* include_juce_cryptography.mm */,
+				1DE5BBC777FB64798D823002 /* include_juce_data_structures.mm */,
+				5867DC4E39DF8539B54C0D59 /* include_juce_events.mm */,
+				1B9B5A37F079FE3B3CF8FAB6 /* include_juce_graphics.mm */,
+				0462692BAA9CD1BE6DFBCC33 /* include_juce_gui_basics.mm */,
+				AECE3914F5119A3D586A5635 /* include_juce_gui_extra.mm */,
+				364D1A9B113320407A7E57B9 /* JuceHeader.h */,
+			);
+			name = "Juce Library Code";
+			sourceTree = "<group>";
+		};
+		3CC531922CC2D398E283A845 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				D3109994DA6AD871BE85C4E2 /* Projucer */,
+				8A24D1B6925535A868974986 /* Juce Modules */,
+				2C6746F66EF4444F53B3221F /* Juce Library Code */,
+				8180B5894A78501084B8F133 /* Resources */,
+				0FFEF043CA89142B18C79ABE /* Frameworks */,
+				92ABB8016546F41128399E9D /* Products */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		48618F36B2E3C15A7B0F63AC /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				441CFEA771BAA50E187342E9 /* jucer_AppearanceSettings.cpp */,
+				223C4209F18A221EB183A056 /* jucer_AppearanceSettings.h */,
+				7CA44FF0BA319517C6E39651 /* jucer_Application.cpp */,
+				EE690110171E1648FF2118B8 /* jucer_Application.h */,
+				0D4D508C638BC74943B9976D /* jucer_AutoUpdater.cpp */,
+				4D698BF12BCD6B0896BCDF17 /* jucer_AutoUpdater.h */,
+				23A8DE16C0CDB8EED18B008B /* jucer_CommandIDs.h */,
+				0400CB0E056A1D840304D2DE /* jucer_CommandLine.cpp */,
+				2EEB1C074162F363C6599282 /* jucer_CommandLine.h */,
+				6E6140969908E7619F858740 /* jucer_CommonHeaders.h */,
+				C7608A3967D9AB9481848F2B /* jucer_DocumentEditorComponent.cpp */,
+				E65A820D34BF39478B7C5925 /* jucer_DocumentEditorComponent.h */,
+				11EB44786085029106099D01 /* jucer_DownloadCompileEngineThread.cpp */,
+				B7307A82D9EB1EDBA91EE43D /* jucer_DownloadCompileEngineThread.h */,
+				D526C38D581425949BA0E4AC /* jucer_FilePreviewComponent.h */,
+				F03E2BDD36E6F4F53AB767A8 /* jucer_Headers.h */,
+				8C52A3DDA62A746AA7A68535 /* jucer_Main.cpp */,
+				9069981E414A631B036CC9AC /* jucer_MainWindow.cpp */,
+				2CD34A70B4032C0426F7AA10 /* jucer_MainWindow.h */,
+				2247EE920DF0610CAF9F4513 /* jucer_OpenDocumentManager.cpp */,
+				563091B0916AD9AAA36C7DC5 /* jucer_OpenDocumentManager.h */,
+			);
+			name = Application;
+			sourceTree = "<group>";
+		};
+		524339C1BD702C610F2A7DAB /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				8F8BF1A7130D858E0A239F9E /* jucer_ConfigTree_Base.h */,
+				7B4E33B1E04139F359FB484B /* jucer_ConfigTree_Exporter.h */,
+				9F75811FE7B5F8D1321BEC69 /* jucer_ConfigTree_Modules.h */,
+				DCBB17488227A2CA7D3D3947 /* jucer_DependencyPathPropertyComponent.cpp */,
+				0C2AD2FC0C196F440C3FF994 /* jucer_DependencyPathPropertyComponent.h */,
+				C7B47372A9D5970E3D9A5400 /* jucer_GroupInformationComponent.h */,
+				8DBD2FBBC7B523D1F8AF1E54 /* jucer_HeaderComponent.h */,
+				46CDD8C3C86FD61741B88A69 /* jucer_LiveBuildTab.h */,
+				F797071D88542C813CF7222A /* jucer_Module.cpp */,
+				7211101FFA28400ADBB1D47A /* jucer_Module.h */,
+				AFEBD8423B07599B1DE175A3 /* jucer_ModulesPanel.h */,
+				BAC43B20E14A340CCF14119C /* jucer_Project.cpp */,
+				BF3CEF080FA013E2778DCE90 /* jucer_Project.h */,
+				86E468DE6556BB2AD76A3D80 /* jucer_ProjectContentComponent.cpp */,
+				E60E28D1B7491047DEA236AE /* jucer_ProjectContentComponent.h */,
+				32C81E19D3D68B9DDF870FE9 /* jucer_ProjectTab.h */,
+				375AFDF06A908D89DEC5205F /* jucer_ProjectTree_Base.h */,
+				47B49049B85EED74D29C9906 /* jucer_ProjectTree_File.h */,
+				4F6365A0D2D51337151D85C3 /* jucer_ProjectTree_Group.h */,
+				B8385E9A644BD3CD94876448 /* jucer_ProjectType.h */,
+				9EA541503DBADC5FFDEB0282 /* jucer_TreeItemTypes.h */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+		63EE1C3AC218E509130AF2BA /* BinaryData */ = {
+			isa = PBXGroup;
+			children = (
+				645F98392B3C8E92EE64B533 /* gradle */,
+				C76CE0579AC77DF56E755836 /* templates */,
+				BB9C1E6E54A16F795908C469 /* background_logo.svg */,
+				301592EBAC0FFF6F5B268E99 /* background_tile.png */,
+				41105E536155E394E54BDD35 /* colourscheme_dark.xml */,
+				5F6584B675E30761521A9F42 /* colourscheme_light.xml */,
+				1C73D7591E63E8018E279716 /* export_android.svg */,
+				B73B25AD624B88B29EA0589C /* export_codeBlocks.svg */,
+				6DA8A2AEF943230FF7DB510B /* export_linux.svg */,
+				56C3CA379E90628CCB5BC37C /* export_visualStudio.svg */,
+				B3FA8ADA3F66D5EE0C0E5CBE /* export_xcode.svg */,
+				66DEA1923FE5B9A614C7E9DC /* huckleberry_icon.svg */,
+				5F1C141139AA646EABD72145 /* juce-logo-with-text.svg */,
+				B483D960309FAFC193F9CDA2 /* juce_icon.png */,
+				8C281F2F8EA3AD614ADF7955 /* offlinepage.html */,
+				4073A12E196BDDADE211E19F /* projucer_EULA.txt */,
+				A973D33C0CE829AD293E035B /* projucer_login_bg.svg */,
+				58139D8D454051C59E77609B /* RecentFilesMenuTemplate.nib */,
+				7B6E461262D8822132135F56 /* wizard_AnimatedApp.svg */,
+				E1D8CCD9F4ACBE1EC1D5BEA0 /* wizard_AudioApp.svg */,
+				F5885B5AAF46864D562D5B83 /* wizard_AudioPlugin.svg */,
+				FB61FEC24C6C031EB0455B0A /* wizard_ConsoleApp.svg */,
+				7256D1C79741E66E2C002EE2 /* wizard_DLL.svg */,
+				F4B63624DBF543082235F821 /* wizard_GUI.svg */,
+				1D99EA99F946D665FE583414 /* wizard_Highlight.svg */,
+				358DA8CCDC8FA5B0D62D6CA3 /* wizard_Openfile.svg */,
+				A4D275622A4B115AABE190A4 /* wizard_OpenGL.svg */,
+				0DB0A9E30EEDDEA720BC5A03 /* wizard_StaticLibrary.svg */,
+			);
+			name = BinaryData;
+			sourceTree = "<group>";
+		};
+		645F98392B3C8E92EE64B533 /* gradle */ = {
+			isa = PBXGroup;
+			children = (
+				129F2DE0FEF154F8F8C7A74E /* gradle-wrapper.jar */,
+				0B24F292A357ABFD9BCC6D7F /* gradlew */,
+				576A92E1E0D8F453EC0FEB34 /* gradlew.bat */,
+				996E472B82A75531875A5E38 /* LICENSE */,
+			);
+			name = gradle;
+			sourceTree = "<group>";
+		};
+		6580E53C420AA794542CC8D7 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				A32FE0EBE29FABE58E664E67 /* jucer_AboutWindowComponent.h */,
+				934C3778397D89F8C535E417 /* jucer_ApplicationUsageDataWindowComponent.h */,
+				9B9CAD20E1243B4351B4C8D8 /* jucer_CodeHelpers.cpp */,
+				914ADDB50ED7365F08BA91F9 /* jucer_CodeHelpers.h */,
+				DF78EF6242D82F912534A277 /* jucer_ColourPropertyComponent.h */,
+				188D03A4247F4BC0539F5C49 /* jucer_Colours.h */,
+				C15220EDA1A8315DA3255E87 /* jucer_EditorColourSchemeWindowComponent.h */,
+				1729AEDC34001C31B8CC357C /* jucer_FileHelpers.cpp */,
+				553725A0E3A391651ED1731E /* jucer_FileHelpers.h */,
+				35A36102EAD2D2620EE99E7E /* jucer_FilePathPropertyComponent.h */,
+				E382C78A1D837DD98916E86A /* jucer_FloatingToolWindow.h */,
+				4856DA6706D794E2D89DAB63 /* jucer_GlobalSearchPathsWindowComponent.h */,
+				CF21D9DB3AEC0A4DCAB36A99 /* jucer_Icons.cpp */,
+				515FF6E74826E3E3F7273621 /* jucer_Icons.h */,
+				47DD50A5A9091F9900E0EAD9 /* jucer_JucerTreeViewBase.cpp */,
+				820291543BF93243B718F0EE /* jucer_JucerTreeViewBase.h */,
+				0F249640243FBD5717F6ADD9 /* jucer_MiscUtilities.cpp */,
+				4A41FD3066D0979DB48691E5 /* jucer_MiscUtilities.h */,
+				1AF7EFBE4961C7B6C834BF54 /* jucer_PresetIDs.h */,
+				87414819D9DE343EA28E0AAD /* jucer_ProjucerLookAndFeel.cpp */,
+				BCB819DDDD2AC13632CA502F /* jucer_ProjucerLookAndFeel.h */,
+				1F421199C40092BFEE0658C2 /* jucer_RelativePath.h */,
+				20FAAE9F3A7B96C2D8C75BB2 /* jucer_SlidingPanelComponent.cpp */,
+				C22791DB75870C4F102AA8A3 /* jucer_SlidingPanelComponent.h */,
+				631983AA62673015F8D7453B /* jucer_StoredSettings.cpp */,
+				9BC8AE609A07657CEF587548 /* jucer_StoredSettings.h */,
+				B0D2198D1261755918CD454D /* jucer_SVGPathDataComponent.h */,
+				8C67B567CF362A163D24B3B1 /* jucer_TranslationHelpers.h */,
+				546593F6EA70EABF708772FE /* jucer_TranslationToolComponent.h */,
+				7F29F77B1C00A9704E6D0859 /* jucer_UTF8Component.h */,
+				8090981F07A76E465DAAADF4 /* jucer_ValueSourceHelpers.h */,
+			);
+			name = Utility;
+			sourceTree = "<group>";
+		};
+		6CE6335290CF9C26FBE93D7C /* components */ = {
+			isa = PBXGroup;
+			children = (
+				0FF1C6905150EAAB1AE081A7 /* jucer_ButtonHandler.h */,
+				008C8B2C2328CFBB9375397D /* jucer_ComboBoxHandler.h */,
+				B741170E45D74F30B7D5CDDF /* jucer_ComponentNameProperty.h */,
+				65C498761CE166072A202AA0 /* jucer_ComponentTypeHandler.cpp */,
+				5D9E7814B713670624F0028F /* jucer_ComponentTypeHandler.h */,
+				E0F9CA57E44F7F7E7E217E47 /* jucer_ComponentUndoableAction.h */,
+				92F91DC29B64AD85B1F508BD /* jucer_GenericComponentHandler.h */,
+				D374DC78AAC02504576AA9B3 /* jucer_GroupComponentHandler.h */,
+				1F9BBDFA52513AD34D906D2A /* jucer_HyperlinkButtonHandler.h */,
+				4C2093BCD3528ACEDC7A2B33 /* jucer_ImageButtonHandler.h */,
+				EFA8CF715611D845AB284500 /* jucer_JucerComponentHandler.h */,
+				FF94FF5C4BEC605E56149EFC /* jucer_LabelHandler.h */,
+				BCCFDFB2C02C4AA436C0ECF8 /* jucer_SliderHandler.h */,
+				400E4C67ABCDDB1D49EBB85E /* jucer_TabbedComponentHandler.h */,
+				E4BB22E27C5AA4B666F265BD /* jucer_TextButtonHandler.h */,
+				F59077841FC17DD07060A2A9 /* jucer_TextEditorHandler.h */,
+				084C0070BC67BC893B967EF1 /* jucer_ToggleButtonHandler.h */,
+				DAF84A553D264705FA6EB6FF /* jucer_TreeViewHandler.h */,
+				A0951828C3BF47FA7E1E52F8 /* jucer_ViewportHandler.h */,
+			);
+			name = components;
+			sourceTree = "<group>";
+		};
+		78FDC751FE3D97F79839DBC6 /* ComponentEditor */ = {
+			isa = PBXGroup;
+			children = (
+				6CE6335290CF9C26FBE93D7C /* components */,
+				7CF8A12404899178DC6EBF9C /* documents */,
+				105940C80EB9807392E04AB9 /* paintelements */,
+				BD7D64D86872DEDFCAF1CC39 /* properties */,
+				976B9E06EE94AA45594FEAF6 /* ui */,
+				9EF583A6201DBC813C2F63C4 /* jucer_BinaryResources.cpp */,
+				6AC88EFC247C225CC5C11A43 /* jucer_BinaryResources.h */,
+				133F1E428260C5ADDF496DF9 /* jucer_ComponentLayout.cpp */,
+				3F9D4C7F6E5779D4E4AE655D /* jucer_ComponentLayout.h */,
+				78D0DBC4798FF040FDB90F6D /* jucer_GeneratedCode.cpp */,
+				DA345D5B9DABD049F90DC96F /* jucer_GeneratedCode.h */,
+				269A454F1FF081DA67FFD578 /* jucer_JucerDocument.cpp */,
+				8F30A53C7FE4BC65171FB3E2 /* jucer_JucerDocument.h */,
+				9D7689451732AF8333402B3A /* jucer_ObjectTypes.cpp */,
+				50498FF6EA3901CBD58223B3 /* jucer_ObjectTypes.h */,
+				C187718F7B9EBA88584B43F3 /* jucer_PaintRoutine.cpp */,
+				66B49F08C5EC3E4974825FF8 /* jucer_PaintRoutine.h */,
+				5432B7B9B2CF2EAEC8B66D5C /* jucer_UtilityFunctions.h */,
+			);
+			name = ComponentEditor;
+			sourceTree = "<group>";
+		};
+		7CF8A12404899178DC6EBF9C /* documents */ = {
+			isa = PBXGroup;
+			children = (
+				3E03B7C7A19E63A724EB79F4 /* jucer_ButtonDocument.cpp */,
+				1FA92F8F2B26C6CEC8B1D737 /* jucer_ButtonDocument.h */,
+				662C76394C5D1B56766FAFD9 /* jucer_ComponentDocument.cpp */,
+				9C803826E5E3FDB1B37660D5 /* jucer_ComponentDocument.h */,
+			);
+			name = documents;
+			sourceTree = "<group>";
+		};
+		8180B5894A78501084B8F133 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				E266DE67FF319D56F63193A6 /* Info-App.plist */,
+				6678E9B3EEACAD47F438B264 /* RecentFilesMenuTemplate.nib */,
+				951128CA33CCDEF570436B1C /* Icon.icns */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		82B98DB2654A087911E8157F /* LiveBuildEngine */ = {
+			isa = PBXGroup;
+			children = (
+				5C7636E577B8DBB1D3133022 /* projucer_ActivityList.h */,
+				43C068B8D98821C09492AB29 /* projucer_ActivityListComponent.h */,
+				4A035FB6A8D93BF154C08C3F /* projucer_BuildTabStatusComp.h */,
+				C714153DB8056CAC5BC69FAF /* projucer_ClassDatabase.h */,
+				CEF0436C145DA86ACE2CA5E3 /* projucer_ClientServerMessages.h */,
+				A1333F975410DD3DBBE2841F /* projucer_CompileEngineClient.cpp */,
+				C00793A0D4A59BDADC62EEF7 /* projucer_CompileEngineClient.h */,
+				CCEF7B4C6667DDE5D32FD219 /* projucer_CompileEngineDLL.h */,
+				635290DEB1D564927D7A450C /* projucer_CompileEngineServer.cpp */,
+				AF57278F8F46D86B4EBA449E /* projucer_CompileEngineServer.h */,
+				2C7CDA71ACB5829BC616A353 /* projucer_ComponentListComp.h */,
+				FA70084EC51835082E67D261 /* projucer_CppHelpers.h */,
+				90E05EF7005D9C0712FA7662 /* projucer_DiagnosticMessage.h */,
+				BD2BC2395BF27FD40259F14F /* projucer_ErrorList.h */,
+				0C6B1A14D37958E405448B8D /* projucer_ErrorListComponent.h */,
+				CB147AFB52BD5FC0816C0EEE /* projucer_LiveCodeBuilderDLL.h */,
+				C63233C27ED46CECF10EC7C3 /* projucer_MessageIDs.h */,
+				313BC56B30B05119686B1E99 /* projucer_ProjectBuildInfo.h */,
+				B5CB69026BC4E8F439355CDC /* projucer_SourceCodeRange.h */,
+			);
+			name = LiveBuildEngine;
+			sourceTree = "<group>";
+		};
+		8A24D1B6925535A868974986 /* Juce Modules */ = {
+			isa = PBXGroup;
+			children = (
+				BA159A3B7D129771F5C15EA3 /* juce_core */,
+				AA1C44E89D792DDC4867B2C8 /* juce_cryptography */,
+				69555CEFC6ED613AA3949298 /* juce_data_structures */,
+				21F4833C5B5C17B159B956F3 /* juce_events */,
+				B6F2905330EA5C560D527209 /* juce_graphics */,
+				7AB7640968FAAC73072FBD10 /* juce_gui_basics */,
+				D05BD91B6105827B010E1C20 /* juce_gui_extra */,
+			);
+			name = "Juce Modules";
+			sourceTree = "<group>";
+		};
+		92ABB8016546F41128399E9D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				09DE066936CF037E9709ADB1 /* Projucer.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		976B9E06EE94AA45594FEAF6 /* ui */ = {
+			isa = PBXGroup;
+			children = (
+				EF30A74B566A461A171BBF83 /* jucer_ComponentLayoutEditor.cpp */,
+				263D9041F9B7D6A79DC38CD6 /* jucer_ComponentLayoutEditor.h */,
+				3514E78B58A08F4C98F54C5A /* jucer_ComponentLayoutPanel.h */,
+				4E191CDCE7565DB726CF7065 /* jucer_ComponentOverlayComponent.cpp */,
+				FBBDD70D47163D341B2F0A8D /* jucer_ComponentOverlayComponent.h */,
+				98F42686D9DAC974F2514217 /* jucer_EditingPanelBase.cpp */,
+				97E75A598791645465FEDCE1 /* jucer_EditingPanelBase.h */,
+				F6D3F208B6EE2A50CE1F0A18 /* jucer_JucerCommandIDs.h */,
+				9C7FA58D223674C4C2AC6595 /* jucer_JucerDocumentEditor.cpp */,
+				1125D1B2AE54AEF2EB3D51C0 /* jucer_JucerDocumentEditor.h */,
+				B15E33E7342F6EB4F95C9B1D /* jucer_PaintRoutineEditor.cpp */,
+				4E60769DE992CA7FC1A4A486 /* jucer_PaintRoutineEditor.h */,
+				16203C6791259C9718A04C3A /* jucer_PaintRoutinePanel.cpp */,
+				B06C7C053DB0660CDA8B5C2C /* jucer_PaintRoutinePanel.h */,
+				D92A6E9404A30EED32DCE4ED /* jucer_RelativePositionedRectangle.h */,
+				DF725A596B7BCD7520CC0A9F /* jucer_ResourceEditorPanel.cpp */,
+				641B57E5FAE6BEFDB6462921 /* jucer_ResourceEditorPanel.h */,
+				3A5B5DC92BE6D22CA15B9671 /* jucer_SnapGridPainter.h */,
+				921752D9B004A15973DDF56F /* jucer_TestComponent.cpp */,
+				9F41F3338BF00D0FC74C6390 /* jucer_TestComponent.h */,
+			);
+			name = ui;
+			sourceTree = "<group>";
+		};
+		BD7D64D86872DEDFCAF1CC39 /* properties */ = {
+			isa = PBXGroup;
+			children = (
+				B00F60201606F195058BB575 /* jucer_ColourPropertyComponent.h */,
+				04C1267B2BD11A6ECCCA654C /* jucer_ComponentBooleanProperty.h */,
+				6A337C69A928E3CE79C55457 /* jucer_ComponentChoiceProperty.h */,
+				AA8EED79F095953D2B5923B8 /* jucer_ComponentColourProperty.h */,
+				D4444EC6342A2A7BC4F7BC46 /* jucer_ComponentTextProperty.h */,
+				295A9B126C98FE15F5A8B81E /* jucer_FilePropertyComponent.h */,
+				8138A55052E9FC27284B74DD /* jucer_FontPropertyComponent.h */,
+				D87FC8F6834E9DC9C8E88B94 /* jucer_JustificationProperty.h */,
+				576D62C0C9C1BA4B7A514721 /* jucer_PositionPropertyBase.h */,
+			);
+			name = properties;
+			sourceTree = "<group>";
+		};
+		C5A691BE7288ADA68DC8D39A /* Wizards */ = {
+			isa = PBXGroup;
+			children = (
+				A69024A225F2AC31F17B1314 /* jucer_NewFileWizard.cpp */,
+				11DC04468BC6023671017EBF /* jucer_NewFileWizard.h */,
+				087CB3A961CD3C7434D660A4 /* jucer_NewProjectWizard.h */,
+				4B083E951ECB62217C46CB01 /* jucer_NewProjectWizardClasses.cpp */,
+				C2990A8D054BC230E7C637C3 /* jucer_NewProjectWizardClasses.h */,
+				8BD8E9DA627D6EF9BA10FB9E /* jucer_NewProjectWizardComponent.h */,
+				3C95FA2AA91EBA19ADDD5C29 /* jucer_ProjectWizard_Animated.h */,
+				8A825FDDC00DD253F44D2C3A /* jucer_ProjectWizard_AudioApp.h */,
+				4A4EBDAD8D098F72CE053235 /* jucer_ProjectWizard_AudioPlugin.h */,
+				0F01067432AC314EAC213C1C /* jucer_ProjectWizard_Blank.h */,
+				A44A774EFC020D3D046A9249 /* jucer_ProjectWizard_Console.h */,
+				9992E6950C64322A11E39ADF /* jucer_ProjectWizard_DLL.h */,
+				05D67B5A8D64947C067C0945 /* jucer_ProjectWizard_GUIApp.h */,
+				A085174413736ACC8D7D42A2 /* jucer_ProjectWizard_openGL.h */,
+				471C7B0A8B92320AF0C80839 /* jucer_ProjectWizard_StaticLibrary.h */,
+				714267352CE5C4357ADBC231 /* jucer_StartPageComponent.h */,
+				C09BBB58CA45B66D693E8C31 /* jucer_TemplateThumbnailsComponent.h */,
+			);
+			name = Wizards;
+			sourceTree = "<group>";
+		};
+		C76CE0579AC77DF56E755836 /* templates */ = {
+			isa = PBXGroup;
+			children = (
+				468BFFBE4DA7835DD40C5FE8 /* jucer_AnimatedComponentTemplate.cpp */,
+				E3B56C5718D87CA0EFCB2662 /* jucer_AudioComponentTemplate.cpp */,
+				0075C5208947159AF2802F3B /* jucer_AudioPluginEditorTemplate.cpp */,
+				AFF72BA2B130F3F9AC029080 /* jucer_AudioPluginEditorTemplate.h */,
+				65F4749184C84C2FDBB4C305 /* jucer_AudioPluginFilterTemplate.cpp */,
+				03D3053EDE47FED1919C6674 /* jucer_AudioPluginFilterTemplate.h */,
+				DC922C6A65D260C18E888E49 /* jucer_ComponentTemplate.cpp */,
+				963E0740B7B4D59EF2D16740 /* jucer_ComponentTemplate.h */,
+				9683B04CA3BD7F73E8236FE2 /* jucer_ContentCompTemplate.cpp */,
+				35E6EE1E98DD7050DDFECD9B /* jucer_ContentCompTemplate.h */,
+				24C34D0578AE6C7A3EA18781 /* jucer_InlineComponentTemplate.h */,
+				18D9EBA1DAE45EEF81FD5C8F /* jucer_MainConsoleAppTemplate.cpp */,
+				AE1BC6DCCFC1A18E2ACE23F1 /* jucer_MainTemplate_NoWindow.cpp */,
+				E4BD4C43370651B49F75855B /* jucer_MainTemplate_SimpleWindow.cpp */,
+				86E8A40E5A83781A8478454D /* jucer_MainTemplate_Window.cpp */,
+				61BE37E2B26C25056D9E8FE2 /* jucer_NewComponentTemplate.cpp */,
+				E2374E15D65425C4101237E2 /* jucer_NewComponentTemplate.h */,
+				CF8011B3C67B609032974DA5 /* jucer_NewCppFileTemplate.cpp */,
+				53151B683E11F420203E61C2 /* jucer_NewCppFileTemplate.h */,
+				F7CAB5BC15EE351949D3F2C3 /* jucer_NewInlineComponentTemplate.h */,
+				73B9F17FE55A02C2BB87E008 /* jucer_OpenGLComponentTemplate.cpp */,
+			);
+			name = templates;
+			sourceTree = "<group>";
+		};
+		D3109994DA6AD871BE85C4E2 /* Projucer */ = {
+			isa = PBXGroup;
+			children = (
+				48618F36B2E3C15A7B0F63AC /* Application */,
+				DD016058D39CAFA2C86BAF40 /* Licenses */,
+				82B98DB2654A087911E8157F /* LiveBuildEngine */,
+				142DEF17A4C953926833D7F8 /* Code Editor */,
+				78FDC751FE3D97F79839DBC6 /* ComponentEditor */,
+				524339C1BD702C610F2A7DAB /* Project */,
+				EB15E4BA49763AC74CE29FDE /* Project Saving */,
+				6580E53C420AA794542CC8D7 /* Utility */,
+				C5A691BE7288ADA68DC8D39A /* Wizards */,
+				63EE1C3AC218E509130AF2BA /* BinaryData */,
+			);
+			name = Projucer;
+			sourceTree = "<group>";
+		};
+		DD016058D39CAFA2C86BAF40 /* Licenses */ = {
+			isa = PBXGroup;
+			children = (
+				51CBE59779A36D1B80B26974 /* jucer_LicenseController.cpp */,
+				BB187CD608EB6368B29EC335 /* jucer_LicenseController.h */,
+				790F6302B9A0620F23F8A6C1 /* jucer_LicenseThread.h */,
+				98E6D61BFF7D85F0E00F0FBF /* jucer_LicenseWebview.h */,
+			);
+			name = Licenses;
+			sourceTree = "<group>";
+		};
+		EB15E4BA49763AC74CE29FDE /* Project Saving */ = {
+			isa = PBXGroup;
+			children = (
+				6E7353DFEA8825B515049ABB /* jucer_ProjectExport_Android.h */,
+				DBE0CDE1B017190ABBFF557C /* jucer_ProjectExport_CodeBlocks.h */,
+				05076CDF1511A5F8A8E18F1D /* jucer_ProjectExport_Make.h */,
+				C8A229ACD244F402C57286CD /* jucer_ProjectExport_MSVC.h */,
+				974B862C51DA9A16CBBB3A29 /* jucer_ProjectExport_XCode.h */,
+				F71AF6D2DF3E652F8B51EBAB /* jucer_ProjectExporter.cpp */,
+				35CB48D497F35BF3F6998F5D /* jucer_ProjectExporter.h */,
+				14A24BB4AB7B81D40EF062E5 /* jucer_ProjectSaver.cpp */,
+				9C04F9680F82BF279D528688 /* jucer_ProjectSaver.h */,
+				D10D51A0A2D63F38B4D86A60 /* jucer_ResourceFile.cpp */,
+				C9616830BB2474066AC8C910 /* jucer_ResourceFile.h */,
+			);
+			name = "Project Saving";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0039FE1A254FE518518BF8B8 /* Projucer - App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0655A4A348F7F91F77583ADC /* Build configuration list for PBXNativeTarget "Projucer - App" */;
+			buildPhases = (
+				C262D0F297DDE25326F5AC81 /* Resources */,
+				5CB869A8DA78BE6FA2757034 /* Sources */,
+				D150288A32EE596408C2B99F /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Projucer - App";
+			productName = Projucer;
+			productReference = 09DE066936CF037E9709ADB1 /* Projucer.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		74EA481348A24104E6ACE009 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				TargetAttributes = {
+					0039FE1A254FE518518BF8B8 = {
+						SystemCapabilities = {
+							com.apple.InAppPurchase = {
+								enabled = 0;
+							};
+							com.apple.InterAppAudio = {
+								enabled = 0;
+							};
+							com.apple.Push = {
+								enabled = 0;
+							};
+							com.apple.Sandbox = {
+								enabled = 0;
+							};
+						};
+					};
+				};
+			};
+			buildConfigurationList = F90407F24422C589DA251604 /* Build configuration list for PBXProject "Projucer" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3CC531922CC2D398E283A845 /* Source */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0039FE1A254FE518518BF8B8 /* Projucer - App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C262D0F297DDE25326F5AC81 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2610F357881240ACBF612F48 /* RecentFilesMenuTemplate.nib in Resources */,
+				1321E6C1C6170B6C898AD09D /* Icon.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5CB869A8DA78BE6FA2757034 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				357A6AA6960EF95D92929BEE /* jucer_AppearanceSettings.cpp in Sources */,
+				6DD9DA1677A6CF789CDAB478 /* jucer_AutoUpdater.cpp in Sources */,
+				954A036F5DDB375DB23FFB3E /* jucer_CommandLine.cpp in Sources */,
+				3EB3D569250C4BA4CA9AF578 /* jucer_DocumentEditorComponent.cpp in Sources */,
+				636D21BF846031A6A1A7476A /* jucer_DownloadCompileEngineThread.cpp in Sources */,
+				95B44E6C74B1DED31DBE37EB /* jucer_Main.cpp in Sources */,
+				AA9D0B8E23F3D87A23DE9F8A /* jucer_MainWindow.cpp in Sources */,
+				244BA1BDA5FAA465EA3F9C6D /* jucer_OpenDocumentManager.cpp in Sources */,
+				6FD0752A5CADCF60D79FDBB7 /* jucer_LicenseController.cpp in Sources */,
+				85B5E65F8DD80938BFBDCE61 /* projucer_CompileEngineClient.cpp in Sources */,
+				D805169E01D7F90B01C11769 /* projucer_CompileEngineServer.cpp in Sources */,
+				FCE6F604C00039A32649CB69 /* jucer_SourceCodeEditor.cpp in Sources */,
+				9BF773500BA51A8B5C6C7348 /* jucer_ComponentTypeHandler.cpp in Sources */,
+				57B1F32A372143B4D3B1C517 /* jucer_ButtonDocument.cpp in Sources */,
+				3DC282564876B1FC88AAA9B3 /* jucer_ComponentDocument.cpp in Sources */,
+				C49E1D32A9DCE3D59BC48B1D /* jucer_ColouredElement.cpp in Sources */,
+				E1268E019B434F6B5E9317DC /* jucer_PaintElement.cpp in Sources */,
+				CE91112DADB97C573C3C674D /* jucer_PaintElementPath.cpp in Sources */,
+				A70F0274076C0D44ED71C980 /* jucer_ComponentLayoutEditor.cpp in Sources */,
+				BD1E0CBE74DDD2F303978E1F /* jucer_ComponentOverlayComponent.cpp in Sources */,
+				8C1CC0E7A772D66635BA482F /* jucer_EditingPanelBase.cpp in Sources */,
+				A69BF71FA90E5A66B6EB2E0F /* jucer_JucerDocumentEditor.cpp in Sources */,
+				D68DE111AFBD82F0D44A3B69 /* jucer_PaintRoutineEditor.cpp in Sources */,
+				EC6A34EC9A9D454BF26AAD32 /* jucer_PaintRoutinePanel.cpp in Sources */,
+				8AD28823205783E6F676F254 /* jucer_ResourceEditorPanel.cpp in Sources */,
+				34716A3539FD288C09CBA38A /* jucer_TestComponent.cpp in Sources */,
+				45A53AF13B0D663050632E8C /* jucer_BinaryResources.cpp in Sources */,
+				C2A85091A28C907A4E1E1687 /* jucer_ComponentLayout.cpp in Sources */,
+				83431B7234A78ECFB3C15F63 /* jucer_GeneratedCode.cpp in Sources */,
+				209FCCC2155A1FCB7E11E20D /* jucer_JucerDocument.cpp in Sources */,
+				C93569F47B4AC1A8E37992ED /* jucer_ObjectTypes.cpp in Sources */,
+				1B988E139004D8E2850EB656 /* jucer_PaintRoutine.cpp in Sources */,
+				3D777382FE212D59BAF871FD /* jucer_DependencyPathPropertyComponent.cpp in Sources */,
+				3FCA61C401007B243E2E9035 /* jucer_Module.cpp in Sources */,
+				30B921C38DCEE787B294B746 /* jucer_Project.cpp in Sources */,
+				1F37544891EC8DBB5E500C1C /* jucer_ProjectExporter.cpp in Sources */,
+				0C5F43C262695A3EB7A9E1C0 /* jucer_ProjectSaver.cpp in Sources */,
+				110221CD5578153B528AD2BE /* jucer_ResourceFile.cpp in Sources */,
+				CD4F7B119CE718BCE78D61F4 /* jucer_CodeHelpers.cpp in Sources */,
+				78CB463DD98A55313A543859 /* jucer_FileHelpers.cpp in Sources */,
+				1499DF2E85B05AC1BF423773 /* jucer_Icons.cpp in Sources */,
+				123810DAF8AF758928916ECE /* jucer_JucerTreeViewBase.cpp in Sources */,
+				C9F11BA62D6D092A300363F7 /* jucer_MiscUtilities.cpp in Sources */,
+				9EAF9BE59FFE0BD49410B10E /* jucer_ProjucerLookAndFeel.cpp in Sources */,
+				4A1DB797F1356E85110FF871 /* jucer_SlidingPanelComponent.cpp in Sources */,
+				F6635694A01FFBF5EF0968DB /* jucer_StoredSettings.cpp in Sources */,
+				518DD443B6F17A5AFD707263 /* jucer_NewFileWizard.cpp in Sources */,
+				B7EBA1A83575F48CD08140B9 /* jucer_NewProjectWizardClasses.cpp in Sources */,
+				3C5267E06A897B0DC0F7EA50 /* BinaryData.cpp in Sources */,
+				5DD883699B85E4C492CAD065 /* include_juce_core.mm in Sources */,
+				D5C9125F65493CA481F18E53 /* include_juce_cryptography.mm in Sources */,
+				02E8F35A8E0D4A0DF6F38D60 /* include_juce_data_structures.mm in Sources */,
+				234B6BA2952CBC7C61EF70EF /* include_juce_events.mm in Sources */,
+				254A7C08594A152C2C646334 /* include_juce_graphics.mm in Sources */,
+				F15F0512666FF8CDC0D08905 /* include_juce_gui_basics.mm in Sources */,
+				B18248959DDC44EF4E85320A /* include_juce_gui_extra.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0BC15DC2E5FE5ECFFB398D49 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_LINK_OBJC_RUNTIME = NO;
@@ -779,139 +1064,210 @@
 					"JucePlugin_Build_AUv3=0",
 					"JucePlugin_Build_RTAS=0",
 					"JucePlugin_Build_AAX=0",
-					"JucePlugin_Build_Standalone=0", );
+					"JucePlugin_Build_Standalone=0",
+				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
-				HEADER_SEARCH_PATHS = ("../../JuceLibraryCode", "../../../../modules", "$(inherited)");
-				INFOPLIST_FILE = Info-App.plist;
+				HEADER_SEARCH_PATHS = (
+					../../JuceLibraryCode,
+					../../../../modules,
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Info-App.plist";
 				INFOPLIST_PREPROCESS = NO;
 				INSTALL_PATH = "$(HOME)/Applications";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
-				OTHER_CPLUSPLUSFLAGS = "-Wall -Wshadow -Wno-missing-field-initializers -Wshadow -Wshorten-64-to-32 -Wstrict-aliasing -Wuninitialized -Wunused-parameter -Wconversion -Wsign-compare -Wint-conversion -Woverloaded-virtual -Wreorder -Wconstant-conversion -Wsign-conversion -Wextra-semi";
+				OTHER_CPLUSPLUSFLAGS = (
+					"-Wall",
+					"-Wshadow",
+					"-Wno-missing-field-initializers",
+					"-Wshadow",
+					"-Wshorten-64-to-32",
+					"-Wstrict-aliasing",
+					"-Wuninitialized",
+					"-Wunused-parameter",
+					"-Wconversion",
+					"-Wsign-compare",
+					"-Wint-conversion",
+					"-Woverloaded-virtual",
+					"-Wreorder",
+					"-Wconstant-conversion",
+					"-Wsign-conversion",
+					"-Wextra-semi",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.juce.theprojucer;
 				SDKROOT_ppc = macosx10.5;
-				USE_HEADERMAP = NO; }; name = Release; };
-		C42924A24AB55E6A940423EA = {isa = XCBuildConfiguration; buildSettings = {
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		0CC6C439D038EDA0D7F10DF0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_LINK_OBJC_RUNTIME = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_DEBUG=1",
+					"DEBUG=1",
+					"JUCER_XCODE_MAC_F6D2F4CF=1",
+					"JUCE_APP_VERSION=5.0.2",
+					"JUCE_APP_VERSION_HEX=0x50002",
+					"JucePlugin_Build_VST=0",
+					"JucePlugin_Build_VST3=0",
+					"JucePlugin_Build_AU=0",
+					"JucePlugin_Build_AUv3=0",
+					"JucePlugin_Build_RTAS=0",
+					"JucePlugin_Build_AAX=0",
+					"JucePlugin_Build_Standalone=0",
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					../../JuceLibraryCode,
+					../../../../modules,
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Info-App.plist";
+				INFOPLIST_PREPROCESS = NO;
+				INSTALL_PATH = "$(HOME)/Applications";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MACOSX_DEPLOYMENT_TARGET_ppc = 10.4;
+				OTHER_CPLUSPLUSFLAGS = (
+					"-Wall",
+					"-Wshadow",
+					"-Wno-missing-field-initializers",
+					"-Wshadow",
+					"-Wshorten-64-to-32",
+					"-Wstrict-aliasing",
+					"-Wuninitialized",
+					"-Wunused-parameter",
+					"-Wconversion",
+					"-Wsign-compare",
+					"-Wint-conversion",
+					"-Woverloaded-virtual",
+					"-Wreorder",
+					"-Wconstant-conversion",
+					"-Wsign-conversion",
+					"-Wextra-semi",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.juce.theprojucer;
+				SDKROOT_ppc = macosx10.5;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		70135D15D7E0D8410C42BBA3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = c11;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_MODEL_TUNING = G5;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = Projucer;
+				WARNING_CFLAGS = "-Wreorder";
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		C42924A24AB55E6A940423EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c11;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
 				GCC_WARN_MISSING_PARENTHESES = YES;
 				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "Projucer";
-				WARNING_CFLAGS = -Wreorder;
-				ZERO_LINK = NO; }; name = Debug; };
-		70135D15D7E0D8410C42BBA3 = {isa = XCBuildConfiguration; buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf";
-				GCC_C_LANGUAGE_STANDARD = c11;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				GCC_MODEL_TUNING = G5;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
-				GCC_WARN_MISSING_PARENTHESES = YES;
-				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
-				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				PRODUCT_NAME = "Projucer";
-				WARNING_CFLAGS = -Wreorder;
-				ZERO_LINK = NO; }; name = Release; };
-		50E3FDD15B8D8C9793DFABF9 = {isa = PBXTargetDependency; target = 0039FE1A254FE518518BF8B8; };
-		F90407F24422C589DA251604 = {isa = XCConfigurationList; buildConfigurations = (
-					C42924A24AB55E6A940423EA,
-					70135D15D7E0D8410C42BBA3, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Debug; };
-		0655A4A348F7F91F77583ADC = {isa = XCConfigurationList; buildConfigurations = (
-					0CC6C439D038EDA0D7F10DF0,
-					0BC15DC2E5FE5ECFFB398D49, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Debug; };
-		C262D0F297DDE25326F5AC81 = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (
-					2610F357881240ACBF612F48,
-					1321E6C1C6170B6C898AD09D, ); runOnlyForDeploymentPostprocessing = 0; };
-		5CB869A8DA78BE6FA2757034 = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (
-					357A6AA6960EF95D92929BEE,
-					6DD9DA1677A6CF789CDAB478,
-					954A036F5DDB375DB23FFB3E,
-					3EB3D569250C4BA4CA9AF578,
-					636D21BF846031A6A1A7476A,
-					95B44E6C74B1DED31DBE37EB,
-					AA9D0B8E23F3D87A23DE9F8A,
-					244BA1BDA5FAA465EA3F9C6D,
-					6FD0752A5CADCF60D79FDBB7,
-					85B5E65F8DD80938BFBDCE61,
-					D805169E01D7F90B01C11769,
-					FCE6F604C00039A32649CB69,
-					9BF773500BA51A8B5C6C7348,
-					57B1F32A372143B4D3B1C517,
-					3DC282564876B1FC88AAA9B3,
-					C49E1D32A9DCE3D59BC48B1D,
-					E1268E019B434F6B5E9317DC,
-					CE91112DADB97C573C3C674D,
-					A70F0274076C0D44ED71C980,
-					BD1E0CBE74DDD2F303978E1F,
-					8C1CC0E7A772D66635BA482F,
-					A69BF71FA90E5A66B6EB2E0F,
-					D68DE111AFBD82F0D44A3B69,
-					EC6A34EC9A9D454BF26AAD32,
-					8AD28823205783E6F676F254,
-					34716A3539FD288C09CBA38A,
-					45A53AF13B0D663050632E8C,
-					C2A85091A28C907A4E1E1687,
-					83431B7234A78ECFB3C15F63,
-					209FCCC2155A1FCB7E11E20D,
-					C93569F47B4AC1A8E37992ED,
-					1B988E139004D8E2850EB656,
-					3D777382FE212D59BAF871FD,
-					3FCA61C401007B243E2E9035,
-					30B921C38DCEE787B294B746,
-					1F37544891EC8DBB5E500C1C,
-					0C5F43C262695A3EB7A9E1C0,
-					110221CD5578153B528AD2BE,
-					CD4F7B119CE718BCE78D61F4,
-					78CB463DD98A55313A543859,
-					1499DF2E85B05AC1BF423773,
-					123810DAF8AF758928916ECE,
-					C9F11BA62D6D092A300363F7,
-					9EAF9BE59FFE0BD49410B10E,
-					4A1DB797F1356E85110FF871,
-					F6635694A01FFBF5EF0968DB,
-					518DD443B6F17A5AFD707263,
-					B7EBA1A83575F48CD08140B9,
-					3C5267E06A897B0DC0F7EA50,
-					5DD883699B85E4C492CAD065,
-					D5C9125F65493CA481F18E53,
-					02E8F35A8E0D4A0DF6F38D60,
-					234B6BA2952CBC7C61EF70EF,
-					254A7C08594A152C2C646334,
-					F15F0512666FF8CDC0D08905,
-					B18248959DDC44EF4E85320A, ); runOnlyForDeploymentPostprocessing = 0; };
-		D150288A32EE596408C2B99F = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
-					A578EAD4BB55680E8097BE0F,
-					C1B9334AE849F93FB3C56B34,
-					8B4A593B3869815BBAC3EF93,
-					A14C2C2725DA3CA7995D2815,
-					1E76E36772355E2A43CF4961,
-					241F29FCBB7A17BB44A0B10C,
-					9359F9401D59B4517F75C39C,
-					091A57B4B9CE623E75E9A756,
-					FAB47E69F7D9DCE1F906AA07,
-					0E884E47A637D6C65154699A,
-					49C22786B54C5DC94E4654B8,
-					CDEF9FF2D119476D707305DF,
-					96EC6315E1B3F1A109F84BAF,
-					11D42F7EC6E6539D79A7F4B1,
-					B980464FA2761CCD64B1FAD6, ); runOnlyForDeploymentPostprocessing = 0; };
-		0039FE1A254FE518518BF8B8 = {isa = PBXNativeTarget; buildConfigurationList = 0655A4A348F7F91F77583ADC; buildPhases = (
-					C262D0F297DDE25326F5AC81,
-					5CB869A8DA78BE6FA2757034,
-					D150288A32EE596408C2B99F, ); buildRules = ( ); dependencies = (  ); name = "Projucer - App"; productName = Projucer; productReference = 09DE066936CF037E9709ADB1; productType = "com.apple.product-type.application"; };
-		74EA481348A24104E6ACE009 = {isa = PBXProject; buildConfigurationList = F90407F24422C589DA251604; attributes = { LastUpgradeCheck = 0830; TargetAttributes = { 0039FE1A254FE518518BF8B8 = { SystemCapabilities = {com.apple.InAppPurchase = { enabled = 0; }; com.apple.InterAppAudio = { enabled = 0; }; com.apple.Push = { enabled = 0; }; com.apple.Sandbox = { enabled = 0; }; }; }; }; }; compatibilityVersion = "Xcode 3.2"; hasScannedForEncodings = 0; mainGroup = 3CC531922CC2D398E283A845; projectDirPath = ""; projectRoot = ""; targets = (0039FE1A254FE518518BF8B8); };
+				PRODUCT_NAME = Projucer;
+				WARNING_CFLAGS = "-Wreorder";
+				ZERO_LINK = NO;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0655A4A348F7F91F77583ADC /* Build configuration list for PBXNativeTarget "Projucer - App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0CC6C439D038EDA0D7F10DF0 /* Debug */,
+				0BC15DC2E5FE5ECFFB398D49 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F90407F24422C589DA251604 /* Build configuration list for PBXProject "Projucer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C42924A24AB55E6A940423EA /* Debug */,
+				70135D15D7E0D8410C42BBA3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
 	};
-	rootObject = 74EA481348A24104E6ACE009;
+	rootObject = 74EA481348A24104E6ACE009 /* Project object */;
 }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class ButtonHandler  : public ComponentTypeHandler
 {
@@ -32,8 +32,8 @@ public:
                    const std::type_info& componentClass,
                    const int defaultWidth_,
                    const int defaultHeight_)
-        : ComponentTypeHandler (typeDescription_, className_, componentClass,
-                                defaultWidth_, defaultHeight_)
+    : ComponentTypeHandler (typeDescription_, className_, componentClass,
+                            defaultWidth_, defaultHeight_)
     {}
 
     void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
@@ -99,8 +99,8 @@ public:
         if (b->getButtonText() != b->getName())
         {
             code.constructorCode
-              << memberVariableName << "->setButtonText ("
-              << quotedString (b->getButtonText(), code.shouldUseTransMacro()) << ");\n";
+            << memberVariableName << "->setButtonText ("
+            << quotedString (b->getButtonText(), code.shouldUseTransMacro()) << ");\n";
         }
 
         if (b->getConnectedEdgeFlags() != 0)
@@ -121,14 +121,14 @@ public:
 
             String s;
             s << memberVariableName << "->setConnectedEdges ("
-              << flags.joinIntoString (" | ") << ");\n";
+            << flags.joinIntoString (" | ") << ");\n";
 
             code.constructorCode += s;
         }
 
         if (b->getRadioGroupId() != 0)
             code.constructorCode << memberVariableName << "->setRadioGroupId ("
-                                 << b->getRadioGroupId() << ");\n";
+            << b->getRadioGroupId() << ");\n";
 
         if (needsButtonListener (component))
             code.constructorCode << memberVariableName << "->addListener (this);\n";
@@ -152,8 +152,8 @@ public:
             const String userCodeComment ("UserButtonCode_" + memberVariableName);
 
             callback
-                << "if (buttonThatWasClicked == " << memberVariableName
-                << ")\n{\n    //[" << userCodeComment << "] -- add your button handler code here..\n    //[/" << userCodeComment << "]\n}\n";
+            << "if (buttonThatWasClicked == " << memberVariableName
+            << ")\n{\n    //[" << userCodeComment << "] -- add your button handler code here..\n    //[/" << userCodeComment << "]\n}\n";
         }
     }
 
@@ -173,7 +173,7 @@ private:
     {
     public:
         ButtonTextProperty (Button* button_, JucerDocument& doc)
-            : ComponentTextProperty <Button> ("text", 100, false, button_, doc)
+        : ComponentTextProperty <Button> ("text", 100, false, button_, doc)
         {
         }
 
@@ -193,8 +193,8 @@ private:
         {
         public:
             ButtonTextChangeAction (Button* const comp, ComponentLayout& l, const String& newName_)
-                : ComponentUndoableAction <Button> (comp, l),
-                  newName (newName_)
+            : ComponentUndoableAction <Button> (comp, l),
+            newName (newName_)
             {
                 oldName = comp->getButtonText();
             }
@@ -223,7 +223,7 @@ private:
     {
     public:
         ButtonCallbackProperty (Button* b, JucerDocument& doc)
-            : ComponentBooleanProperty <Button> ("callback", "Generate ButtonListener", "Generate ButtonListener", b, doc)
+        : ComponentBooleanProperty <Button> ("callback", "Generate ButtonListener", "Generate ButtonListener", b, doc)
         {
         }
 
@@ -240,8 +240,8 @@ private:
         {
         public:
             ButtonCallbackChangeAction (Button* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <Button> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Button> (comp, l),
+            newState (newState_)
             {
                 oldState = needsButtonListener (comp);
             }
@@ -270,7 +270,7 @@ private:
     {
     public:
         ButtonRadioGroupProperty (Button* const button_, JucerDocument& doc)
-            : ComponentTextProperty <Button> ("radio group", 10, false, button_, doc)
+        : ComponentTextProperty <Button> ("radio group", 10, false, button_, doc)
         {
         }
 
@@ -290,8 +290,8 @@ private:
         {
         public:
             ButtonRadioGroupChangeAction (Button* const comp, ComponentLayout& l, const int newId_)
-                : ComponentUndoableAction <Button> (comp, l),
-                  newId (newId_)
+            : ComponentUndoableAction <Button> (comp, l),
+            newId (newId_)
             {
                 oldId = comp->getRadioGroupId();
             }
@@ -321,8 +321,8 @@ private:
     public:
         ButtonConnectedEdgeProperty (const String& name, const int flag_,
                                      Button* b, JucerDocument& doc)
-            : ComponentBooleanProperty <Button> (name, "Connected", "Connected", b, doc),
-              flag (flag_)
+        : ComponentBooleanProperty <Button> (name, "Connected", "Connected", b, doc),
+        flag (flag_)
         {
         }
 
@@ -344,9 +344,9 @@ private:
         {
         public:
             ButtonConnectedChangeAction (Button* const comp, ComponentLayout& l, const int flag_, const bool newState_)
-                : ComponentUndoableAction <Button> (comp, l),
-                  flag (flag_),
-                  newState (newState_)
+            : ComponentUndoableAction <Button> (comp, l),
+            flag (flag_),
+            newState (newState_)
             {
                 oldState = ((comp->getConnectedEdgeFlags() & flag) != 0);
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
@@ -36,9 +36,12 @@ public:
                                 defaultWidth_, defaultHeight_)
     {}
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Button* const b = dynamic_cast<Button*> (component);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class ComboBoxHandler  : public ComponentTypeHandler
 {
 public:
     ComboBoxHandler()
-        : ComponentTypeHandler ("Combo Box", "ComboBox", typeid (ComboBox), 150, 24)
+    : ComponentTypeHandler ("Combo Box", "ComboBox", typeid (ComboBox), 150, 24)
     {}
 
     Component* createNewComponent (JucerDocument*)
@@ -104,9 +104,9 @@ public:
 
         String s;
         s << memberVariableName << "->setEditableText (" << CodeHelpers::boolLiteral (c->isTextEditable()) << ");\n"
-          << memberVariableName << "->setJustificationType (" << CodeHelpers::justificationToCode (c->getJustificationType()) << ");\n"
-          << memberVariableName << "->setTextWhenNothingSelected (" << quotedString (c->getTextWhenNothingSelected(), code.shouldUseTransMacro()) << ");\n"
-          << memberVariableName << "->setTextWhenNoChoicesAvailable (" << quotedString (c->getTextWhenNoChoicesAvailable(), code.shouldUseTransMacro()) << ");\n";
+        << memberVariableName << "->setJustificationType (" << CodeHelpers::justificationToCode (c->getJustificationType()) << ");\n"
+        << memberVariableName << "->setTextWhenNothingSelected (" << quotedString (c->getTextWhenNothingSelected(), code.shouldUseTransMacro()) << ");\n"
+        << memberVariableName << "->setTextWhenNoChoicesAvailable (" << quotedString (c->getTextWhenNoChoicesAvailable(), code.shouldUseTransMacro()) << ");\n";
 
         StringArray lines;
         lines.addLines (c->getProperties() ["items"].toString());
@@ -118,7 +118,7 @@ public:
                 s << memberVariableName << "->addSeparator();\n";
             else
                 s << memberVariableName << "->addItem ("
-                  << quotedString (lines[i], code.shouldUseTransMacro()) << ", " << itemId++ << ");\n";
+                << quotedString (lines[i], code.shouldUseTransMacro()) << ", " << itemId++ << ");\n";
         }
 
         if (needsCallback (component))
@@ -147,8 +147,8 @@ public:
             const String userCodeComment ("UserComboBoxCode_" + memberVariableName);
 
             callback
-                << "if (comboBoxThatHasChanged == " << memberVariableName
-                << ")\n{\n    //[" << userCodeComment << "] -- add your combo box handling code here..\n    //[/" << userCodeComment << "]\n}\n";
+            << "if (comboBoxThatHasChanged == " << memberVariableName
+            << ")\n{\n    //[" << userCodeComment << "] -- add your combo box handling code here..\n    //[/" << userCodeComment << "]\n}\n";
         }
     }
 
@@ -179,7 +179,7 @@ private:
     {
     public:
         ComboEditableProperty (ComboBox* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <ComboBox> ("editable", "Text is editable", "Text is editable", comp, doc)
+        : ComponentBooleanProperty <ComboBox> ("editable", "Text is editable", "Text is editable", comp, doc)
         {
         }
 
@@ -199,8 +199,8 @@ private:
         {
         public:
             ComboEditableChangeAction (ComboBox* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <ComboBox> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <ComboBox> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isTextEditable();
             }
@@ -230,9 +230,9 @@ private:
     {
     public:
         ComboJustificationProperty (ComboBox* comp, JucerDocument& doc)
-            : JustificationProperty ("text layout", false),
-              component (comp),
-              document (doc)
+        : JustificationProperty ("text layout", false),
+        component (comp),
+        document (doc)
         {
         }
 
@@ -252,9 +252,9 @@ private:
         {
         public:
             ComboJustifyChangeAction (ComboBox* const comp, ComponentLayout& l, Justification newState_)
-                : ComponentUndoableAction <ComboBox> (comp, l),
-                  newState (newState_),
-                  oldState (comp->getJustificationType())
+            : ComponentUndoableAction <ComboBox> (comp, l),
+            newState (newState_),
+            oldState (comp->getJustificationType())
             {
             }
 
@@ -283,7 +283,7 @@ private:
     {
     public:
         ComboItemsProperty (ComboBox* comp, JucerDocument& doc)
-            : ComponentTextProperty <ComboBox> ("items", 10000, true, comp, doc)
+        : ComponentTextProperty <ComboBox> ("items", 10000, true, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -302,8 +302,8 @@ private:
         {
         public:
             ComboItemsChangeAction (ComboBox* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <ComboBox> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <ComboBox> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getProperties() ["items"];
             }
@@ -335,7 +335,7 @@ private:
     {
     public:
         ComboTextWhenNoneSelectedProperty (ComboBox* comp, JucerDocument& doc)
-            : ComponentTextProperty <ComboBox> ("text when none selected", 200, false, comp, doc)
+        : ComponentTextProperty <ComboBox> ("text when none selected", 200, false, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -354,8 +354,8 @@ private:
         {
         public:
             ComboNonSelTextChangeAction (ComboBox* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <ComboBox> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <ComboBox> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getTextWhenNothingSelected();
             }
@@ -385,7 +385,7 @@ private:
     {
     public:
         ComboTextWhenNoItemsProperty (ComboBox* comp, JucerDocument& doc)
-            : ComponentTextProperty <ComboBox> ("text when no items", 200, false, comp, doc)
+        : ComponentTextProperty <ComboBox> ("text when no items", 200, false, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -404,8 +404,8 @@ private:
         {
         public:
             ComboNoItemTextChangeAction (ComboBox* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <ComboBox> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <ComboBox> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getTextWhenNoChoicesAvailable();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
@@ -73,9 +73,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         ComboBox* const c = dynamic_cast<ComboBox*> (component);
         jassert (c != nullptr);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
@@ -87,6 +87,11 @@ void ComponentTypeHandler::showPopupMenu (Component*, ComponentLayout&)
     m.addCommandItem (commandManager, JucerCommandIDs::toFront);
     m.addCommandItem (commandManager, JucerCommandIDs::toBack);
     m.addSeparator();
+    m.addCommandItem (commandManager, JucerCommandIDs::alignLeft);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignRight);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignTop);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignBottom);
+    m.addSeparator();
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::cut);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::copy);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::paste);
@@ -330,7 +335,7 @@ public:
     ComponentPositionProperty (Component* comp,
                                JucerDocument& doc,
                                const String& name,
-                               ComponentPositionDimension dimension_)
+                               ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
         : PositionPropertyBase (comp, name, dimension_,
                                 true, true,
                                 doc.getComponentLayout()),
@@ -347,6 +352,11 @@ public:
     void setPosition (const RelativePositionedRectangle& newPos)
     {
         document.getComponentLayout()->setComponentPosition (component, newPos, true);
+    }
+
+    void setSingleDimension(bool undoable, const double newValue , ComponentLayout::ComponentPositionDimension dim)// D STENNING
+    {
+        document.getComponentLayout()->setSingleDimension ( undoable, newValue,dim );
     }
 
     RelativePositionedRectangle getPosition() const
@@ -413,27 +423,33 @@ private:
 //==============================================================================
 void ComponentTypeHandler::getEditableProperties (Component* component,
                                                   JucerDocument& document,
-                                                  Array<PropertyComponent*>& props)
+                                                  Array<PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new ComponentMemberNameProperty (component, document));
-    props.add (new ComponentNameProperty (component, document));
-    props.add (new ComponentVirtualClassProperty (component, document));
+    if ( ! multipleSelected )
+    {
+        props.add (new ComponentMemberNameProperty (component, document));
+        props.add (new ComponentNameProperty (component, document));
+        props.add (new ComponentVirtualClassProperty (component, document));
+    }
 
-    props.add (new ComponentPositionProperty (component, document, "x", ComponentPositionProperty::componentX));
-    props.add (new ComponentPositionProperty (component, document, "y", ComponentPositionProperty::componentY));
-    props.add (new ComponentPositionProperty (component, document, "width", ComponentPositionProperty::componentWidth));
-    props.add (new ComponentPositionProperty (component, document, "height", ComponentPositionProperty::componentHeight));
+    props.add (new ComponentPositionProperty (component, document, "x", ComponentLayout::componentX));  // D STENNING
+    props.add (new ComponentPositionProperty (component, document, "y", ComponentLayout::componentY));
+    props.add (new ComponentPositionProperty (component, document, "width", ComponentLayout::componentWidth));
+    props.add (new ComponentPositionProperty (component, document, "height", ComponentLayout::componentHeight));
 
-    if (dynamic_cast<SettableTooltipClient*> (component) != nullptr)
-        props.add (new TooltipProperty (component, document));
+    if ( ! multipleSelected )
+    {
+        if (dynamic_cast<SettableTooltipClient*> (component) != nullptr)
+            props.add (new TooltipProperty (component, document));
 
-    props.add (new FocusOrderProperty (component, document));
+        props.add (new FocusOrderProperty (component, document));
+    }
 }
 
-void ComponentTypeHandler::addPropertiesToPropertyPanel (Component* comp, JucerDocument& document, PropertyPanel& panel)
+void ComponentTypeHandler::addPropertiesToPropertyPanel (Component* comp, JucerDocument& document, PropertyPanel& panel, bool multipleSelected)  //  D STENNING
 {
     Array <PropertyComponent*> props;
-    getEditableProperties (comp, document, props);
+    getEditableProperties (comp, document, props, multipleSelected);
 
     panel.addSection (getClassName (comp), props);
 }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "../../Application/jucer_Application.h"
@@ -37,11 +37,11 @@
 
 static String getTypeInfoName (const std::type_info& info)
 {
-   #if JUCE_MSVC
+#if JUCE_MSVC
     return info.raw_name();
-   #else
+#else
     return info.name();
-   #endif
+#endif
 }
 
 //==============================================================================
@@ -50,11 +50,11 @@ ComponentTypeHandler::ComponentTypeHandler (const String& typeName_,
                                             const std::type_info& componentClass_,
                                             const int defaultWidth_,
                                             const int defaultHeight_)
-    : typeName (typeName_),
-      className (className_),
-      componentClassRawName (getTypeInfoName (componentClass_)),
-      defaultWidth (defaultWidth_),
-      defaultHeight (defaultHeight_)
+: typeName (typeName_),
+className (className_),
+componentClassRawName (getTypeInfoName (componentClass_)),
+defaultWidth (defaultWidth_),
+defaultHeight (defaultHeight_)
 {
 }
 
@@ -262,12 +262,13 @@ void ComponentTypeHandler::setComponentPosition (Component* comp,
                                           layout));
 }
 
+
 //==============================================================================
 class TooltipProperty   : public ComponentTextProperty <Component>
 {
 public:
     TooltipProperty (Component* comp, JucerDocument& doc)
-        : ComponentTextProperty<Component> ("tooltip", 1024, true, comp, doc)
+    : ComponentTextProperty<Component> ("tooltip", 1024, true, comp, doc)
     {
     }
 
@@ -288,8 +289,8 @@ private:
     {
     public:
         SetTooltipAction (Component* const comp, ComponentLayout& l, const String& newValue_)
-            : ComponentUndoableAction<Component> (comp, l),
-              newValue (newValue_)
+        : ComponentUndoableAction<Component> (comp, l),
+        newValue (newValue_)
         {
             SettableTooltipClient* ttc = dynamic_cast<SettableTooltipClient*> (comp);
             jassert (ttc != nullptr);
@@ -374,7 +375,7 @@ class FocusOrderProperty   : public ComponentTextProperty <Component>
 {
 public:
     FocusOrderProperty (Component* comp, JucerDocument& doc)
-        : ComponentTextProperty <Component> ("focus order", 8, false, comp, doc)
+    : ComponentTextProperty <Component> ("focus order", 8, false, comp, doc)
     {
     }
 
@@ -394,8 +395,8 @@ private:
     {
     public:
         SetFocusOrderAction (Component* const comp, ComponentLayout& l, const int newOrder_)
-            : ComponentUndoableAction <Component> (comp, l),
-              newValue (newOrder_)
+        : ComponentUndoableAction <Component> (comp, l),
+        newValue (newOrder_)
         {
             oldValue = comp->getExplicitFocusOrder();
         }
@@ -489,10 +490,10 @@ String ComponentTypeHandler::getColourIntialisationCode (Component* component,
         if (component->isColourSpecified (colours[i]->colourId))
         {
             s << objectName << "->setColour ("
-              << colours[i]->colourIdCode
-              << ", "
-              << CodeHelpers::colourToCode (component->findColour (colours[i]->colourId))
-              << ");\n";
+            << colours[i]->colourIdCode
+            << ", "
+            << CodeHelpers::colourToCode (component->findColour (colours[i]->colourId))
+            << ");\n";
         }
     }
 
@@ -520,7 +521,7 @@ void ComponentTypeHandler::fillInMemberVariableDeclarations (GeneratedCode& code
         clsName = getClassName (component);
 
     code.privateMemberDeclarations
-        << "ScopedPointer<" << clsName << "> " << memberVariableName << ";\n";
+    << "ScopedPointer<" << clsName << "> " << memberVariableName << ";\n";
 }
 
 void ComponentTypeHandler::fillInResizeCode (GeneratedCode& code, Component* component, const String& memberVariableName)
@@ -531,7 +532,7 @@ void ComponentTypeHandler::fillInResizeCode (GeneratedCode& code, Component* com
     positionToCode (pos, code.document->getComponentLayout(), x, y, w, h);
 
     r << memberVariableName << "->setBounds ("
-      << x << ", " << y << ", " << w << ", " << h << ");\n";
+    << x << ", " << y << ", " << w << ", " << h << ");\n";
 
     if (pos.rect.isPositionAbsolute())
         code.constructorCode += r + "\n";
@@ -574,15 +575,15 @@ void ComponentTypeHandler::fillInCreationCode (GeneratedCode& code, Component* c
         if (ttc->getTooltip().isNotEmpty())
         {
             s << memberVariableName << "->setTooltip ("
-              << quotedString (ttc->getTooltip(), code.shouldUseTransMacro())
-              << ");\n";
+            << quotedString (ttc->getTooltip(), code.shouldUseTransMacro())
+            << ");\n";
         }
     }
 
     if (component->getExplicitFocusOrder() > 0)
         s << memberVariableName << "->setExplicitFocusOrder ("
-          << component->getExplicitFocusOrder()
-          << ");\n";
+        << component->getExplicitFocusOrder()
+        << ");\n";
 
     code.constructorCode += s;
 }
@@ -591,5 +592,5 @@ void ComponentTypeHandler::fillInDeletionCode (GeneratedCode& code, Component*,
                                                const String& memberVariableName)
 {
     code.destructorCode
-        << memberVariableName << " = nullptr;\n";
+    << memberVariableName << " = nullptr;\n";
 }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
@@ -63,11 +63,12 @@ public:
 
     virtual void getEditableProperties (Component* component,
                                         JucerDocument& document,
-                                        Array<PropertyComponent*>& props);
+                                        Array<PropertyComponent*>& props, bool multipleSelected);  // D STENNING
 
     virtual void addPropertiesToPropertyPanel (Component* component,
                                                JucerDocument& document,
-                                               PropertyPanel& panel);
+                                               PropertyPanel& panel,
+                                               bool multipleSelected);  // D STENNING
 
 
     void registerEditableColour (int colourId,

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
@@ -1,41 +1,42 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
 class ComponentOverlayComponent;
 class ComponentLayout;
+
 #include "../jucer_GeneratedCode.h"
 #include "../ui/jucer_RelativePositionedRectangle.h"
 
 
 //==============================================================================
 /**
-    Base class for handlers that can understand the properties of all the component classes.
-*/
+ Base class for handlers that can understand the properties of all the component classes.
+ */
 class ComponentTypeHandler
 {
 public:
@@ -76,8 +77,8 @@ public:
                                  const String& colourName,
                                  const String& xmlTagName);
 
-    #define registerColour(colourId, colourName, xmlTagName)   \
-        registerEditableColour (colourId, #colourId, colourName, xmlTagName)
+#define registerColour(colourId, colourName, xmlTagName)   \
+registerEditableColour (colourId, #colourId, colourName, xmlTagName)
 
     void addColourProperties (Component* component,
                               JucerDocument& document,
@@ -121,6 +122,7 @@ public:
     static void setComponentPosition (Component* comp,
                                       const RelativePositionedRectangle& newPos,
                                       const ComponentLayout* layout);
+
 
     static JucerDocument* findParentDocument (Component* component);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
@@ -99,9 +99,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new GenericCompClassProperty (dynamic_cast<GenericComponent*> (component), document));
         props.add (new GenericCompParamsProperty (dynamic_cast<GenericComponent*> (component), document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
@@ -1,35 +1,35 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class GenericComponent  : public Component
 {
 public:
     GenericComponent()
-        : Component ("new component"),
-          actualClassName ("Component")
+    : Component ("new component"),
+    actualClassName ("Component")
     {
     }
 
@@ -72,7 +72,7 @@ class GenericComponentHandler  : public ComponentTypeHandler
 {
 public:
     GenericComponentHandler()
-        : ComponentTypeHandler ("Generic Component", "GenericComponent", typeid (GenericComponent), 150, 24)
+    : ComponentTypeHandler ("Generic Component", "GenericComponent", typeid (GenericComponent), 150, 24)
     {}
 
     Component* createNewComponent (JucerDocument*)
@@ -126,9 +126,9 @@ public:
 
         if (component->getName().isNotEmpty())
             code.constructorCode
-                << memberVariableName << "->setName ("
-                << quotedString (component->getName(), false)
-                << ");\n\n";
+            << memberVariableName << "->setName ("
+            << quotedString (component->getName(), false)
+            << ");\n\n";
         else
             code.constructorCode << "\n";
     }
@@ -138,7 +138,7 @@ private:
     {
     public:
         GenericCompClassProperty (GenericComponent* comp, JucerDocument& doc)
-            : ComponentTextProperty <GenericComponent> ("class", 300, false, comp, doc)
+        : ComponentTextProperty <GenericComponent> ("class", 300, false, comp, doc)
         {
         }
 
@@ -159,8 +159,8 @@ private:
         {
         public:
             GenericCompClassChangeAction (GenericComponent* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <GenericComponent> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <GenericComponent> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->actualClassName;
             }
@@ -189,7 +189,7 @@ private:
     {
     public:
         GenericCompParamsProperty (GenericComponent* comp, JucerDocument& doc)
-            : ComponentTextProperty <GenericComponent> ("constructor params", 1024, true, comp, doc)
+        : ComponentTextProperty <GenericComponent> ("constructor params", 1024, true, comp, doc)
         {
         }
 
@@ -209,8 +209,8 @@ private:
         {
         public:
             GenericCompParamsChangeAction (GenericComponent* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <GenericComponent> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <GenericComponent> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->constructorParams;
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
@@ -99,9 +99,12 @@ public:
         code.constructorCode += s;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new GroupTitleProperty ((GroupComponent*) component, document));
         props.add (new GroupJustificationProperty ((GroupComponent*) component, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class GroupComponentHandler  : public ComponentTypeHandler
 {
 public:
     GroupComponentHandler()
-        : ComponentTypeHandler ("Group Box", "GroupComponent", typeid (GroupComponent), 200, 150)
+    : ComponentTypeHandler ("Group Box", "GroupComponent", typeid (GroupComponent), 200, 150)
     {
         registerColour (GroupComponent::outlineColourId, "outline", "outlinecol");
         registerColour (GroupComponent::textColourId, "text", "textcol");
@@ -72,8 +72,8 @@ public:
         GroupComponent* g = dynamic_cast<GroupComponent*> (component);
 
         return quotedString (component->getName(), false)
-                + ",\n"
-                + quotedString (g->getText(), code.shouldUseTransMacro());
+        + ",\n"
+        + quotedString (g->getText(), code.shouldUseTransMacro());
     }
 
     void fillInCreationCode (GeneratedCode& code, Component* component, const String& memberVariableName)
@@ -89,12 +89,12 @@ public:
         if (g->getTextLabelPosition().getFlags() != defaultComp.getTextLabelPosition().getFlags())
         {
             s << memberVariableName << "->setTextLabelPosition ("
-              << CodeHelpers::justificationToCode (g->getTextLabelPosition())
-              << ");\n";
+            << CodeHelpers::justificationToCode (g->getTextLabelPosition())
+            << ");\n";
         }
 
         s << getColourIntialisationCode (component, memberVariableName)
-          << '\n';
+        << '\n';
 
         code.constructorCode += s;
     }
@@ -118,7 +118,7 @@ private:
     {
     public:
         GroupTitleProperty (GroupComponent* comp, JucerDocument& doc)
-            : ComponentTextProperty <GroupComponent> ("text", 200, false, comp, doc)
+        : ComponentTextProperty <GroupComponent> ("text", 200, false, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -137,8 +137,8 @@ private:
         {
         public:
             GroupTitleChangeAction (GroupComponent* const comp, ComponentLayout& l, const String& newName_)
-                : ComponentUndoableAction <GroupComponent> (comp, l),
-                  newName (newName_)
+            : ComponentUndoableAction <GroupComponent> (comp, l),
+            newName (newName_)
             {
                 oldName = comp->getText();
             }
@@ -165,13 +165,13 @@ private:
 
     //==============================================================================
     class GroupJustificationProperty  : public JustificationProperty,
-                                        public ChangeListener
+    public ChangeListener
     {
     public:
         GroupJustificationProperty (GroupComponent* const group_, JucerDocument& doc)
-            : JustificationProperty ("layout", true),
-              group (group_),
-              document (doc)
+        : JustificationProperty ("layout", true),
+        group (group_),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -202,9 +202,9 @@ private:
         {
         public:
             GroupJustifyChangeAction (GroupComponent* const comp, ComponentLayout& l, Justification newState_)
-                : ComponentUndoableAction <GroupComponent> (comp, l),
-                  newState (newState_),
-                  oldState (comp->getTextLabelPosition())
+            : ComponentUndoableAction <GroupComponent> (comp, l),
+            newState (newState_),
+            oldState (comp->getTextLabelPosition())
             {
             }
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class HyperlinkButtonHandler  : public ButtonHandler
 {
 public:
     HyperlinkButtonHandler()
-        : ButtonHandler ("Hyperlink Button", "HyperlinkButton", typeid (HyperlinkButton), 150, 24)
+    : ButtonHandler ("Hyperlink Button", "HyperlinkButton", typeid (HyperlinkButton), 150, 24)
     {
         registerColour (HyperlinkButton::textColourId, "text", "textCol");
     }
@@ -78,9 +78,9 @@ public:
         HyperlinkButton* const hb = dynamic_cast<HyperlinkButton*> (comp);
 
         return quotedString (hb->getButtonText(), code.shouldUseTransMacro())
-                + ",\nURL ("
-                + quotedString (hb->getURL().toString (false), false)
-                + ")";
+        + ",\nURL ("
+        + quotedString (hb->getURL().toString (false), false)
+        + ")";
     }
 
     void fillInCreationCode (GeneratedCode& code, Component* component, const String& memberVariableName)
@@ -88,7 +88,7 @@ public:
         ButtonHandler::fillInCreationCode (code, component, memberVariableName);
 
         code.constructorCode << getColourIntialisationCode (component, memberVariableName)
-                             << '\n';
+        << '\n';
     }
 
 private:
@@ -97,7 +97,7 @@ private:
     {
     public:
         HyperlinkURLProperty (HyperlinkButton* comp, JucerDocument& doc)
-            : ComponentTextProperty <HyperlinkButton> ("URL", 512, false, comp, doc)
+        : ComponentTextProperty <HyperlinkButton> ("URL", 512, false, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -116,8 +116,8 @@ private:
         {
         public:
             HyperlinkURLChangeAction (HyperlinkButton* const comp, ComponentLayout& l, const URL& newState_)
-                : ComponentUndoableAction <HyperlinkButton> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <HyperlinkButton> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getURL();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
@@ -41,10 +41,14 @@ public:
         return hb;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
         HyperlinkButton* const hb = (HyperlinkButton*) component;
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         props.add (new HyperlinkURLProperty (hb, document));
         addColourProperties (component, document, props);
     }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class ImageButtonHandler  : public ButtonHandler
 {
@@ -36,7 +36,7 @@ public:
 
     //==============================================================================
     ImageButtonHandler()
-        : ButtonHandler ("Image Button", "ImageButton", typeid (ImageButton), 150, 24)
+    : ButtonHandler ("Image Button", "ImageButton", typeid (ImageButton), 150, 24)
     {
     }
 
@@ -130,25 +130,25 @@ public:
         String s;
 
         s << getColourIntialisationCode (component, memberVariableName)
-          << '\n';
+        << '\n';
 
         const String indent (String::repeatedString (" ", memberVariableName.length() + 13));
 
         s << memberVariableName << "->setImages (false, true, "
-          << CodeHelpers::boolLiteral (doesImageKeepProportions (ib)) << ",\n"
-          << indent
-          << getImageCreationCode (ib, normalImage) << ", "
-          << CodeHelpers::floatLiteral (getImageOpacity (ib, normalImage), 3) << ", "
-          << CodeHelpers::colourToCode (getImageColour (ib, normalImage)) << ",\n"
-          << indent
-          << getImageCreationCode (ib, overImage) << ", "
-          << CodeHelpers::floatLiteral (getImageOpacity (ib, overImage), 3) << ", "
-          << CodeHelpers::colourToCode (getImageColour (ib, overImage)) << ",\n"
-          << indent
-          << getImageCreationCode (ib, downImage) << ", "
-          << CodeHelpers::floatLiteral (getImageOpacity (ib, downImage), 3) << ", "
-          << CodeHelpers::colourToCode (getImageColour (ib, downImage))
-          << ");\n";
+        << CodeHelpers::boolLiteral (doesImageKeepProportions (ib)) << ",\n"
+        << indent
+        << getImageCreationCode (ib, normalImage) << ", "
+        << CodeHelpers::floatLiteral (getImageOpacity (ib, normalImage), 3) << ", "
+        << CodeHelpers::colourToCode (getImageColour (ib, normalImage)) << ",\n"
+        << indent
+        << getImageCreationCode (ib, overImage) << ", "
+        << CodeHelpers::floatLiteral (getImageOpacity (ib, overImage), 3) << ", "
+        << CodeHelpers::colourToCode (getImageColour (ib, overImage)) << ",\n"
+        << indent
+        << getImageCreationCode (ib, downImage) << ", "
+        << CodeHelpers::floatLiteral (getImageOpacity (ib, downImage), 3) << ", "
+        << CodeHelpers::colourToCode (getImageColour (ib, downImage))
+        << ");\n";
 
         code.constructorCode += s;
     }
@@ -168,9 +168,9 @@ public:
     {
     public:
         ImageButtonResourceProperty (ComponentLayout& layout_, ImageButton* const owner_, const ImageRole role_, const String& name)
-            : ImageResourceProperty <ImageButton> (*layout_.getDocument(), owner_, name, true),
-              role (role_),
-              layout (layout_)
+        : ImageResourceProperty <ImageButton> (*layout_.getDocument(), owner_, name, true),
+        role (role_),
+        layout (layout_)
         {
         }
 
@@ -196,10 +196,10 @@ public:
                                 ComponentLayout& layout_,
                                 const ImageRole role_,
                                 const String& newResource_)
-            : ComponentUndoableAction <ImageButton> (button, layout_),
-              newResource (newResource_),
-              role (role_),
-              layout (layout_)
+        : ComponentUndoableAction <ImageButton> (button, layout_),
+        newResource (newResource_),
+        role (role_),
+        layout (layout_)
         {
             oldResource = ImageButtonHandler::getImageResource (button, role_);
         }
@@ -258,9 +258,9 @@ public:
         SetImageKeepsPropAction (ImageButton* const button,
                                  ComponentLayout& layout_,
                                  const bool newState_)
-            : ComponentUndoableAction <ImageButton> (button, layout_),
-              newState (newState_),
-              layout (layout_)
+        : ComponentUndoableAction <ImageButton> (button, layout_),
+        newState (newState_),
+        layout (layout_)
         {
             oldState = ImageButtonHandler::doesImageKeepProportions (button);
         }
@@ -307,9 +307,9 @@ public:
     {
     public:
         ImageButtonProportionProperty (ComponentLayout& layout_, ImageButton* const owner_)
-            : ComponentBooleanProperty <ImageButton> ("proportional", "maintain image proportions", "scale to fit",
-                                                      owner_, *layout_.getDocument()),
-              layout (layout_)
+        : ComponentBooleanProperty <ImageButton> ("proportional", "maintain image proportions", "scale to fit",
+                                                  owner_, *layout_.getDocument()),
+        layout (layout_)
         {
         }
 
@@ -335,10 +335,10 @@ public:
                                ComponentLayout& layout_,
                                const ImageRole role_,
                                const float newState_)
-            : ComponentUndoableAction <ImageButton> (button, layout_),
-              role (role_),
-              newState (newState_),
-              layout (layout_)
+        : ComponentUndoableAction <ImageButton> (button, layout_),
+        role (role_),
+        newState (newState_),
+        layout (layout_)
         {
             oldState = ImageButtonHandler::getImageOpacity (button, role_);
         }
@@ -387,10 +387,10 @@ public:
     public:
         ImageButtonOpacityProperty (ComponentLayout& layout_, ImageButton* const owner_,
                                     const String& name, const ImageRole role_)
-            : SliderPropertyComponent (name, 0.0, 1.0, 0.0),
-              owner (owner_),
-              layout (layout_),
-              role (role_)
+        : SliderPropertyComponent (name, 0.0, 1.0, 0.0),
+        owner (owner_),
+        layout (layout_),
+        role (role_)
         {
         }
 
@@ -418,10 +418,10 @@ public:
                               ComponentLayout& layout_,
                               const ImageRole role_,
                               Colour newState_)
-            : ComponentUndoableAction<ImageButton> (button, layout_),
-              role (role_),
-              newState (newState_),
-              layout (layout_)
+        : ComponentUndoableAction<ImageButton> (button, layout_),
+        role (role_),
+        newState (newState_),
+        layout (layout_)
         {
             oldState = ImageButtonHandler::getImageColour (button, role_);
         }
@@ -467,15 +467,15 @@ public:
     }
 
     class ImageButtonColourProperty    : public JucerColourPropertyComponent,
-                                         public ChangeListener
+    public ChangeListener
     {
     public:
         ImageButtonColourProperty (ComponentLayout& layout_, ImageButton* const owner_,
                                    const String& name, const ImageRole role_)
-            : JucerColourPropertyComponent (name, false),
-              owner (owner_),
-              layout (layout_),
-              role (role_)
+        : JucerColourPropertyComponent (name, false),
+        owner (owner_),
+        layout (layout_),
+        role (role_)
         {
             layout_.getDocument()->addChangeListener (this);
         }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
@@ -45,9 +45,12 @@ public:
         return new ImageButton ("new button");
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         addColourProperties (component, document, props);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -38,8 +38,8 @@ class JucerComponentHandler  : public ComponentTypeHandler
 {
 public:
     JucerComponentHandler()
-        : ComponentTypeHandler ("Projucer Component", "xxx",
-                                typeid (TestComponent), 300, 200)
+    : ComponentTypeHandler ("Projucer Component", "xxx",
+                            typeid (TestComponent), 300, 200)
     {}
 
     Component* createNewComponent (JucerDocument* doc)
@@ -122,8 +122,8 @@ public:
     {
     public:
         JucerCompFileChangeAction (TestComponent* const comp, ComponentLayout& l, const String& newState_)
-            : ComponentUndoableAction <TestComponent> (comp, l),
-              newState (newState_)
+        : ComponentUndoableAction <TestComponent> (comp, l),
+        newState (newState_)
         {
             oldState = comp->getFilename();
         }
@@ -159,13 +159,13 @@ public:
 private:
     //==============================================================================
     class JucerCompFileProperty  : public FilePropertyComponent,
-                                   public ChangeListener
+    public ChangeListener
     {
     public:
         JucerCompFileProperty (TestComponent* const comp, JucerDocument& doc)
-            : FilePropertyComponent ("Jucer file", false, true),
-              component (comp),
-              document (doc)
+        : FilePropertyComponent ("Jucer file", false, true),
+        component (comp),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -179,7 +179,7 @@ private:
         {
             setJucerComponentFile (document, component,
                                    newFile.getRelativePathFrom (document.getCppFile().getParentDirectory())
-                                          .replaceCharacter ('\\', '/'));
+                                   .replaceCharacter ('\\', '/'));
         }
 
         File getFile() const
@@ -201,8 +201,8 @@ private:
     struct JucerCompOpenDocProperty  : public ButtonPropertyComponent
     {
         JucerCompOpenDocProperty (TestComponent* const c)
-            : ButtonPropertyComponent ("edit", false),
-              component (c)
+        : ButtonPropertyComponent ("edit", false),
+        component (c)
         {
         }
 
@@ -224,7 +224,7 @@ private:
     struct ConstructorParamsProperty   : public ComponentTextProperty <TestComponent>
     {
         ConstructorParamsProperty (TestComponent* comp, JucerDocument& doc)
-            : ComponentTextProperty <TestComponent> ("constructor params", 512, false, comp, doc)
+        : ComponentTextProperty <TestComponent> ("constructor params", 512, false, comp, doc)
         {
         }
 
@@ -243,8 +243,8 @@ private:
         struct ConstructorParamChangeAction  : public ComponentUndoableAction <TestComponent>
         {
             ConstructorParamChangeAction (TestComponent* const comp, ComponentLayout& l, const String& newValue_)
-                : ComponentUndoableAction <TestComponent> (comp, l),
-                  newValue (newValue_)
+            : ComponentUndoableAction <TestComponent> (comp, l),
+            newValue (newValue_)
             {
                 oldValue = comp->getConstructorParams();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
@@ -88,11 +88,14 @@ public:
         return jucerCompClassName;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
         TestComponent* const tc = dynamic_cast<TestComponent*> (component);
 
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new JucerCompFileProperty (tc, document));
         props.add (new ConstructorParamsProperty (tc, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class LabelHandler  : public ComponentTypeHandler
 {
 public:
     LabelHandler()
-        : ComponentTypeHandler ("Label", "Label", typeid (Label), 150, 24)
+    : ComponentTypeHandler ("Label", "Label", typeid (Label), 150, 24)
     {
         registerColour (Label::backgroundColourId, "background", "bkgCol");
         registerColour (Label::textColourId, "text", "textCol");
@@ -114,8 +114,8 @@ public:
         Label* const l = dynamic_cast<Label*> (component);
 
         return quotedString (component->getName(), false)
-                 + ",\n"
-                 + quotedString (l->getText(), code.shouldUseTransMacro());
+        + ",\n"
+        + quotedString (l->getText(), code.shouldUseTransMacro());
     }
 
     void fillInCreationCode (GeneratedCode& code, Component* component, const String& memberVariableName)
@@ -127,16 +127,16 @@ public:
         String s;
 
         s << memberVariableName << "->setFont ("
-          << FontPropertyComponent::getCompleteFontCode (l->getFont(), l->getProperties().getWithDefault ("typefaceName", FontPropertyComponent::getDefaultFont()))
-          << ");\n"
-          << memberVariableName << "->setJustificationType ("
-          << CodeHelpers::justificationToCode (l->getJustificationType())
-          << ");\n"
-          << memberVariableName << "->setEditable ("
-          << CodeHelpers::boolLiteral (l->isEditableOnSingleClick()) << ", "
-          << CodeHelpers::boolLiteral (l->isEditableOnDoubleClick()) << ", "
-          << CodeHelpers::boolLiteral (l->doesLossOfFocusDiscardChanges()) << ");\n"
-          << getColourIntialisationCode (component, memberVariableName);
+        << FontPropertyComponent::getCompleteFontCode (l->getFont(), l->getProperties().getWithDefault ("typefaceName", FontPropertyComponent::getDefaultFont()))
+        << ");\n"
+        << memberVariableName << "->setJustificationType ("
+        << CodeHelpers::justificationToCode (l->getJustificationType())
+        << ");\n"
+        << memberVariableName << "->setEditable ("
+        << CodeHelpers::boolLiteral (l->isEditableOnSingleClick()) << ", "
+        << CodeHelpers::boolLiteral (l->isEditableOnDoubleClick()) << ", "
+        << CodeHelpers::boolLiteral (l->doesLossOfFocusDiscardChanges()) << ");\n"
+        << getColourIntialisationCode (component, memberVariableName);
 
         if (needsCallback (component))
             s << memberVariableName << "->addListener (this);\n";
@@ -164,8 +164,8 @@ public:
             const String userCodeComment ("UserLabelCode_" + memberVariableName);
 
             callback
-                << "if (labelThatHasChanged == " << memberVariableName
-                << ")\n{\n    //[" << userCodeComment << "] -- add your label text handling code here..\n    //[/" << userCodeComment << "]\n}\n";
+            << "if (labelThatHasChanged == " << memberVariableName
+            << ")\n{\n    //[" << userCodeComment << "] -- add your label text handling code here..\n    //[/" << userCodeComment << "]\n}\n";
         }
     }
 
@@ -195,7 +195,7 @@ public:
     static bool needsCallback (Component* label)
     {
         return ((Label*) label)->isEditableOnSingleClick()
-                 || ((Label*) label)->isEditableOnDoubleClick(); // xxx should be configurable
+        || ((Label*) label)->isEditableOnDoubleClick(); // xxx should be configurable
     }
 
 private:
@@ -205,7 +205,7 @@ private:
     {
     public:
         LabelTextProperty (Label* comp, JucerDocument& doc)
-            : ComponentTextProperty <Label> ("text", 10000, true, comp, doc)
+        : ComponentTextProperty <Label> ("text", 10000, true, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -224,8 +224,8 @@ private:
         {
         public:
             LabelTextChangeAction (Label* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getText();
             }
@@ -255,7 +255,7 @@ private:
     {
     public:
         LabelEditableProperty (Label* comp, JucerDocument& doc)
-           : ComponentChoiceProperty <Label> ("editing", comp, doc)
+        : ComponentChoiceProperty <Label> ("editing", comp, doc)
         {
             choices.add ("read-only");
             choices.add ("edit on single-click");
@@ -271,8 +271,8 @@ private:
         int getIndex() const
         {
             return component->isEditableOnSingleClick()
-                    ? 1
-                    : (component->isEditableOnDoubleClick() ? 2 : 0);
+            ? 1
+            : (component->isEditableOnDoubleClick() ? 2 : 0);
         }
 
     private:
@@ -280,12 +280,12 @@ private:
         {
         public:
             LabelEditableChangeAction (Label* const comp, ComponentLayout& l, const int newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isEditableOnSingleClick()
-                            ? 1
-                            : (comp->isEditableOnDoubleClick() ? 2 : 0);
+                ? 1
+                : (comp->isEditableOnDoubleClick() ? 2 : 0);
             }
 
             bool perform()
@@ -315,7 +315,7 @@ private:
     {
     public:
         LabelLossOfFocusProperty (Label* comp, JucerDocument& doc)
-           : ComponentChoiceProperty <Label> ("focus", comp, doc)
+        : ComponentChoiceProperty <Label> ("focus", comp, doc)
         {
             choices.add ("loss of focus discards changes");
             choices.add ("loss of focus commits changes");
@@ -337,8 +337,8 @@ private:
         {
         public:
             LabelFocusLossChangeAction (Label* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->doesLossOfFocusDiscardChanges();
             }
@@ -369,13 +369,13 @@ private:
 
     //==============================================================================
     class LabelJustificationProperty  : public JustificationProperty,
-                                        public ChangeListener
+    public ChangeListener
     {
     public:
         LabelJustificationProperty (Label* const label_, JucerDocument& doc)
-            : JustificationProperty ("layout", false),
-              label (label_),
-              document (doc)
+        : JustificationProperty ("layout", false),
+        label (label_),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -406,9 +406,9 @@ private:
         {
         public:
             LabelJustifyChangeAction (Label* const comp, ComponentLayout& l, Justification newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_),
-                  oldState (comp->getJustificationType())
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_),
+            oldState (comp->getJustificationType())
             {
             }
 
@@ -434,13 +434,13 @@ private:
 
     //==============================================================================
     class FontNameProperty  : public FontPropertyComponent,
-                              public ChangeListener
+    public ChangeListener
     {
     public:
         FontNameProperty (Label* const label_, JucerDocument& doc)
-            : FontPropertyComponent ("font"),
-              label (label_),
-              document (doc)
+        : FontPropertyComponent ("font"),
+        label (label_),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -471,8 +471,8 @@ private:
         {
         public:
             FontNameChangeAction (Label* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getProperties().getWithDefault ("typefaceName", FontPropertyComponent::getDefaultFont());
             }
@@ -501,13 +501,13 @@ private:
 
     //==============================================================================
     class FontSizeProperty  : public SliderPropertyComponent,
-                              public ChangeListener
+    public ChangeListener
     {
     public:
         FontSizeProperty (Label* const label_, JucerDocument& doc)
-            : SliderPropertyComponent ("size", 1.0, 250.0, 0.1, 0.3),
-              label (label_),
-              document (doc)
+        : SliderPropertyComponent ("size", 1.0, 250.0, 0.1, 0.3),
+        label (label_),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -540,8 +540,8 @@ private:
         {
         public:
             FontSizeChangeAction (Label* const comp, ComponentLayout& l, const float newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getFont().getHeight();
             }
@@ -572,13 +572,13 @@ private:
 
     //==============================================================================
     class FontStyleProperty  : public ChoicePropertyComponent,
-                               public ChangeListener
+    public ChangeListener
     {
     public:
         FontStyleProperty (Label* const label_, JucerDocument& doc)
-            : ChoicePropertyComponent ("style"),
-              label (label_),
-              document (doc)
+        : ChoicePropertyComponent ("style"),
+        label (label_),
+        document (doc)
         {
             document.addChangeListener (this);
 
@@ -666,8 +666,8 @@ private:
         {
         public:
             FontStyleChangeAction (Label* const comp, ComponentLayout& l, const Font& newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getFont();
             }
@@ -694,13 +694,13 @@ private:
 
     //==============================================================================
     class FontKerningProperty  : public SliderPropertyComponent,
-                                 public ChangeListener
+    public ChangeListener
     {
     public:
         FontKerningProperty (Label* const label_, JucerDocument& doc)
-            : SliderPropertyComponent ("kerning", -0.5, 0.5, 0.001),
-              label (label_),
-              document (doc)
+        : SliderPropertyComponent ("kerning", -0.5, 0.5, 0.001),
+        label (label_),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -736,8 +736,8 @@ private:
         {
         public:
             FontKerningChangeAction (Label* const comp, ComponentLayout& l, const float newState_)
-                : ComponentUndoableAction <Label> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Label> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getFont().getExtraKerningFactor();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
@@ -169,9 +169,12 @@ public:
         }
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Label* const l = dynamic_cast<Label*> (component);
         props.add (new LabelTextProperty          (l, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
@@ -172,9 +172,12 @@ struct SliderHandler  : public ComponentTypeHandler
         }
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props) override
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected) override
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Slider* s = dynamic_cast<Slider*> (component);
         jassert (s != 0);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 static const Slider::SliderStyle sliderStyleTypes[] =
 {
@@ -54,7 +54,7 @@ static const Slider::TextEntryBoxPosition sliderTextBoxPositions[] =
 struct SliderHandler  : public ComponentTypeHandler
 {
     SliderHandler()
-        : ComponentTypeHandler ("Slider", "Slider", typeid (Slider), 150, 24)
+    : ComponentTypeHandler ("Slider", "Slider", typeid (Slider), 150, 24)
     {
         registerColour (Slider::backgroundColourId, "background", "bkgcol");
         registerColour (Slider::thumbColourId, "thumb", "thumbcol");
@@ -129,15 +129,15 @@ struct SliderHandler  : public ComponentTypeHandler
 
         String r;
         r << memberVariableName << "->setRange ("
-          << s->getMinimum() << ", " << s->getMaximum() << ", " << s->getInterval()
-          << ");\n"
-          << memberVariableName << "->setSliderStyle (Slider::"
-          << sliderStyleToString (s->getSliderStyle()) << ");\n"
-          << memberVariableName << "->setTextBoxStyle (Slider::"
-          << textBoxPosToString (s->getTextBoxPosition())
-          << ", " << CodeHelpers::boolLiteral (! s->isTextBoxEditable())
-          << ", " << s->getTextBoxWidth() << ", " << s->getTextBoxHeight() << ");\n"
-          << getColourIntialisationCode (component, memberVariableName);
+        << s->getMinimum() << ", " << s->getMaximum() << ", " << s->getInterval()
+        << ");\n"
+        << memberVariableName << "->setSliderStyle (Slider::"
+        << sliderStyleToString (s->getSliderStyle()) << ");\n"
+        << memberVariableName << "->setTextBoxStyle (Slider::"
+        << textBoxPosToString (s->getTextBoxPosition())
+        << ", " << CodeHelpers::boolLiteral (! s->isTextBoxEditable())
+        << ", " << s->getTextBoxWidth() << ", " << s->getTextBoxHeight() << ");\n"
+        << getColourIntialisationCode (component, memberVariableName);
 
         if (needsSliderListener (component))
             r << memberVariableName << "->addListener (this);\n";
@@ -167,8 +167,8 @@ struct SliderHandler  : public ComponentTypeHandler
             const String userCodeComment ("UserSliderCode_" + memberVariableName);
 
             callback
-                << "if (sliderThatWasMoved == " << memberVariableName
-                << ")\n{\n    //[" << userCodeComment << "] -- add your slider handling code here..\n    //[/" << userCodeComment << "]\n}\n";
+            << "if (sliderThatWasMoved == " << memberVariableName
+            << ")\n{\n    //[" << userCodeComment << "] -- add your slider handling code here..\n    //[/" << userCodeComment << "]\n}\n";
         }
     }
 
@@ -211,7 +211,7 @@ private:
     struct SliderTypeProperty  : public ComponentChoiceProperty<Slider>
     {
         SliderTypeProperty (Slider* slider, JucerDocument& doc)
-            : ComponentChoiceProperty<Slider> ("type", slider, doc)
+        : ComponentChoiceProperty<Slider> ("type", slider, doc)
         {
             choices.add ("Linear Horizontal");
             choices.add ("Linear Vertical");
@@ -249,8 +249,8 @@ private:
         struct SliderTypeChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderTypeChangeAction (Slider* comp, ComponentLayout& l, Slider::SliderStyle newState_)
-                : ComponentUndoableAction<Slider> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<Slider> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getSliderStyle();
             }
@@ -279,7 +279,7 @@ private:
     struct SliderTextboxProperty  : public ComponentChoiceProperty<Slider>
     {
         SliderTextboxProperty (Slider* slider, JucerDocument& doc)
-            : ComponentChoiceProperty<Slider> ("text position", slider, doc)
+        : ComponentChoiceProperty<Slider> ("text position", slider, doc)
         {
             choices.add ("No text box");
             choices.add ("Text box on left");
@@ -309,8 +309,8 @@ private:
         struct SliderTextBoxChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderTextBoxChangeAction (Slider* comp, ComponentLayout& l, Slider::TextEntryBoxPosition newState_)
-                : ComponentUndoableAction<Slider> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<Slider> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getTextBoxPosition();
             }
@@ -345,7 +345,7 @@ private:
     struct SliderTextboxEditableProperty  : public ComponentBooleanProperty<Slider>
     {
         SliderTextboxEditableProperty (Slider* slider, JucerDocument& doc)
-            : ComponentBooleanProperty<Slider> ("text box mode", "Editable", "Editable", slider, doc)
+        : ComponentBooleanProperty<Slider> ("text box mode", "Editable", "Editable", slider, doc)
         {
         }
 
@@ -364,8 +364,8 @@ private:
         struct SliderEditableChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderEditableChangeAction (Slider* const comp, ComponentLayout& l, bool newState_)
-                : ComponentUndoableAction<Slider> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<Slider> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isTextBoxEditable();
             }
@@ -394,8 +394,8 @@ private:
     struct SliderCallbackProperty  : public ComponentBooleanProperty<Slider>
     {
         SliderCallbackProperty (Slider* s, JucerDocument& doc)
-            : ComponentBooleanProperty<Slider> ("callback", "Generate SliderListener",
-                                                "Generate SliderListener", s, doc)
+        : ComponentBooleanProperty<Slider> ("callback", "Generate SliderListener",
+                                            "Generate SliderListener", s, doc)
         {
         }
 
@@ -410,8 +410,8 @@ private:
         struct SliderCallbackChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderCallbackChangeAction (Slider* comp, ComponentLayout& l, bool newState_)
-                : ComponentUndoableAction<Slider> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<Slider> (comp, l),
+            newState (newState_)
             {
                 oldState = needsSliderListener (comp);
             }
@@ -440,9 +440,9 @@ private:
     struct SliderTextboxSizeProperty  : public ComponentTextProperty<Slider>
     {
         SliderTextboxSizeProperty (Slider* slider, JucerDocument& doc, bool isWidth_)
-            : ComponentTextProperty<Slider> (isWidth_ ? "text box width" : "text box height",
-                                             12, false, slider, doc),
-              isWidth (isWidth_)
+        : ComponentTextProperty<Slider> (isWidth_ ? "text box width" : "text box height",
+                                         12, false, slider, doc),
+        isWidth (isWidth_)
         {
         }
 
@@ -455,7 +455,7 @@ private:
         String getText() const override
         {
             return String (isWidth ? component->getTextBoxWidth()
-                                   : component->getTextBoxHeight());
+                           : component->getTextBoxHeight());
         }
 
     private:
@@ -464,12 +464,12 @@ private:
         struct SliderBoxSizeChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderBoxSizeChangeAction (Slider* const comp, ComponentLayout& l, bool isWidth_, int newSize_)
-                : ComponentUndoableAction<Slider> (comp, l),
-                  isWidth (isWidth_),
-                  newSize (newSize_)
+            : ComponentUndoableAction<Slider> (comp, l),
+            isWidth (isWidth_),
+            newSize (newSize_)
             {
                 oldSize = isWidth ? comp->getTextBoxWidth()
-                                  : comp->getTextBoxHeight();
+                : comp->getTextBoxHeight();
             }
 
             bool perform() override
@@ -520,8 +520,8 @@ private:
     {
         SliderRangeProperty (Slider* slider, JucerDocument& doc,
                              const String& name, int rangeParam_)
-            : ComponentTextProperty<Slider> (name, 15, false, slider, doc),
-              rangeParam (rangeParam_)
+        : ComponentTextProperty<Slider> (name, 15, false, slider, doc),
+        rangeParam (rangeParam_)
         {
         }
 
@@ -560,7 +560,7 @@ private:
         struct SliderRangeChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderRangeChangeAction (Slider* comp, ComponentLayout& l, const double newState_[3])
-                : ComponentUndoableAction<Slider> (comp, l)
+            : ComponentUndoableAction<Slider> (comp, l)
             {
                 newState[0] = newState_ [0];
                 newState[1] = newState_ [1];
@@ -595,7 +595,7 @@ private:
     struct SliderSkewProperty  : public ComponentTextProperty<Slider>
     {
         SliderSkewProperty (Slider* slider, JucerDocument& doc)
-            : ComponentTextProperty<Slider> ("skew factor", 12, false, slider, doc)
+        : ComponentTextProperty<Slider> ("skew factor", 12, false, slider, doc)
         {
         }
 
@@ -618,7 +618,7 @@ private:
         struct SliderSkewChangeAction  : public ComponentUndoableAction<Slider>
         {
             SliderSkewChangeAction (Slider* comp, ComponentLayout& l, double newValue_)
-                : ComponentUndoableAction<Slider> (comp, l)
+            : ComponentUndoableAction<Slider> (comp, l)
             {
                 newValue = newValue_;
                 oldValue = comp->getSkewFactor();

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class TabbedComponentHandler  : public ComponentTypeHandler
 {
 public:
     TabbedComponentHandler()
-        : ComponentTypeHandler ("Tabbed Component", "TabbedComponent", typeid (TabbedComponent), 200, 150)
+    : ComponentTypeHandler ("Tabbed Component", "TabbedComponent", typeid (TabbedComponent), 200, 150)
     {}
 
     Component* createNewComponent (JucerDocument*)
@@ -162,7 +162,7 @@ public:
         ComponentTypeHandler::fillInCreationCode (code, component, memberVariableName);
 
         code.constructorCode
-            << memberVariableName << "->setTabBarDepth (" << t->getTabBarDepth() << ");\n";
+        << memberVariableName << "->setTabBarDepth (" << t->getTabBarDepth() << ");\n";
 
         for (int i = 0; i < t->getNumTabs(); ++i)
         {
@@ -186,11 +186,11 @@ public:
             }
 
             code.constructorCode
-                << memberVariableName
-                << "->addTab ("
-                << quotedString (t->getTabNames() [i], code.shouldUseTransMacro())
-                << ", "
-                << CodeHelpers::colourToCode (t->getTabBackgroundColour (i));
+            << memberVariableName
+            << "->addTab ("
+            << quotedString (t->getTabNames() [i], code.shouldUseTransMacro())
+            << ", "
+            << CodeHelpers::colourToCode (t->getTabBackgroundColour (i));
 
             if (contentClassName.isNotEmpty())
             {
@@ -208,7 +208,7 @@ public:
         }
 
         code.constructorCode
-            << memberVariableName << "->setCurrentTabIndex (" << t->getCurrentTabIndex() << ");\n";
+        << memberVariableName << "->setCurrentTabIndex (" << t->getCurrentTabIndex() << ");\n";
 
         code.constructorCode << "\n";
     }
@@ -341,7 +341,7 @@ private:
     {
     public:
         TabDemoContentComp()
-            : isUsingJucerComp (false)
+        : isUsingJucerComp (false)
         {
             setSize (2048, 2048);
         }
@@ -404,7 +404,7 @@ private:
     {
     public:
         TabOrientationProperty (TabbedComponent* comp, JucerDocument& doc)
-            : ComponentChoiceProperty<TabbedComponent> ("tab position", comp, doc)
+        : ComponentChoiceProperty<TabbedComponent> ("tab position", comp, doc)
         {
             choices.add ("Tabs at top");
             choices.add ("Tabs at bottom");
@@ -415,9 +415,9 @@ private:
         void setIndex (int newIndex)
         {
             const TabbedButtonBar::Orientation orientations[] = { TabbedButtonBar::TabsAtTop,
-                                                                  TabbedButtonBar::TabsAtBottom,
-                                                                  TabbedButtonBar::TabsAtLeft,
-                                                                  TabbedButtonBar::TabsAtRight };
+                TabbedButtonBar::TabsAtBottom,
+                TabbedButtonBar::TabsAtLeft,
+                TabbedButtonBar::TabsAtRight };
 
             document.perform (new TabOrienationChangeAction (component, *document.getComponentLayout(), orientations [newIndex]),
                               "Change TabComponent orientation");
@@ -442,8 +442,8 @@ private:
         {
         public:
             TabOrienationChangeAction (TabbedComponent* const comp, ComponentLayout& l, const TabbedButtonBar::Orientation newState_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getOrientation();
             }
@@ -473,7 +473,7 @@ private:
     {
     public:
         TabInitialTabProperty (TabbedComponent* comp, JucerDocument& doc)
-            : ComponentChoiceProperty<TabbedComponent> ("initial tab", comp, doc)
+        : ComponentChoiceProperty<TabbedComponent> ("initial tab", comp, doc)
         {
             for (int i = 0; i < comp->getNumTabs(); ++i)
                 choices.add ("Tab " + String (i) + ": \"" + comp->getTabNames() [i] + "\"");
@@ -495,8 +495,8 @@ private:
         {
         public:
             InitialTabChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            newValue (newValue_)
             {
                 oldValue = comp->getCurrentTabIndex();
             }
@@ -524,13 +524,13 @@ private:
 
     //==============================================================================
     class TabDepthProperty  : public SliderPropertyComponent,
-                              public ChangeListener
+    public ChangeListener
     {
     public:
         TabDepthProperty (TabbedComponent* comp, JucerDocument& doc)
-            : SliderPropertyComponent ("tab depth", 10.0, 80.0, 1.0, 1.0),
-              component (comp),
-              document (doc)
+        : SliderPropertyComponent ("tab depth", 10.0, 80.0, 1.0, 1.0),
+        component (comp),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -566,8 +566,8 @@ private:
         {
         public:
             TabDepthChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int newState_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getTabBarDepth();
             }
@@ -597,9 +597,9 @@ private:
     {
     public:
         TabAddTabProperty (TabbedComponent* comp, JucerDocument& doc)
-            : ButtonPropertyComponent ("add tab", false),
-              component (comp),
-              document (doc)
+        : ButtonPropertyComponent ("add tab", false),
+        component (comp),
+        document (doc)
         {
         }
 
@@ -622,7 +622,7 @@ private:
         {
         public:
             AddTabAction (TabbedComponent* const comp, ComponentLayout& l)
-                : ComponentUndoableAction<TabbedComponent> (comp, l)
+            : ComponentUndoableAction<TabbedComponent> (comp, l)
             {
             }
 
@@ -651,9 +651,9 @@ private:
     {
     public:
         TabRemoveTabProperty (TabbedComponent* comp, JucerDocument& doc)
-            : ButtonPropertyComponent ("remove tab", true),
-              component (comp),
-              document (doc)
+        : ButtonPropertyComponent ("remove tab", true),
+        component (comp),
+        document (doc)
         {
         }
 
@@ -664,7 +664,7 @@ private:
             PopupMenu m;
             for (int i = 0; i < component->getNumTabs(); ++i)
                 m.addItem (i + 1, "Delete tab " + String (i)
-                                    + ": \"" + names[i] + "\"");
+                           + ": \"" + names[i] + "\"");
 
             const int r = m.showAt (this);
 
@@ -688,8 +688,8 @@ private:
         {
         public:
             RemoveTabAction (TabbedComponent* const comp, ComponentLayout& l, int indexToRemove_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  indexToRemove (indexToRemove_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            indexToRemove (indexToRemove_)
             {
                 previousState = getTabState (comp, indexToRemove);
             }
@@ -725,8 +725,8 @@ private:
     {
     public:
         TabNameProperty (TabbedComponent* comp, JucerDocument& doc, const int tabIndex_)
-            : ComponentTextProperty<TabbedComponent> ("name", 200, false, comp, doc),
-              tabIndex (tabIndex_)
+        : ComponentTextProperty<TabbedComponent> ("name", 200, false, comp, doc),
+        tabIndex (tabIndex_)
         {
         }
 
@@ -748,9 +748,9 @@ private:
         {
         public:
             TabNameChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int tabIndex_, const String& newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newValue (newValue_)
             {
                 oldValue = comp->getTabNames() [tabIndex];
             }
@@ -779,14 +779,14 @@ private:
 
     //==============================================================================
     class TabColourProperty  : public JucerColourPropertyComponent,
-                               private ChangeListener
+    private ChangeListener
     {
     public:
         TabColourProperty (TabbedComponent* comp, JucerDocument& doc, const int tabIndex_)
-            : JucerColourPropertyComponent ("colour", false),
-              component (comp),
-              document (doc),
-              tabIndex (tabIndex_)
+        : JucerColourPropertyComponent ("colour", false),
+        component (comp),
+        document (doc),
+        tabIndex (tabIndex_)
         {
             document.addChangeListener (this);
         }
@@ -826,9 +826,9 @@ private:
         public:
             TabColourChangeAction (TabbedComponent* comp, ComponentLayout& l,
                                    int tabIndex_, Colour newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newValue (newValue_)
             {
                 oldValue = comp->getTabBackgroundColour (tabIndex);
             }
@@ -860,8 +860,8 @@ private:
     {
     public:
         TabContentTypeProperty (TabbedComponent* comp, JucerDocument& doc, const int tabIndex_)
-            : ComponentChoiceProperty<TabbedComponent> ("content type", comp, doc),
-              tabIndex (tabIndex_)
+        : ComponentChoiceProperty<TabbedComponent> ("content type", comp, doc),
+        tabIndex (tabIndex_)
         {
             choices.add ("Jucer content component");
             choices.add ("Named content component");
@@ -885,9 +885,9 @@ private:
         {
         public:
             TabContentTypeChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int tabIndex_, const bool newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newValue (newValue_)
             {
                 oldValue = isTabUsingJucerComp (comp, tabIndex);
             }
@@ -918,14 +918,14 @@ private:
 
     //==============================================================================
     class TabJucerFileProperty   : public FilePropertyComponent,
-                                   public ChangeListener
+    public ChangeListener
     {
     public:
         TabJucerFileProperty (TabbedComponent* const comp, JucerDocument& doc, const int tabIndex_)
-            : FilePropertyComponent ("jucer file", false, true),
-              component (comp),
-              document (doc),
-              tabIndex (tabIndex_)
+        : FilePropertyComponent ("jucer file", false, true),
+        component (comp),
+        document (doc),
+        tabIndex (tabIndex_)
         {
             document.addChangeListener (this);
         }
@@ -940,7 +940,7 @@ private:
         {
             document.perform (new JucerCompFileChangeAction (component, *document.getComponentLayout(), tabIndex,
                                                              newFile.getRelativePathFrom (document.getCppFile().getParentDirectory())
-                                                                    .replaceCharacter ('\\', '/')),
+                                                             .replaceCharacter ('\\', '/')),
                               "Change tab component file");
         }
 
@@ -960,9 +960,9 @@ private:
         {
         public:
             JucerCompFileChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int tabIndex_, const String& newState_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newState (newState_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newState (newState_)
             {
                 oldState = getTabJucerFile (comp, tabIndex);
             }
@@ -993,8 +993,8 @@ private:
     {
     public:
         TabContentClassProperty (TabbedComponent* comp, JucerDocument& doc, const int tabIndex_)
-            : ComponentTextProperty<TabbedComponent> ("content class", 256, false, comp, doc),
-              tabIndex (tabIndex_)
+        : ComponentTextProperty<TabbedComponent> ("content class", 256, false, comp, doc),
+        tabIndex (tabIndex_)
         {
         }
 
@@ -1016,9 +1016,9 @@ private:
         {
         public:
             TabClassNameChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int tabIndex_, const String& newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newValue (newValue_)
             {
                 oldValue = getTabClassName (comp, tabIndex);
             }
@@ -1051,8 +1051,8 @@ private:
     {
     public:
         TabContentConstructorParamsProperty (TabbedComponent* comp, JucerDocument& doc, const int tabIndex_)
-            : ComponentTextProperty<TabbedComponent> ("constructor params", 512, false, comp, doc),
-              tabIndex (tabIndex_)
+        : ComponentTextProperty<TabbedComponent> ("constructor params", 512, false, comp, doc),
+        tabIndex (tabIndex_)
         {
         }
 
@@ -1074,9 +1074,9 @@ private:
         {
         public:
             TabConstructorParamChangeAction (TabbedComponent* const comp, ComponentLayout& l, const int tabIndex_, const String& newValue_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  tabIndex (tabIndex_),
-                  newValue (newValue_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            tabIndex (tabIndex_),
+            newValue (newValue_)
             {
                 oldValue = getTabConstructorParams (comp, tabIndex);
             }
@@ -1110,11 +1110,11 @@ private:
     public:
         TabMoveProperty (TabbedComponent* comp, JucerDocument& doc,
                          const int tabIndex_, const int totalNumTabs_)
-            : ButtonPropertyComponent ("move tab", false),
-              component (comp),
-              document (doc),
-              tabIndex (tabIndex_),
-              totalNumTabs (totalNumTabs_)
+        : ButtonPropertyComponent ("move tab", false),
+        component (comp),
+        document (doc),
+        tabIndex (tabIndex_),
+        totalNumTabs (totalNumTabs_)
         {
 
         }
@@ -1147,9 +1147,9 @@ private:
         public:
             MoveTabAction (TabbedComponent* const comp, ComponentLayout& l,
                            const int oldIndex_, const int newIndex_)
-                : ComponentUndoableAction<TabbedComponent> (comp, l),
-                  oldIndex (oldIndex_),
-                  newIndex (newIndex_)
+            : ComponentUndoableAction<TabbedComponent> (comp, l),
+            oldIndex (oldIndex_),
+            newIndex (newIndex_)
             {
             }
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
@@ -90,9 +90,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& doc, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& doc, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, doc, props);
+        ComponentTypeHandler::getEditableProperties (component, doc, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         TabbedComponent* const t = dynamic_cast<TabbedComponent*> (component);
 
@@ -108,9 +111,9 @@ public:
             props.add (new TabRemoveTabProperty (t, doc));
     }
 
-    void addPropertiesToPropertyPanel (Component* comp, JucerDocument& doc, PropertyPanel& panel)
+    void addPropertiesToPropertyPanel (Component* comp, JucerDocument& doc, PropertyPanel& panel, bool multipleSelected)
     {
-        ComponentTypeHandler::addPropertiesToPropertyPanel (comp, doc, panel);
+        ComponentTypeHandler::addPropertiesToPropertyPanel(comp, doc, panel, multipleSelected);
 
         TabbedComponent* const t = dynamic_cast<TabbedComponent*> (comp);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
@@ -41,9 +41,13 @@ public:
         return new TextButton ("new button", String());
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         addColourProperties (component, document, props);
     }
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class TextButtonHandler  : public ButtonHandler
 {
 public:
     TextButtonHandler()
-        : ButtonHandler ("Text Button", "TextButton", typeid (TextButton), 150, 24)
+    : ButtonHandler ("Text Button", "TextButton", typeid (TextButton), 150, 24)
     {
         registerColour (TextButton::buttonColourId, "background (normal)", "bgColOff");
         registerColour (TextButton::buttonOnColourId, "background (on)", "bgColOn");
@@ -68,7 +68,7 @@ public:
         String s;
 
         s << getColourIntialisationCode (component, memberVariableName)
-          << '\n';
+        << '\n';
 
         code.constructorCode += s;
     }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class TextEditorHandler  : public ComponentTypeHandler
 {
 public:
     TextEditorHandler()
-        : ComponentTypeHandler ("Text Editor", "TextEditor", typeid (TextEditor), 150, 24)
+    : ComponentTypeHandler ("Text Editor", "TextEditor", typeid (TextEditor), 150, 24)
     {
         registerColour (TextEditor::textColourId, "text", "textcol");
         registerColour (TextEditor::backgroundColourId, "background", "bkgcol");
@@ -116,13 +116,13 @@ public:
 
         String s;
         s << memberVariableName << "->setMultiLine (" << CodeHelpers::boolLiteral (te->isMultiLine()) << ");\n"
-          << memberVariableName << "->setReturnKeyStartsNewLine (" << CodeHelpers::boolLiteral (te->getReturnKeyStartsNewLine()) << ");\n"
-          << memberVariableName << "->setReadOnly (" << CodeHelpers::boolLiteral (te->isReadOnly()) << ");\n"
-          << memberVariableName << "->setScrollbarsShown (" << CodeHelpers::boolLiteral (te->areScrollbarsShown()) << ");\n"
-          << memberVariableName << "->setCaretVisible (" << CodeHelpers::boolLiteral (te->isCaretVisible()) << ");\n"
-          << memberVariableName << "->setPopupMenuEnabled (" << CodeHelpers::boolLiteral (te->isPopupMenuEnabled()) << ");\n"
-          << getColourIntialisationCode (component, memberVariableName)
-          << memberVariableName << "->setText (" << quotedString (te->getProperties() ["initialText"].toString(), code.shouldUseTransMacro()) << ");\n\n";
+        << memberVariableName << "->setReturnKeyStartsNewLine (" << CodeHelpers::boolLiteral (te->getReturnKeyStartsNewLine()) << ");\n"
+        << memberVariableName << "->setReadOnly (" << CodeHelpers::boolLiteral (te->isReadOnly()) << ");\n"
+        << memberVariableName << "->setScrollbarsShown (" << CodeHelpers::boolLiteral (te->areScrollbarsShown()) << ");\n"
+        << memberVariableName << "->setCaretVisible (" << CodeHelpers::boolLiteral (te->isCaretVisible()) << ");\n"
+        << memberVariableName << "->setPopupMenuEnabled (" << CodeHelpers::boolLiteral (te->isPopupMenuEnabled()) << ");\n"
+        << getColourIntialisationCode (component, memberVariableName)
+        << memberVariableName << "->setText (" << quotedString (te->getProperties() ["initialText"].toString(), code.shouldUseTransMacro()) << ");\n\n";
 
         code.constructorCode += s;
     }
@@ -133,7 +133,7 @@ private:
     {
     public:
         TextEditorMultiLineProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentChoiceProperty <TextEditor> ("mode", comp, doc)
+        : ComponentChoiceProperty <TextEditor> ("mode", comp, doc)
         {
             choices.add ("single line");
             choices.add ("multi-line, return key starts new line");
@@ -156,8 +156,8 @@ private:
         {
         public:
             TextEditorMultilineChangeAction (TextEditor* const comp, ComponentLayout& l, const int newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isMultiLine() ? (comp->getReturnKeyStartsNewLine() ? 1 : 2) : 0;
             }
@@ -189,7 +189,7 @@ private:
     {
     public:
         TextEditorReadOnlyProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <TextEditor> ("editable", "Editable", "Editable", comp, doc)
+        : ComponentBooleanProperty <TextEditor> ("editable", "Editable", "Editable", comp, doc)
         {
         }
 
@@ -206,8 +206,8 @@ private:
         {
         public:
             TextEditorReadonlyChangeAction (TextEditor* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isReadOnly();
             }
@@ -237,7 +237,7 @@ private:
     {
     public:
         TextEditorScrollbarsProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <TextEditor> ("scrollbars", "Scrollbars enabled", "Scrollbars enabled", comp, doc)
+        : ComponentBooleanProperty <TextEditor> ("scrollbars", "Scrollbars enabled", "Scrollbars enabled", comp, doc)
         {
         }
 
@@ -254,8 +254,8 @@ private:
         {
         public:
             TextEditorScrollbarChangeAction (TextEditor* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->areScrollbarsShown();
             }
@@ -285,7 +285,7 @@ private:
     {
     public:
         TextEditorCaretProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <TextEditor> ("caret", "Caret visible", "Caret visible", comp, doc)
+        : ComponentBooleanProperty <TextEditor> ("caret", "Caret visible", "Caret visible", comp, doc)
         {
         }
 
@@ -302,8 +302,8 @@ private:
         {
         public:
             TextEditorCaretChangeAction (TextEditor* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isCaretVisible();
             }
@@ -333,7 +333,7 @@ private:
     {
     public:
         TextEditorPopupMenuProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <TextEditor> ("popup menu", "Popup menu enabled", "Popup menu enabled", comp, doc)
+        : ComponentBooleanProperty <TextEditor> ("popup menu", "Popup menu enabled", "Popup menu enabled", comp, doc)
         {
         }
 
@@ -350,8 +350,8 @@ private:
         {
         public:
             TextEditorPopupMenuChangeAction (TextEditor* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isPopupMenuEnabled();
             }
@@ -381,7 +381,7 @@ private:
     {
     public:
         TextEditorInitialTextProperty (TextEditor* comp, JucerDocument& doc)
-            : ComponentTextProperty <TextEditor> ("initial text", 10000, true, comp, doc)
+        : ComponentTextProperty <TextEditor> ("initial text", 10000, true, comp, doc)
         {}
 
         void setText (const String& newText) override
@@ -400,8 +400,8 @@ private:
         {
         public:
             TextEditorInitialTextChangeAction (TextEditor* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <TextEditor> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TextEditor> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getProperties() ["initialText"];
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
@@ -81,9 +81,13 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
 
         TextEditor* const t = dynamic_cast<TextEditor*> (component);
         jassert (t != nullptr);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
@@ -38,9 +38,12 @@ public:
         return new ToggleButton ("new toggle button");
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new ToggleButtonStateProperty ((ToggleButton*) component, document));
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class ToggleButtonHandler  : public ButtonHandler
 {
 public:
     ToggleButtonHandler()
-        : ButtonHandler ("Toggle Button", "ToggleButton", typeid (ToggleButton), 150, 24)
+    : ButtonHandler ("Toggle Button", "ToggleButton", typeid (ToggleButton), 150, 24)
     {
         registerColour (ToggleButton::textColourId, "text colour", "txtcol");
     }
@@ -83,7 +83,7 @@ public:
             s << memberVariableName << "->setToggleState (true, dontSendNotification);\n";
 
         s << getColourIntialisationCode (component, memberVariableName)
-          << '\n';
+        << '\n';
 
         code.constructorCode += s;
     }
@@ -93,7 +93,7 @@ private:
     {
     public:
         ToggleButtonStateProperty (ToggleButton* button_, JucerDocument& doc)
-            : ComponentBooleanProperty <ToggleButton> ("initial state", "on", "off", button_, doc)
+        : ComponentBooleanProperty <ToggleButton> ("initial state", "on", "off", button_, doc)
         {
         }
 
@@ -113,8 +113,8 @@ private:
         {
         public:
             ToggleStateChangeAction (ToggleButton* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <ToggleButton> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <ToggleButton> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getToggleState();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
@@ -64,9 +64,13 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         TreeView* const t = dynamic_cast<TreeView*> (component);
 
         props.add (new TreeViewRootItemProperty (t, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class TreeViewHandler  : public ComponentTypeHandler
 {
 public:
     TreeViewHandler()
-        : ComponentTypeHandler ("TreeView", "TreeView", typeid (DemoTreeView), 150, 150)
+    : ComponentTypeHandler ("TreeView", "TreeView", typeid (DemoTreeView), 150, 150)
     {
         registerColour (TreeView::backgroundColourId, "background", "backgroundColour");
         registerColour (TreeView::linesColourId, "lines", "linecol");
@@ -94,15 +94,15 @@ public:
         if (defaultTreeView.isRootItemVisible() != t->isRootItemVisible())
         {
             code.constructorCode
-                << memberVariableName << "->setRootItemVisible ("
-                << CodeHelpers::boolLiteral (t->isRootItemVisible()) << ");\n";
+            << memberVariableName << "->setRootItemVisible ("
+            << CodeHelpers::boolLiteral (t->isRootItemVisible()) << ");\n";
         }
 
         if (defaultTreeView.areItemsOpenByDefault() != t->areItemsOpenByDefault())
         {
             code.constructorCode
-                << memberVariableName << "->setDefaultOpenness ("
-                << CodeHelpers::boolLiteral (t->areItemsOpenByDefault()) << ");\n";
+            << memberVariableName << "->setDefaultOpenness ("
+            << CodeHelpers::boolLiteral (t->areItemsOpenByDefault()) << ");\n";
         }
 
         code.constructorCode << getColourIntialisationCode (component, memberVariableName);
@@ -115,7 +115,7 @@ private:
     {
     public:
         DemoTreeView()
-            : TreeView ("new treeview")
+        : TreeView ("new treeview")
         {
             setRootItem (new DemoTreeViewItem ("Demo root node", 4));
         }
@@ -130,7 +130,7 @@ private:
         {
         public:
             DemoTreeViewItem (const String& name_, const int numItems)
-                : name (name_)
+            : name (name_)
             {
                 for (int i = 0; i < numItems; ++i)
                     addSubItem (new DemoTreeViewItem ("Demo sub-node " + String (i), numItems - 1));
@@ -160,7 +160,7 @@ private:
     {
     public:
         TreeViewRootItemProperty (TreeView* comp, JucerDocument& doc)
-            : ComponentBooleanProperty <TreeView> ("show root item", "Root item visible", "Root item visible", comp, doc)
+        : ComponentBooleanProperty <TreeView> ("show root item", "Root item visible", "Root item visible", comp, doc)
         {
         }
 
@@ -180,8 +180,8 @@ private:
         {
         public:
             TreeviewRootChangeAction (TreeView* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TreeView> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TreeView> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->isRootItemVisible();
             }
@@ -211,7 +211,7 @@ private:
     {
     public:
         TreeViewRootOpennessProperty (TreeView* comp, JucerDocument& doc)
-            : ComponentChoiceProperty <TreeView> ("default openness", comp, doc)
+        : ComponentChoiceProperty <TreeView> ("default openness", comp, doc)
         {
             choices.add ("Items open by default");
             choices.add ("Items closed by default");
@@ -233,8 +233,8 @@ private:
         {
         public:
             TreeviewOpennessChangeAction (TreeView* const comp, ComponentLayout& l, const bool newState_)
-                : ComponentUndoableAction <TreeView> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <TreeView> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->areItemsOpenByDefault();
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
@@ -1,34 +1,34 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 class ViewportHandler  : public ComponentTypeHandler
 {
 public:
     ViewportHandler()
-        : ComponentTypeHandler ("Viewport", "Viewport", typeid (UpdatingViewport), 150, 150)
+    : ComponentTypeHandler ("Viewport", "Viewport", typeid (UpdatingViewport), 150, 150)
     {}
 
     Component* createNewComponent (JucerDocument*)
@@ -115,19 +115,19 @@ public:
         ComponentTypeHandler::fillInCreationCode (code, component, memberVariableName);
 
         if (defaultViewport.isVerticalScrollBarShown() != v->isVerticalScrollBarShown()
-             || defaultViewport.isHorizontalScrollBarShown() != v->isHorizontalScrollBarShown())
+            || defaultViewport.isHorizontalScrollBarShown() != v->isHorizontalScrollBarShown())
         {
             code.constructorCode
-                << memberVariableName << "->setScrollBarsShown ("
-                << CodeHelpers::boolLiteral (v->isVerticalScrollBarShown()) << ", "
-                << CodeHelpers::boolLiteral (v->isHorizontalScrollBarShown()) << ");\n";
+            << memberVariableName << "->setScrollBarsShown ("
+            << CodeHelpers::boolLiteral (v->isVerticalScrollBarShown()) << ", "
+            << CodeHelpers::boolLiteral (v->isHorizontalScrollBarShown()) << ");\n";
         }
 
         if (defaultViewport.getScrollBarThickness() != v->getScrollBarThickness())
         {
             code.constructorCode
-                << memberVariableName << "->setScrollBarThickness ("
-                << v->getScrollBarThickness() << ");\n";
+            << memberVariableName << "->setScrollBarThickness ("
+            << v->getScrollBarThickness() << ");\n";
         }
 
         if (getViewportContentType (v) != 0)
@@ -148,8 +148,8 @@ public:
                 if (doc != nullptr)
                 {
                     code.includeFilesCPP.add (doc->getHeaderFile()
-                                                .getRelativePathFrom (code.document->getCppFile().getParentDirectory())
-                                                .replaceCharacter ('\\', '/'));
+                                              .getRelativePathFrom (code.document->getCppFile().getParentDirectory())
+                                              .replaceCharacter ('\\', '/'));
 
                     classNm = doc->getClassName();
                 }
@@ -162,8 +162,8 @@ public:
             if (classNm.isNotEmpty())
             {
                 code.constructorCode
-                    << memberVariableName << "->setViewedComponent (new "
-                    << classNm;
+                << memberVariableName << "->setViewedComponent (new "
+                << classNm;
 
                 if (getViewportConstructorParams (v).trim().isNotEmpty())
                 {
@@ -259,7 +259,7 @@ private:
     {
     public:
         UpdatingViewport (const String& name)
-            : Viewport (name)
+        : Viewport (name)
         {
         }
 
@@ -291,10 +291,10 @@ private:
     {
     public:
         ViewportScrollbarShownProperty (Viewport* comp, JucerDocument& doc, const bool vertical_)
-            : ComponentBooleanProperty <Viewport> (vertical_ ? "V scrollbar" : "H scrollbar",
-                                                   "enabled", "enabled",
-                                                   comp, doc),
-               vertical (vertical_)
+        : ComponentBooleanProperty <Viewport> (vertical_ ? "V scrollbar" : "H scrollbar",
+                                               "enabled", "enabled",
+                                               comp, doc),
+        vertical (vertical_)
         {
         }
 
@@ -307,7 +307,7 @@ private:
         bool getState() const
         {
             return vertical ? component->isVerticalScrollBarShown()
-                            : component->isHorizontalScrollBarShown();
+            : component->isHorizontalScrollBarShown();
         }
 
         const bool vertical;
@@ -317,12 +317,12 @@ private:
         {
         public:
             ViewportScrollbarChangeAction (Viewport* const comp, ComponentLayout& l, const bool vertical_, const bool newState_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  vertical (vertical_),
-                  newState (newState_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            vertical (vertical_),
+            newState (newState_)
             {
                 oldState = vertical ? comp->isVerticalScrollBarShown()
-                                    : comp->isHorizontalScrollBarShown();
+                : comp->isHorizontalScrollBarShown();
             }
 
             bool perform()
@@ -355,13 +355,13 @@ private:
 
     //==============================================================================
     class ViewportScrollbarSizeProperty  : public SliderPropertyComponent,
-                                           public ChangeListener
+    public ChangeListener
     {
     public:
         ViewportScrollbarSizeProperty (Viewport* comp, JucerDocument& doc)
-            : SliderPropertyComponent ("scrollbar size", 3.0, 30.0, 1.0, 1.0),
-              component (comp),
-              document (doc)
+        : SliderPropertyComponent ("scrollbar size", 3.0, 30.0, 1.0, 1.0),
+        component (comp),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -397,8 +397,8 @@ private:
         {
         public:
             ViewportScrollbarSizeChangeAction (Viewport* const comp, ComponentLayout& l, const int newState_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            newState (newState_)
             {
                 oldState = comp->getScrollBarThickness();
             }
@@ -428,7 +428,7 @@ private:
     {
     public:
         ViewportContentTypeProperty (Viewport* comp, JucerDocument& doc)
-            : ComponentChoiceProperty <Viewport> ("content", comp, doc)
+        : ComponentChoiceProperty <Viewport> ("content", comp, doc)
         {
             choices.add ("No content component");
             choices.add ("Jucer content component");
@@ -451,8 +451,8 @@ private:
         {
         public:
             ViewportContentTypeChangeAction (Viewport* const comp, ComponentLayout& l, const int newValue_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  newValue (newValue_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            newValue (newValue_)
             {
                 oldValue = getViewportContentType (comp);
             }
@@ -481,13 +481,13 @@ private:
 
     //==============================================================================
     class ViewportJucerFileProperty   : public FilePropertyComponent,
-                                        public ChangeListener
+    public ChangeListener
     {
     public:
         ViewportJucerFileProperty (Viewport* const comp, JucerDocument& doc)
-            : FilePropertyComponent ("Jucer file", false, true),
-              component (comp),
-              document (doc)
+        : FilePropertyComponent ("Jucer file", false, true),
+        component (comp),
+        document (doc)
         {
             document.addChangeListener (this);
         }
@@ -501,7 +501,7 @@ private:
         {
             document.perform (new JucerCompFileChangeAction (component, *document.getComponentLayout(),
                                                              newFile.getRelativePathFrom (document.getCppFile().getParentDirectory())
-                                                                    .replaceCharacter ('\\', '/')),
+                                                             .replaceCharacter ('\\', '/')),
                               "Change Projucer component file");
         }
 
@@ -528,8 +528,8 @@ private:
         {
         public:
             JucerCompFileChangeAction (Viewport* const comp, ComponentLayout& l, const String& newState_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  newState (newState_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            newState (newState_)
             {
                 oldState = getViewportJucerComponentFile (comp);
             }
@@ -559,7 +559,7 @@ private:
     {
     public:
         ViewportContentClassProperty (Viewport* comp, JucerDocument& doc)
-            : ComponentTextProperty <Viewport> ("content class", 256, false, comp, doc)
+        : ComponentTextProperty <Viewport> ("content class", 256, false, comp, doc)
         {
         }
 
@@ -579,8 +579,8 @@ private:
         {
         public:
             ViewportClassNameChangeAction (Viewport* const comp, ComponentLayout& l, const String& newValue_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  newValue (newValue_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            newValue (newValue_)
             {
                 oldValue = getViewportGenericComponentClass (comp);
             }
@@ -612,7 +612,7 @@ private:
     {
     public:
         ConstructorParamsProperty (Viewport* comp, JucerDocument& doc)
-            : ComponentTextProperty <Viewport> ("constructor params", 512, false, comp, doc)
+        : ComponentTextProperty <Viewport> ("constructor params", 512, false, comp, doc)
         {
         }
 
@@ -632,8 +632,8 @@ private:
         {
         public:
             ConstructorParamChangeAction (Viewport* const comp, ComponentLayout& l, const String& newValue_)
-                : ComponentUndoableAction <Viewport> (comp, l),
-                  newValue (newValue_)
+            : ComponentUndoableAction <Viewport> (comp, l),
+            newValue (newValue_)
             {
                 oldValue = getViewportConstructorParams (comp);
             }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
@@ -76,9 +76,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Viewport* const v = dynamic_cast<Viewport*> (component);
 

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
@@ -574,8 +574,193 @@ void ComponentLayout::setComponentPosition (Component* comp,
             changed();
         }
     }
+
 }
 
+
+
+void ComponentLayout::setComponentSingleDimension( Component* comp, const bool undoable, const double value, ComponentLayout::ComponentPositionDimension dimension) // D STENNING)
+{
+    RelativePositionedRectangle newPos = ComponentTypeHandler::getComponentPosition (comp);
+    PositionedRectangle p (newPos.rect);
+
+    switch (dimension)
+    {
+        case ComponentLayout::componentX:
+            if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                p.setX (value / 100.0);
+            else
+                p.setX (value);
+            break;
+
+        case ComponentLayout::componentY:
+            if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+                p.setY (value / 100.0);
+            else
+                p.setY (value);
+            break;
+
+        case ComponentLayout::componentWidth:
+            if (p.getWidthMode() == PositionedRectangle::proportionalSize)
+                p.setWidth (value / 100.0);
+            else
+                p.setWidth (value);
+            break;
+
+        case ComponentLayout::componentHeight:
+            if (p.getHeightMode() == PositionedRectangle::proportionalSize)
+                p.setHeight (value / 100.0);
+            else
+                p.setHeight (value);
+            break;
+
+        default:
+            jassertfalse;
+            break;
+    };
+
+    if (p != newPos.rect)
+    {
+        newPos.rect = p;
+
+        if (undoable)
+        {
+            perform (new ChangeCompPositionAction (comp, *this, newPos), "Move components");
+        }
+        else
+        {
+            ComponentTypeHandler::setComponentPosition (comp, newPos, this);
+            changed();
+        }
+    }
+}
+
+void ComponentLayout::setSingleDimension(const bool undoable,const double value ,ComponentPositionDimension dimension) // D STENNING
+{
+    for (auto c : selected)
+    {
+        setComponentSingleDimension( c,undoable, value, dimension);
+    }
+
+}
+
+void ComponentLayout::alignLeft()  // D STENNING
+{
+    ComponentPositionDimension dimension = componentX;
+    if ( components.size() > -1 )
+    {
+        Component* const comp = components[0];
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getX() * 100.0;
+        else
+            value =  p.getX();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void ComponentLayout::alignRight()
+{
+    ComponentPositionDimension dimension = componentX;
+
+    if ( selected.getNumSelected() > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        PositionedRectangle p (newPos.rect);
+
+        double rightX =  p.getX()+p.getWidth();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            rightX =  (p.getX()+p.getWidth()) * 100.0;
+
+
+
+        for (auto c : selected)
+        {
+            if (c != comp)
+            {
+                RelativePositionedRectangle compPos (ComponentTypeHandler::getComponentPosition (c));
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldW =  oldPR.getWidth();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                {
+                    oldW *=  100.0;
+                }
+
+                double value = rightX - oldW;
+
+                setComponentSingleDimension( c,true, value, dimension);
+            }
+        }
+
+    }
+
+
+}
+void ComponentLayout::alignTop()
+{
+    ComponentPositionDimension dimension = componentY;
+    if ( selected.getNumSelected()  > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getY() * 100.0;
+        else
+            value =  p.getY();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void ComponentLayout::alignBottom() // D STENNING
+{
+    ComponentPositionDimension dimension = componentY;
+
+    if ( selected.getNumSelected() > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        PositionedRectangle p (newPos.rect);
+
+        double bottomY =  p.getY()+p.getHeight();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            bottomY *= 100.0;
+
+        for (auto c : selected)
+        {
+            if (c != comp)
+            {
+                RelativePositionedRectangle compPos (ComponentTypeHandler::getComponentPosition (c));
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldH =  oldPR.getHeight();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                    oldH *=  100.0;
+
+                double value = bottomY - oldH;
+
+                setComponentSingleDimension( c,true, value, dimension);
+            }
+        }
+    }
+
+}
+
+
+//=========================================================================================
 void ComponentLayout::updateStoredComponentPosition (Component* comp, const bool undoable)
 {
     RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../jucer_Headers.h"
 #include "jucer_JucerDocument.h"
@@ -33,8 +33,8 @@
 
 //==============================================================================
 ComponentLayout::ComponentLayout()
-    : document (nullptr),
-      nextCompUID (1)
+: document (nullptr),
+nextCompUID (1)
 {
 }
 
@@ -79,9 +79,9 @@ class AddCompAction  : public UndoableAction
 {
 public:
     AddCompAction (XmlElement* const xml_, ComponentLayout& layout_)
-       : indexAdded (-1),
-         xml (xml_),
-         layout (layout_)
+    : indexAdded (-1),
+    xml (xml_),
+    layout (layout_)
     {
     }
 
@@ -126,8 +126,8 @@ class DeleteCompAction  : public ComponentUndoableAction <Component>
 {
 public:
     DeleteCompAction (Component* const comp, ComponentLayout& l)
-       : ComponentUndoableAction <Component> (comp, l),
-         oldIndex (-1)
+    : ComponentUndoableAction <Component> (comp, l),
+    oldIndex (-1)
     {
         if (ComponentTypeHandler* const h = ComponentTypeHandler::getHandlerFor (*comp))
             xml = h->createXmlFor (comp, &layout);
@@ -184,8 +184,8 @@ class FrontBackCompAction  : public ComponentUndoableAction <Component>
 {
 public:
     FrontBackCompAction (Component* const comp, ComponentLayout& l, int newIndex_)
-       : ComponentUndoableAction <Component> (comp, l),
-         newIndex (newIndex_)
+    : ComponentUndoableAction <Component> (comp, l),
+    newIndex (newIndex_)
     {
         oldIndex = l.indexOfComponent (comp);
     }
@@ -280,8 +280,8 @@ void ComponentLayout::paste()
         selected.deselectAll();
 
         forEachXmlChildElement (*doc, e)
-            if (Component* newComp = addComponentFromXml (*e, true))
-                selected.addToSelection (newComp);
+        if (Component* newComp = addComponentFromXml (*e, true))
+            selected.addToSelection (newComp);
 
         startDragging();
         dragSelectedComps (Random::getSystemRandom().nextInt (40),
@@ -305,7 +305,7 @@ void ComponentLayout::deleteSelected()
 
         if (document != nullptr)
             document->dispatchPendingMessages(); // forces the change to propagate before a paint() callback can happen,
-                                                 // in case there are components floating around that are now dangling pointers
+        // in case there are components floating around that are now dangling pointers
     }
 }
 
@@ -330,6 +330,7 @@ void ComponentLayout::selectedToBack()
     for (int i = 0; i < temp.getNumSelected(); ++i)
         componentToBack (temp.getSelectedItem(i), true);
 }
+
 
 void ComponentLayout::bringLostItemsBackOnScreen (int width, int height)
 {
@@ -382,7 +383,7 @@ Component* ComponentLayout::addComponentFromXml (const XmlElement& xml, const bo
     }
 
     if (ComponentTypeHandler* const type
-           = ComponentTypeHandler::getHandlerForXmlTag (xml.getTagName()))
+        = ComponentTypeHandler::getHandlerForXmlTag (xml.getTagName()))
     {
         ScopedPointer<Component> newComp (type->createNewComponent (getDocument()));
 
@@ -433,7 +434,7 @@ Component* ComponentLayout::getComponentRelativePosTarget (Component* comp, int 
     }
 
     return findComponentWithId (comp->getProperties() [String ("relativeTo") + dimensionSuffixes [whichDimension]]
-                                    .toString().getHexValue64());
+                                .toString().getHexValue64());
 }
 
 void ComponentLayout::setComponentRelativeTarget (Component* comp, int whichDimension, Component* compToBeRelativeTo)
@@ -446,7 +447,7 @@ void ComponentLayout::setComponentRelativeTarget (Component* comp, int whichDime
     jassert (compToBeRelativeTo == 0 || ! dependsOnComponentForRelativePos (compToBeRelativeTo, comp));
 
     if (compToBeRelativeTo != getComponentRelativePosTarget (comp, whichDimension)
-         && (compToBeRelativeTo == 0 || ! dependsOnComponentForRelativePos (compToBeRelativeTo, comp)))
+        && (compToBeRelativeTo == 0 || ! dependsOnComponentForRelativePos (compToBeRelativeTo, comp)))
     {
         const int64 compId = ComponentTypeHandler::getComponentId (compToBeRelativeTo);
 
@@ -512,7 +513,7 @@ PopupMenu ComponentLayout::getRelativeTargetMenu (Component* comp, int whichDime
         if (c != comp)
             m.addItem (menuIdBase + i + 1,
                        "Relative to " + getComponentMemberVariableName (c)
-                        + " (class: " + ComponentTypeHandler::getHandlerFor (*c)->getClassName (c) + ")",
+                       + " (class: " + ComponentTypeHandler::getHandlerFor (*c)->getClassName (c) + ")",
                        ! dependsOnComponentForRelativePos (c, comp),
                        current == c);
     }
@@ -535,8 +536,8 @@ class ChangeCompPositionAction  : public ComponentUndoableAction <Component>
 public:
     ChangeCompPositionAction (Component* const comp, ComponentLayout& l,
                               const RelativePositionedRectangle& newPos_)
-       : ComponentUndoableAction <Component> (comp, l),
-         newPos (newPos_), oldPos (ComponentTypeHandler::getComponentPosition (comp))
+    : ComponentUndoableAction <Component> (comp, l),
+    newPos (newPos_), oldPos (ComponentTypeHandler::getComponentPosition (comp))
     {
     }
 
@@ -558,10 +559,12 @@ private:
     RelativePositionedRectangle newPos, oldPos;
 };
 
+
 void ComponentLayout::setComponentPosition (Component* comp,
                                             const RelativePositionedRectangle& newPos,
                                             const bool undoable)
 {
+
     if (ComponentTypeHandler::getComponentPosition (comp) != newPos)
     {
         if (undoable)
@@ -649,7 +652,7 @@ void ComponentLayout::alignLeft()  // D STENNING
     ComponentPositionDimension dimension = componentX;
     if ( components.size() > -1 )
     {
-        Component* const comp = components[0];
+        Component* const comp =  selected.getSelectedItem(0);
         RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
         double value;
         PositionedRectangle p (newPos.rect);
@@ -782,6 +785,8 @@ void ComponentLayout::startDragging()
 
     jassert (document != nullptr);
     document->beginTransaction();
+
+
 }
 
 void ComponentLayout::dragSelectedComps (int dx, int dy, const bool allowSnap)
@@ -942,7 +947,7 @@ String ComponentLayout::getUnusedMemberName (String nameRoot, Component* comp) c
         for (int i = 0; i < components.size(); ++i)
         {
             if (components[i] != comp
-                 && components[i]->getProperties() ["memberName"] == n)
+                && components[i]->getProperties() ["memberName"] == n)
             {
                 alreadyUsed = true;
                 break;
@@ -1010,13 +1015,13 @@ void positionToCode (const RelativePositionedRectangle& position,
     String wrx, wry, wrw, wrh;
 
     if (Component* const relCompW = (layout != nullptr && position.rect.getWidthMode() != PositionedRectangle::absoluteSize)
-                                        ? layout->findComponentWithId (position.relativeToW) : nullptr)
+        ? layout->findComponentWithId (position.relativeToW) : nullptr)
         positionToCode (ComponentTypeHandler::getComponentPosition (relCompW), layout, wrx, wry, wrw, wrh);
 
     String hrx, hry, hrw, hrh;
 
     if (Component* const relCompH = (layout != nullptr && position.rect.getHeightMode() != PositionedRectangle::absoluteSize)
-                                        ? layout->findComponentWithId (position.relativeToH) : nullptr)
+        ? layout->findComponentWithId (position.relativeToH) : nullptr)
         positionToCode (ComponentTypeHandler::getComponentPosition (relCompH), layout, hrx, hry, hrw, hrh);
 
     // width

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
@@ -39,6 +39,16 @@ class JucerDocument;
 class ComponentLayout
 {
 public:
+
+    enum ComponentPositionDimension // D STENNING
+    {
+        componentX          = 0,
+        componentY          = 1,
+        componentWidth      = 2,
+        componentHeight     = 3
+    };
+
+
     //==============================================================================
     ComponentLayout();
     ~ComponentLayout();
@@ -66,6 +76,9 @@ public:
 
     void setComponentPosition (Component* comp, const RelativePositionedRectangle& newPos, const bool undoable);
     void updateStoredComponentPosition (Component* comp, const bool undoable);
+
+    void setComponentSingleDimension(Component* comp,const bool undoable, const double value , ComponentPositionDimension dim); // D STENNING)
+    void setSingleDimension( const bool undoable, const double value , ComponentPositionDimension dim); // D STENNING
 
     //==============================================================================
     Component* getComponentRelativePosTarget (Component* comp, int whichDimension) const;
@@ -95,6 +108,11 @@ public:
 
     void selectedToFront();
     void selectedToBack();
+
+    void alignLeft();  // D STENNING
+    void alignRight();
+    void alignTop();
+    void alignBottom();
 
     void startDragging();
     void dragSelectedComps (int dxFromDragStart, int dyFromDragStart, const bool allowSnap = true);

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -33,9 +33,9 @@ class JucerDocument;
 
 //==============================================================================
 /**
-    Manages the set of sub-components for a JucerDocument.
+ Manages the set of sub-components for a JucerDocument.
 
-*/
+ */
 class ComponentLayout
 {
 public:

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../jucer_Headers.h"
 #include "jucer_PaintRoutine.h"
@@ -37,8 +37,8 @@
 
 //==============================================================================
 PaintRoutine::PaintRoutine()
-    : document (nullptr),
-      backgroundColour (ProjucerApplication::getApp().lookAndFeel.findColour (backgroundColourId))
+: document (nullptr),
+backgroundColour (ProjucerApplication::getApp().lookAndFeel.findColour (backgroundColourId))
 {
     clear();
 }
@@ -46,7 +46,7 @@ PaintRoutine::PaintRoutine()
 PaintRoutine::~PaintRoutine()
 {
     elements.clear(); // do this explicitly before the scalar destructor because these
-                      // objects will be listeners on this object
+    // objects will be listeners on this object
 }
 
 //==============================================================================
@@ -86,7 +86,7 @@ class AddXmlElementAction   : public UndoableAction
 {
 public:
     AddXmlElementAction (PaintRoutine& routine_, XmlElement* xml_)
-        : routine (routine_), xml (xml_)
+    : routine (routine_), xml (xml_)
     {
     }
 
@@ -166,8 +166,8 @@ class DeleteElementAction   : public PaintElementUndoableAction <PaintElement>
 {
 public:
     DeleteElementAction (PaintElement* const element)
-        : PaintElementUndoableAction <PaintElement> (element),
-          oldIndex (-1)
+    : PaintElementUndoableAction <PaintElement> (element),
+    oldIndex (-1)
     {
         xml = element->createXml();
         oldIndex = routine.indexOfElement (element);
@@ -223,8 +223,8 @@ class FrontOrBackElementAction  : public PaintElementUndoableAction <PaintElemen
 {
 public:
     FrontOrBackElementAction (PaintElement* const element, int newIndex_)
-        : PaintElementUndoableAction <PaintElement> (element),
-          newIndex (newIndex_)
+    : PaintElementUndoableAction <PaintElement> (element),
+    newIndex (newIndex_)
     {
         oldIndex = routine.indexOfElement (element);
     }
@@ -311,8 +311,8 @@ void PaintRoutine::paste()
         selectedPoints.deselectAll();
 
         forEachXmlChildElement (*doc, e)
-            if (PaintElement* newElement = addElementFromXml (*e, -1, true))
-                selectedElements.addToSelection (newElement);
+        if (PaintElement* newElement = addElementFromXml (*e, -1, true))
+            selectedElements.addToSelection (newElement);
     }
 }
 
@@ -726,8 +726,8 @@ bool PaintRoutine::loadFromXml (const XmlElement& xml)
         clear();
 
         forEachXmlChildElement (xml, e)
-            if (auto* newElement = ObjectTypes::createElementForXml (e, this))
-                elements.add (newElement);
+        if (auto* newElement = ObjectTypes::createElementForXml (e, this))
+            elements.add (newElement);
 
         return true;
     }

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
@@ -360,6 +360,180 @@ void PaintRoutine::selectAll()
     }
 }
 
+
+void PaintRoutine::setSingleDimension(const bool undoable,const double value, ComponentLayout::ComponentPositionDimension dimension) // D STENNING
+{
+    for (auto e : selectedElements)
+    {
+        setElementSingleDimension( e,undoable, value, dimension);
+    }
+
+}
+
+void PaintRoutine::setElementSingleDimension(PaintElement* e,const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dimension)// D STENNING)
+{
+    RelativePositionedRectangle newPos = e->getPosition();
+    PositionedRectangle p (newPos.rect);
+
+    switch (dimension)
+    {
+        case ComponentLayout::componentX:
+            if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                p.setX (value / 100.0);
+            else
+                p.setX (value);
+            break;
+
+        case ComponentLayout::componentY:
+            if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+                p.setY (value / 100.0);
+            else
+                p.setY (value);
+            break;
+
+        case ComponentLayout::componentWidth:
+            if (p.getWidthMode() == PositionedRectangle::proportionalSize)
+                p.setWidth (value / 100.0);
+            else
+                p.setWidth (value);
+            break;
+
+        case ComponentLayout::componentHeight:
+            if (p.getHeightMode() == PositionedRectangle::proportionalSize)
+                p.setHeight (value / 100.0);
+            else
+                p.setHeight (value);
+            break;
+
+        default:
+            jassertfalse;
+            break;
+    };
+
+    if (p != newPos.rect)
+    {
+        newPos.rect = p;
+        e->setPosition(newPos, undoable);
+    }
+}
+
+void PaintRoutine::alignLeft()  // D STENNING
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentX;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getX() * 100.0;
+        else
+            value =  p.getX();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+
+
+void PaintRoutine::alignRight()
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentX;
+
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+
+        double rightX =  p.getX()+p.getWidth();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            rightX =  (p.getX()+p.getWidth()) * 100.0;
+
+        for (auto c : selectedElements)
+        {
+            if (c != e)
+            {
+                RelativePositionedRectangle compPos = c->getPosition();
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldW =  oldPR.getWidth();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                {
+                    oldW *=  100.0;
+                }
+
+                double value = rightX - oldW;
+
+                setElementSingleDimension( c,true, value, dimension);
+            }
+        }
+
+    }
+
+
+}
+void PaintRoutine::alignTop()
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentY;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+        double value;
+
+        if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getY() * 100.0;
+        else
+            value =  p.getY();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void PaintRoutine::alignBottom() // D STENNING
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentY;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+
+        double bottomY =  p.getY()+p.getHeight();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            bottomY *= 100.0;
+
+        for (auto c : selectedElements)
+        {
+            if (c != e)
+            {
+                RelativePositionedRectangle compPos =  c->getPosition();
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldH =  oldPR.getHeight();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                    oldH *=  100.0;
+
+                double value = bottomY - oldH;
+
+                setElementSingleDimension( c,true, value, dimension);
+            }
+        }
+    }
+
+}
+
+//=========================================================================================
+
+
 void PaintRoutine::selectedToFront()
 {
     const SelectedItemSet<PaintElement*> temp (selectedElements);

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -33,9 +33,9 @@ class PathPoint;
 
 //==============================================================================
 /**
-    Contains a set of PaintElements that constitute some kind of paint() method.
+ Contains a set of PaintElements that constitute some kind of paint() method.
 
-*/
+ */
 class PaintRoutine
 {
 public:

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
@@ -62,6 +62,16 @@ public:
     void elementToFront (PaintElement* element, const bool undoable);
     void elementToBack (PaintElement* element, const bool undoable);
 
+
+    void setSingleDimension(const bool undoable,const double value, ComponentLayout::ComponentPositionDimension dimension); // D STENNING
+    void setElementSingleDimension(PaintElement* e,const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim); // D STENNING)
+
+    void alignLeft();  // D STENNING
+    void alignRight();
+    void alignTop();
+    void alignBottom();
+
+
     const Colour getBackgroundColour() const noexcept                       { return backgroundColour; }
     void setBackgroundColour (Colour newColour) noexcept;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "jucer_ColouredElement.h"
@@ -39,8 +39,8 @@ class ElementFillModeProperty   : public ChoicePropertyComponent
 {
 public:
     ElementFillModeProperty (ColouredElement* const e, const bool isForStroke_)
-        : ChoicePropertyComponent ("fill mode"), listener (e),
-          isForStroke (isForStroke_)
+    : ChoicePropertyComponent ("fill mode"), listener (e),
+    isForStroke (isForStroke_)
     {
         listener.setPropertyToRefresh (*this);
 
@@ -53,7 +53,7 @@ public:
     void setIndex (int newIndex)
     {
         JucerFillType fill (isForStroke ? listener.owner->getStrokeType().fill
-                                        : listener.owner->getFillType());
+                            : listener.owner->getFillType());
 
         switch (newIndex)
         {
@@ -73,7 +73,7 @@ public:
     int getIndex() const
     {
         switch (isForStroke ? listener.owner->getStrokeType().fill.mode
-                            : listener.owner->getFillType().mode)
+                : listener.owner->getFillType().mode)
         {
             case JucerFillType::solidColour:    return 0;
             case JucerFillType::linearGradient: return 1;
@@ -105,10 +105,10 @@ public:
                                ColouredElement* const owner_,
                                const ColourType type_,
                                const bool isForStroke_)
-        : JucerColourPropertyComponent (name, false),
-          listener (owner_),
-          type (type_),
-          isForStroke (isForStroke_)
+    : JucerColourPropertyComponent (name, false),
+    listener (owner_),
+    type (type_),
+    isForStroke (isForStroke_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -118,7 +118,7 @@ public:
         listener.owner->getDocument()->getUndoManager().undoCurrentTransactionOnly();
 
         JucerFillType fill (isForStroke ? listener.owner->getStrokeType().fill
-                                        : listener.owner->getFillType());
+                            : listener.owner->getFillType());
 
         switch (type)
         {
@@ -137,7 +137,7 @@ public:
     Colour getColour() const override
     {
         const JucerFillType fill (isForStroke ? listener.owner->getStrokeType().fill
-                                              : listener.owner->getFillType());
+                                  : listener.owner->getFillType());
 
         switch (type)
         {
@@ -170,11 +170,11 @@ public:
                                  ComponentLayout::ComponentPositionDimension dimension_,
                                  const bool isStart_,
                                  const bool isForStroke_)
-     : PositionPropertyBase (owner_, name, dimension_, false, false,
-                             owner_->getDocument()->getComponentLayout()),
-       listener (owner_),
-       isStart (isStart_),
-       isForStroke (isForStroke_)
+    : PositionPropertyBase (owner_, name, dimension_, false, false,
+                            owner_->getDocument()->getComponentLayout()),
+    listener (owner_),
+    isStart (isStart_),
+    isForStroke (isForStroke_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -182,7 +182,7 @@ public:
     void setPosition (const RelativePositionedRectangle& newPos)
     {
         JucerFillType fill (isForStroke ? listener.owner->getStrokeType().fill
-                                        : listener.owner->getFillType());
+                            : listener.owner->getFillType());
 
         if (isStart)
             fill.gradPos1 = newPos;
@@ -207,10 +207,10 @@ public:
     RelativePositionedRectangle getPosition() const
     {
         const JucerFillType fill (isForStroke ? listener.owner->getStrokeType().fill
-                                              : listener.owner->getFillType());
+                                  : listener.owner->getFillType());
 
         return isStart ? fill.gradPos1
-                       : fill.gradPos2;
+        : fill.gradPos2;
     }
 
 private:
@@ -223,8 +223,8 @@ class EnableStrokeProperty : public BooleanPropertyComponent
 {
 public:
     EnableStrokeProperty (ColouredElement* const owner_)
-        : BooleanPropertyComponent ("outline", "Outline enabled", "No outline"),
-          listener (owner_)
+    : BooleanPropertyComponent ("outline", "Outline enabled", "No outline"),
+    listener (owner_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -241,8 +241,8 @@ class StrokeThicknessProperty   : public SliderPropertyComponent
 {
 public:
     StrokeThicknessProperty (ColouredElement* const owner_)
-        : SliderPropertyComponent ("outline thickness", 0.1, 200.0, 0.1, 0.3),
-          listener (owner_)
+    : SliderPropertyComponent ("outline thickness", 0.1, 200.0, 0.1, 0.3),
+    listener (owner_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -267,8 +267,8 @@ class StrokeJointProperty : public ChoicePropertyComponent
 {
 public:
     StrokeJointProperty (ColouredElement* const owner_)
-        : ChoicePropertyComponent ("joint style"),
-          listener (owner_)
+    : ChoicePropertyComponent ("joint style"),
+    listener (owner_)
     {
         listener.setPropertyToRefresh (*this);
 
@@ -280,8 +280,8 @@ public:
     void setIndex (int newIndex)
     {
         const PathStrokeType::JointStyle joints[] = { PathStrokeType::mitered,
-                                                      PathStrokeType::curved,
-                                                      PathStrokeType::beveled };
+            PathStrokeType::curved,
+            PathStrokeType::beveled };
 
         jassert (newIndex >= 0 && newIndex < 3);
 
@@ -312,8 +312,8 @@ class StrokeEndCapProperty   : public ChoicePropertyComponent
 {
 public:
     StrokeEndCapProperty (ColouredElement* const owner_)
-        : ChoicePropertyComponent ("end-cap style"),
-          listener (owner_)
+    : ChoicePropertyComponent ("end-cap style"),
+    listener (owner_)
     {
         listener.setPropertyToRefresh (*this);
 
@@ -325,8 +325,8 @@ public:
     void setIndex (int newIndex)
     {
         const PathStrokeType::EndCapStyle ends[] = { PathStrokeType::butt,
-                                                     PathStrokeType::square,
-                                                     PathStrokeType::rounded };
+            PathStrokeType::square,
+            PathStrokeType::rounded };
 
         jassert (newIndex >= 0 && newIndex < 3);
 
@@ -357,9 +357,9 @@ class ImageBrushResourceProperty    : public ImageResourceProperty <ColouredElem
 {
 public:
     ImageBrushResourceProperty (ColouredElement* const e, const bool isForStroke_)
-        : ImageResourceProperty <ColouredElement> (e, isForStroke_ ? "stroke image"
-                                                                   : "fill image"),
-          isForStroke (isForStroke_)
+    : ImageResourceProperty <ColouredElement> (e, isForStroke_ ? "stroke image"
+                                               : "fill image"),
+    isForStroke (isForStroke_)
     {
     }
 
@@ -408,10 +408,10 @@ public:
                                 const String& name,
                                 ComponentLayout::ComponentPositionDimension dimension_,
                                 const bool isForStroke_)
-        : PositionPropertyBase (owner_, name, dimension_, false, false,
-                                owner_->getDocument()->getComponentLayout()),
-          listener (owner_),
-          isForStroke (isForStroke_)
+    : PositionPropertyBase (owner_, name, dimension_, false, false,
+                            owner_->getDocument()->getComponentLayout()),
+    listener (owner_),
+    isForStroke (isForStroke_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -459,9 +459,9 @@ class ImageBrushOpacityProperty  : public SliderPropertyComponent
 {
 public:
     ImageBrushOpacityProperty (ColouredElement* const e, const bool isForStroke_)
-        : SliderPropertyComponent ("opacity", 0.0, 1.0, 0.001),
-          listener (e),
-          isForStroke (isForStroke_)
+    : SliderPropertyComponent ("opacity", 0.0, 1.0, 0.001),
+    listener (e),
+    isForStroke (isForStroke_)
     {
         listener.setPropertyToRefresh (*this);
     }
@@ -512,10 +512,10 @@ ColouredElement::ColouredElement (PaintRoutine* owner_,
                                   const String& name,
                                   const bool showOutline_,
                                   const bool showJointAndEnd_)
-    : PaintElement (owner_, name),
-      isStrokePresent (false),
-      showOutline (showOutline_),
-      showJointAndEnd (showJointAndEnd_)
+: PaintElement (owner_, name),
+isStrokePresent (false),
+showOutline (showOutline_),
+showJointAndEnd (showJointAndEnd_)
 {
 }
 
@@ -537,9 +537,9 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
 
     switch (getFillType().mode)
     {
-    case JucerFillType::solidColour:
-        props.add (new ElementFillColourProperty ("colour", this, ElementFillColourProperty::solidColour, false));
-        break;
+        case JucerFillType::solidColour:
+            props.add (new ElementFillColourProperty ("colour", this, ElementFillColourProperty::solidColour, false));
+            break;
 
     case JucerFillType::linearGradient:
     case JucerFillType::radialGradient:
@@ -558,9 +558,9 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
         props.add (new ImageBrushOpacityProperty (this, false));
         break;
 
-    default:
-        jassertfalse;
-        break;
+        default:
+            jassertfalse;
+            break;
     }
 
     if (showOutline)
@@ -620,8 +620,8 @@ class FillTypeChangeAction  : public PaintElementUndoableAction <ColouredElement
 {
 public:
     FillTypeChangeAction (ColouredElement* const element, const JucerFillType& newState_)
-        : PaintElementUndoableAction <ColouredElement> (element),
-          newState (newState_)
+    : PaintElementUndoableAction <ColouredElement> (element),
+    newState (newState_)
     {
         oldState = element->getFillType();
     }
@@ -679,8 +679,8 @@ class StrokeEnableChangeAction  : public PaintElementUndoableAction <ColouredEle
 {
 public:
     StrokeEnableChangeAction (ColouredElement* const element, const bool newState_)
-        : PaintElementUndoableAction <ColouredElement> (element),
-          newState (newState_)
+    : PaintElementUndoableAction <ColouredElement> (element),
+    newState (newState_)
     {
         oldState = element->isStrokeEnabled();
     }
@@ -736,9 +736,9 @@ class StrokeTypeChangeAction  : public PaintElementUndoableAction <ColouredEleme
 {
 public:
     StrokeTypeChangeAction (ColouredElement* const element, const PathStrokeType& newState_)
-        : PaintElementUndoableAction <ColouredElement> (element),
-          newState (newState_),
-          oldState (element->getStrokeType().stroke)
+    : PaintElementUndoableAction <ColouredElement> (element),
+    newState (newState_),
+    oldState (element->getStrokeType().stroke)
     {
     }
 
@@ -782,8 +782,8 @@ class StrokeFillTypeChangeAction  : public PaintElementUndoableAction <ColouredE
 {
 public:
     StrokeFillTypeChangeAction (ColouredElement* const element, const JucerFillType& newState_)
-        : PaintElementUndoableAction <ColouredElement> (element),
-          newState (newState_)
+    : PaintElementUndoableAction <ColouredElement> (element),
+    newState (newState_)
     {
         oldState = element->getStrokeType().fill;
     }
@@ -872,7 +872,7 @@ Rectangle<int> ColouredElement::getCurrentBounds (const Rectangle<int>& parentAr
         borderSize = (int) strokeType.stroke.getStrokeThickness() / 2 + 1;
 
     return position.getRectangle (parentArea, getDocument()->getComponentLayout())
-                   .expanded (borderSize);
+    .expanded (borderSize);
 }
 
 void ColouredElement::setCurrentBounds (const Rectangle<int>& newBounds,

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
@@ -167,7 +167,7 @@ class ElementFillPositionProperty   : public PositionPropertyBase
 public:
     ElementFillPositionProperty (ColouredElement* const owner_,
                                  const String& name,
-                                 ComponentPositionDimension dimension_,
+                                 ComponentLayout::ComponentPositionDimension dimension_,
                                  const bool isStart_,
                                  const bool isForStroke_)
      : PositionPropertyBase (owner_, name, dimension_, false, false,
@@ -193,6 +193,15 @@ public:
             listener.owner->setFillType (fill, true);
         else
             listener.owner->setStrokeFill (fill, true);
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -397,7 +406,7 @@ class ImageBrushPositionProperty    : public PositionPropertyBase
 public:
     ImageBrushPositionProperty (ColouredElement* const owner_,
                                 const String& name,
-                                ComponentPositionDimension dimension_,
+                                ComponentLayout::ComponentPositionDimension dimension_,
                                 const bool isForStroke_)
         : PositionPropertyBase (owner_, name, dimension_, false, false,
                                 owner_->getDocument()->getComponentLayout()),
@@ -421,6 +430,15 @@ public:
             type.imageAnchor = newPos;
             listener.owner->setFillType (type, true);
         }
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -506,10 +524,11 @@ ColouredElement::~ColouredElement()
 }
 
 //==============================================================================
-void ColouredElement::getEditableProperties (Array <PropertyComponent*>& props)
+void ColouredElement::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected) // D STENNING
 {
-    PaintElement::getEditableProperties (props);
-    getColourSpecificProperties (props);
+    PaintElement::getEditableProperties (props, multipleSelected);
+    if( !multipleSelected)
+        getColourSpecificProperties (props);
 }
 
 void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& props)
@@ -525,17 +544,17 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
     case JucerFillType::linearGradient:
     case JucerFillType::radialGradient:
         props.add (new ElementFillColourProperty ("colour 1", this, ElementFillColourProperty::gradientColour1, false));
-        props.add (new ElementFillPositionProperty (this, "x1", PositionPropertyBase::componentX, true, false));
-        props.add (new ElementFillPositionProperty (this, "y1", PositionPropertyBase::componentY, true, false));
+        props.add (new ElementFillPositionProperty (this, "x1", ComponentLayout::componentX, true, false));
+        props.add (new ElementFillPositionProperty (this, "y1", ComponentLayout::componentY, true, false));
         props.add (new ElementFillColourProperty ("colour 2", this, ElementFillColourProperty::gradientColour2, false));
-        props.add (new ElementFillPositionProperty (this, "x2", PositionPropertyBase::componentX, false, false));
-        props.add (new ElementFillPositionProperty (this, "y2", PositionPropertyBase::componentY, false, false));
+        props.add (new ElementFillPositionProperty (this, "x2", ComponentLayout::componentX, false, false));
+        props.add (new ElementFillPositionProperty (this, "y2", ComponentLayout::componentY, false, false));
         break;
 
     case JucerFillType::imageBrush:
         props.add (new ImageBrushResourceProperty (this, false));
-        props.add (new ImageBrushPositionProperty (this, "anchor x", PositionPropertyBase::componentX, false));
-        props.add (new ImageBrushPositionProperty (this, "anchor y", PositionPropertyBase::componentY, false));
+        props.add (new ImageBrushPositionProperty (this, "anchor x", ComponentLayout::componentX, false));
+        props.add (new ImageBrushPositionProperty (this, "anchor y", ComponentLayout::componentY, false));
         props.add (new ImageBrushOpacityProperty (this, false));
         break;
 
@@ -569,17 +588,17 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
                 case JucerFillType::linearGradient:
                 case JucerFillType::radialGradient:
                     props.add (new ElementFillColourProperty ("colour 1", this, ElementFillColourProperty::gradientColour1, true));
-                    props.add (new ElementFillPositionProperty (this, "x1", PositionPropertyBase::componentX, true, true));
-                    props.add (new ElementFillPositionProperty (this, "y1", PositionPropertyBase::componentY, true, true));
+                    props.add (new ElementFillPositionProperty (this, "x1", ComponentLayout::componentX, true, true)); // D STENNING
+                    props.add (new ElementFillPositionProperty (this, "y1", ComponentLayout::componentY, true, true));
                     props.add (new ElementFillColourProperty ("colour 2", this, ElementFillColourProperty::gradientColour2, true));
-                    props.add (new ElementFillPositionProperty (this, "x2", PositionPropertyBase::componentX, false, true));
-                    props.add (new ElementFillPositionProperty (this, "y2", PositionPropertyBase::componentY, false, true));
+                    props.add (new ElementFillPositionProperty (this, "x2", ComponentLayout::componentX, false, true));
+                    props.add (new ElementFillPositionProperty (this, "y2", ComponentLayout::componentY, false, true));
                     break;
 
                 case JucerFillType::imageBrush:
                     props.add (new ImageBrushResourceProperty (this, true));
-                    props.add (new ImageBrushPositionProperty (this, "stroke anchor x", PositionPropertyBase::componentX, true));
-                    props.add (new ImageBrushPositionProperty (this, "stroke anchor y", PositionPropertyBase::componentY, true));
+                    props.add (new ImageBrushPositionProperty (this, "stroke anchor x", ComponentLayout::componentX, true));
+                    props.add (new ImageBrushPositionProperty (this, "stroke anchor y", ComponentLayout::componentY, true));
                     props.add (new ImageBrushOpacityProperty (this, true));
                     break;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
@@ -47,9 +47,8 @@ public:
     ~ColouredElement();
 
     //==============================================================================
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected); //D STENNING
     void getColourSpecificProperties (Array<PropertyComponent*>& props);
-
     //==============================================================================
     const JucerFillType& getFillType() noexcept;
     void setFillType (const JucerFillType& newType, const bool undoable);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -33,9 +33,9 @@
 
 //==============================================================================
 /**
-    Base class for paint elements that have a fill colour and stroke.
+ Base class for paint elements that have a fill colour and stroke.
 
-*/
+ */
 class ColouredElement   : public PaintElement
 {
 public:

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "../../Application/jucer_Application.h"
@@ -38,12 +38,12 @@
 //==============================================================================
 PaintElement::PaintElement (PaintRoutine* owner_,
                             const String& typeName_)
-    : borderThickness (4),
-      owner (owner_),
-      typeName (typeName_),
-      selected (false),
-      dragging (false),
-      originalAspectRatio (1.0)
+: borderThickness (4),
+owner (owner_),
+typeName (typeName_),
+selected (false),
+dragging (false),
+originalAspectRatio (1.0)
 {
     setRepaintsOnMouseActivity (true);
 
@@ -95,9 +95,9 @@ class PaintElementMoveAction  : public PaintElementUndoableAction <PaintElement>
 {
 public:
     PaintElementMoveAction (PaintElement* const element, const RelativePositionedRectangle& newState_)
-        : PaintElementUndoableAction <PaintElement> (element),
-          newState (newState_),
-          oldState (element->getPosition())
+    : PaintElementUndoableAction <PaintElement> (element),
+    newState (newState_),
+    oldState (element->getPosition())
     {
     }
 
@@ -176,8 +176,8 @@ void PaintElement::updateBounds (const Rectangle<int>& parentArea)
     if (! parentArea.isEmpty())
     {
         setBounds (getCurrentBounds (parentArea)
-                        .expanded (borderThickness,
-                                   borderThickness));
+                   .expanded (borderThickness,
+                              borderThickness));
 
         for (int i = siblingComponents.size(); --i >= 0;)
             siblingComponents.getUnchecked(i)->updatePosition();
@@ -428,7 +428,7 @@ void PaintElement::applyBoundsToComponent (Component&, Rectangle<int> newBounds)
 
         if (auto* pe = dynamic_cast<PaintRoutineEditor*> (getParentComponent()))
             setCurrentBounds (newBounds.expanded (-borderThickness, -borderThickness),
-              pe->getComponentArea(), true);
+                              pe->getComponentArea(), true);
     }
 }
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
@@ -137,6 +137,17 @@ void PaintElement::setPosition (const RelativePositionedRectangle& newPosition, 
     }
 }
 
+
+void PaintElement::setSingleDimension( const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim) // D STENNING
+{
+    (void)undoable;
+    (void)value;
+    (void)dim;
+
+    JUCE_BREAK_IN_DEBUGGER;
+
+}
+
 //==============================================================================
 Rectangle<int> PaintElement::getCurrentBounds (const Rectangle<int>& parentArea) const
 {
@@ -178,7 +189,7 @@ class ElementPositionProperty   : public PositionPropertyBase
 {
 public:
     ElementPositionProperty (PaintElement* e, const String& name,
-                             ComponentPositionDimension dimension_)
+                             ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
        : PositionPropertyBase (e, name, dimension_, true, false,
                                e->getDocument()->getComponentLayout()),
          listener (e)
@@ -191,6 +202,14 @@ public:
         listener.owner->setPosition (newPos, true);
     }
 
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        JucerDocument* jd = listener.owner->getDocument();
+        jd->getPaintRoutine(0)->setSingleDimension ( undoable, value,dim );
+
+    }
+
     RelativePositionedRectangle getPosition() const
     {
         return listener.owner->getPosition();
@@ -200,12 +219,14 @@ public:
 };
 
 //==============================================================================
-void PaintElement::getEditableProperties (Array <PropertyComponent*>& props)
+void PaintElement::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new ElementPositionProperty (this, "x", PositionPropertyBase::componentX));
-    props.add (new ElementPositionProperty (this, "y", PositionPropertyBase::componentY));
-    props.add (new ElementPositionProperty (this, "width", PositionPropertyBase::componentWidth));
-    props.add (new ElementPositionProperty (this, "height", PositionPropertyBase::componentHeight));
+    (void)multipleSelected;
+
+    props.add (new ElementPositionProperty (this, "x", ComponentLayout::componentX));
+    props.add (new ElementPositionProperty (this, "y", ComponentLayout::componentY));
+    props.add (new ElementPositionProperty (this, "width", ComponentLayout::componentWidth));
+    props.add (new ElementPositionProperty (this, "height", ComponentLayout::componentHeight));
 }
 
 //==============================================================================
@@ -480,6 +501,11 @@ void PaintElement::showPopupMenu()
 
     m.addCommandItem (commandManager, JucerCommandIDs::toFront);
     m.addCommandItem (commandManager, JucerCommandIDs::toBack);
+    m.addSeparator();
+    m.addCommandItem (commandManager, JucerCommandIDs::alignTop); // D STENNING
+    m.addCommandItem (commandManager, JucerCommandIDs::alignBottom);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignLeft);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignRight);
     m.addSeparator();
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::cut);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::copy);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -38,12 +38,12 @@ class ElementSiblingComponent;
 
 //==============================================================================
 /**
-    Base class for objects that can be used in a PaintRoutine.
+ Base class for objects that can be used in a PaintRoutine.
 
-*/
+ */
 class PaintElement  : public Component,
-                      public ChangeListener,
-                      public ComponentBoundsConstrainer
+public ChangeListener,
+public ComponentBoundsConstrainer
 {
 public:
     //==============================================================================
@@ -144,8 +144,8 @@ class ElementListener   : public ChangeListener
 {
 public:
     ElementListener (ElementType* e)
-        : owner (e), broadcaster (*owner->getDocument()),
-          propToRefresh (nullptr)
+    : owner (e), broadcaster (*owner->getDocument()),
+    propToRefresh (nullptr)
     {
         broadcaster.addChangeListener (this);
     }

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
@@ -28,6 +28,8 @@
 
 #include "../jucer_GeneratedCode.h"
 #include "../ui/jucer_RelativePositionedRectangle.h"
+#include "../jucer_ComponentLayout.h" // D STENNING
+
 class FillType;
 class PaintRoutine;
 class JucerDocument;
@@ -56,6 +58,7 @@ public:
 
     const RelativePositionedRectangle& getPosition() const;
     void setPosition (const RelativePositionedRectangle& newPosition, const bool undoable);
+    void setSingleDimension( const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim); // D STENNING
 
     void updateBounds (const Rectangle<int>& activeArea);
 
@@ -69,7 +72,7 @@ public:
 
     virtual void drawExtraEditorGraphics (Graphics& g, const Rectangle<int>& relativeTo);
 
-    virtual void getEditableProperties (Array<PropertyComponent*>& props);
+    virtual void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected);
 
     virtual void showPopupMenu();
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea)
+    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea) override
     {
         fillType.setFillType (g, getDocument(), parentArea);
 
@@ -54,13 +54,13 @@ public:
         }
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props,bool multipleSelection) override // D STENNING
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelection);
         props.add (new ShapeToPathProperty (this));
     }
 
-    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
+    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) override
     {
         if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
             return;

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -35,7 +35,7 @@ class PaintElementGroup   : public PaintElement
 {
 public:
     PaintElementGroup (PaintRoutine* pr)
-        : PaintElement (pr, "Group")
+    : PaintElement (pr, "Group")
     {
     }
 
@@ -200,8 +200,8 @@ public:
         if (xml.hasTagName (getTagName()))
         {
             forEachXmlChildElement (xml, e)
-                if (PaintElement* const pe = ObjectTypes::createElementForXml (e, owner))
-                    subElements.add (pe);
+            if (PaintElement* const pe = ObjectTypes::createElementForXml (e, owner))
+                subElements.add (pe);
 
             return true;
         }
@@ -222,8 +222,8 @@ private:
     struct UngroupProperty  : public ButtonPropertyComponent
     {
         UngroupProperty (PaintElementGroup* const e)
-            : ButtonPropertyComponent ("ungroup", false),
-              element (e)
+        : ButtonPropertyComponent ("ungroup", false),
+        element (e)
         {
         }
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
@@ -168,9 +168,10 @@ public:
             subElements.getUnchecked(i)->draw (g, layout, parentArea);
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelection) // D STENNING
     {
-        props.add (new UngroupProperty (this));
+        if( !multipleSelection )
+            props.add (new UngroupProperty (this));
     }
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
@@ -83,9 +83,9 @@ public:
     }
 
     //==============================================================================
-    void getEditableProperties (Array <PropertyComponent*>& props)
+    void getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
     {
-        PaintElement::getEditableProperties (props);
+        PaintElement::getEditableProperties (props, multipleSelected);
 
         props.add (new ImageElementResourceProperty (this));
         props.add (new StretchModeProperty (this));

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
@@ -349,10 +349,13 @@ void PaintElementPath::pointListChanged()
 }
 
 //==============================================================================
-void PaintElementPath::getEditableProperties (Array <PropertyComponent*>& props)
+void PaintElementPath::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new PathWindingModeProperty (this));
-    getColourSpecificProperties (props);
+    if( !multipleSelected)
+    {
+        props.add (new PathWindingModeProperty (this));
+        getColourSpecificProperties (props);
+    }
 }
 
 //==============================================================================
@@ -1253,7 +1256,7 @@ public:
     PathPointPositionProperty (PaintElementPath* const owner_,
                                const int index_, const int pointNumber_,
                                const String& name,
-                               ComponentPositionDimension dimension_)
+                               ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
         : PositionPropertyBase (owner_, name, dimension_, false, false,
                                 owner_->getDocument()->getComponentLayout()),
           owner (owner_),
@@ -1271,6 +1274,15 @@ public:
     void setPosition (const RelativePositionedRectangle& newPos)
     {
         owner->setPoint (index, pointNumber, newPos, true);
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -1453,16 +1465,20 @@ void PathPoint::changePointType (const Path::Iterator::PathElementType newType,
     }
 }
 
-void PathPoint::getEditableProperties (Array<PropertyComponent*>& props)
+void PathPoint::getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected )  // D STENNING
 {
+
+    if ( multipleSelected) // D STENNING
+        return;
+
     const int index = owner->points.indexOf (this);
     jassert (index >= 0);
 
     switch (type)
     {
         case Path::Iterator::startNewSubPath:
-            props.add (new PathPointPositionProperty (owner, index, 0, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "x", ComponentLayout::componentX));  // D STENNING
+            props.add (new PathPointPositionProperty (owner, index, 0, "y", ComponentLayout::componentY));
 
             props.add (new PathPointClosedProperty (owner, index));
             props.add (new AddNewPointProperty (owner, index));
@@ -1470,28 +1486,28 @@ void PathPoint::getEditableProperties (Array<PropertyComponent*>& props)
 
         case Path::Iterator::lineTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 
         case Path::Iterator::quadraticTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 1, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 1, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 1, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 1, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 
         case Path::Iterator::cubicTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 2, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 2, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 2, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 2, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "jucer_PaintElementPath.h"
@@ -37,19 +37,19 @@ public:
     ChangePointAction (PathPoint* const point,
                        const int pointIndex,
                        const PathPoint& newValue_)
-        : PaintElementUndoableAction <PaintElementPath> (point->owner),
-          index (pointIndex),
-          newValue (newValue_),
-          oldValue (*point)
+    : PaintElementUndoableAction <PaintElementPath> (point->owner),
+    index (pointIndex),
+    newValue (newValue_),
+    oldValue (*point)
     {
     }
 
     ChangePointAction (PathPoint* const point,
                        const PathPoint& newValue_)
-        : PaintElementUndoableAction <PaintElementPath> (point->owner),
-          index (point->owner->indexOfPoint (point)),
-          newValue (newValue_),
-          oldValue (*point)
+    : PaintElementUndoableAction <PaintElementPath> (point->owner),
+    index (point->owner->indexOfPoint (point)),
+    newValue (newValue_),
+    oldValue (*point)
     {
     }
 
@@ -99,12 +99,12 @@ private:
 
 //==============================================================================
 class PathWindingModeProperty    : public ChoicePropertyComponent,
-                                   public ChangeListener
+public ChangeListener
 {
 public:
     PathWindingModeProperty (PaintElementPath* const owner_)
-        : ChoicePropertyComponent ("winding rule"),
-          owner (owner_)
+    : ChoicePropertyComponent ("winding rule"),
+    owner (owner_)
     {
         choices.add ("Non-zero winding");
         choices.add ("Even/odd winding");
@@ -129,8 +129,8 @@ private:
 
 //==============================================================================
 PaintElementPath::PaintElementPath (PaintRoutine* pr)
-    : ColouredElement (pr, "Path", true, true),
-      nonZeroWinding (true)
+: ColouredElement (pr, "Path", true, true),
+nonZeroWinding (true)
 {
 }
 
@@ -151,9 +151,9 @@ void PaintElementPath::setInitialBounds (int w, int h)
     int y = randomPos (h);
 
     s << "s "
-      << x << " " << y << " l "
-      << (x + 30) << " " << (y + 50) << " l "
-      << (x - 30) << " " << (y + 50) << " x";
+    << x << " " << y << " l "
+    << (x + 30) << " " << (y + 50) << " l "
+    << (x - 30) << " " << (y + 50) << " x";
 
     restorePathFromString (s);
 }
@@ -162,7 +162,7 @@ void PaintElementPath::setInitialBounds (int w, int h)
 int PaintElementPath::getBorderSize() const
 {
     return isStrokePresent ? 1 + roundFloatToInt (strokeType.stroke.getStrokeThickness())
-                           : 0;
+    : 0;
 }
 
 Rectangle<int> PaintElementPath::getCurrentBounds (const Rectangle<int>& parentArea) const
@@ -377,7 +377,7 @@ void PaintElementPath::fillInGeneratedCode (GeneratedCode& code, String& paintMe
     const ComponentLayout* layout = code.document->getComponentLayout();
 
     code.privateMemberDeclarations
-        << "Path " << pathVariable << ";\n";
+    << "Path " << pathVariable << ";\n";
 
     String r;
     bool somePointsAreRelative = false;
@@ -389,41 +389,41 @@ void PaintElementPath::fillInGeneratedCode (GeneratedCode& code, String& paintMe
     {
         switch (p->type)
         {
-        case Path::Iterator::startNewSubPath:
-            r << pathVariable << ".startNewSubPath (" << positionToPairOfValues (p->pos[0], layout) << ");\n";
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
-            break;
+            case Path::Iterator::startNewSubPath:
+                r << pathVariable << ".startNewSubPath (" << positionToPairOfValues (p->pos[0], layout) << ");\n";
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
+                break;
 
-        case Path::Iterator::lineTo:
-            r << pathVariable << ".lineTo (" << positionToPairOfValues (p->pos[0], layout) << ");\n";
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
-            break;
+            case Path::Iterator::lineTo:
+                r << pathVariable << ".lineTo (" << positionToPairOfValues (p->pos[0], layout) << ");\n";
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
+                break;
 
-        case Path::Iterator::quadraticTo:
-            r << pathVariable << ".quadraticTo (" << positionToPairOfValues (p->pos[0], layout)
-              << ", " << positionToPairOfValues (p->pos[1], layout) << ");\n";
+            case Path::Iterator::quadraticTo:
+                r << pathVariable << ".quadraticTo (" << positionToPairOfValues (p->pos[0], layout)
+                << ", " << positionToPairOfValues (p->pos[1], layout) << ");\n";
 
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[1].rect.isPositionAbsolute();
-            break;
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[1].rect.isPositionAbsolute();
+                break;
 
-        case Path::Iterator::cubicTo:
-            r << pathVariable << ".cubicTo (" << positionToPairOfValues (p->pos[0], layout)
-              << ", " << positionToPairOfValues (p->pos[1], layout)
-              << ", " << positionToPairOfValues (p->pos[2], layout) << ");\n";
+            case Path::Iterator::cubicTo:
+                r << pathVariable << ".cubicTo (" << positionToPairOfValues (p->pos[0], layout)
+                << ", " << positionToPairOfValues (p->pos[1], layout)
+                << ", " << positionToPairOfValues (p->pos[2], layout) << ");\n";
 
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[1].rect.isPositionAbsolute();
-            somePointsAreRelative = somePointsAreRelative || ! p->pos[2].rect.isPositionAbsolute();
-            break;
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[0].rect.isPositionAbsolute();
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[1].rect.isPositionAbsolute();
+                somePointsAreRelative = somePointsAreRelative || ! p->pos[2].rect.isPositionAbsolute();
+                break;
 
-        case Path::Iterator::closePath:
-            r << pathVariable << ".closeSubPath();\n";
-            break;
+            case Path::Iterator::closePath:
+                r << pathVariable << ".closeSubPath();\n";
+                break;
 
-        default:
-            jassertfalse;
-            break;
+            default:
+                jassertfalse;
+                break;
         }
     }
 
@@ -431,13 +431,13 @@ void PaintElementPath::fillInGeneratedCode (GeneratedCode& code, String& paintMe
 
     if (somePointsAreRelative)
         code.getCallbackCode (String(), "void", "resized()", false)
-            << pathVariable << ".clear();\n" << r;
+        << pathVariable << ".clear();\n" << r;
     else
         code.constructorCode << r;
 
     String s;
     s << "{\n"
-      << "    float x = 0, y = 0;\n";
+    << "    float x = 0, y = 0;\n";
 
     if (! fillType.isInvisible())
         s << "    " << fillType.generateVariablesCode ("fill");
@@ -446,8 +446,8 @@ void PaintElementPath::fillInGeneratedCode (GeneratedCode& code, String& paintMe
         s << "    " << strokeType.fill.generateVariablesCode ("stroke");
 
     s << "    //[UserPaintCustomArguments] Customize the painting arguments here..\n"
-      << customPaintCode
-      << "    //[/UserPaintCustomArguments]\n";
+    << customPaintCode
+    << "    //[/UserPaintCustomArguments]\n";
 
     RelativePositionedRectangle zero;
 
@@ -568,12 +568,12 @@ String PaintElementPath::pathToString() const
                 break;
             case Path::Iterator::quadraticTo:
                 s << "q " << p->pos[0].toString()
-                  << ' '  << p->pos[1].toString() << ' ';
+                << ' '  << p->pos[1].toString() << ' ';
                 break;
             case Path::Iterator::cubicTo:
                 s << "c " << p->pos[0].toString()
-                  << ' '  << p->pos[1].toString() << ' '
-                  << ' '  << p->pos[2].toString() << ' ';
+                << ' '  << p->pos[1].toString() << ' '
+                << ' '  << p->pos[2].toString() << ' ';
                 break;
             case Path::Iterator::closePath:
                 s << "x ";
@@ -742,9 +742,9 @@ class ChangeWindingAction     : public PaintElementUndoableAction <PaintElementP
 {
 public:
     ChangeWindingAction (PaintElementPath* const path, const bool newValue_)
-        : PaintElementUndoableAction <PaintElementPath> (path),
-          newValue (newValue_),
-          oldValue (path->isNonZeroWinding())
+    : PaintElementUndoableAction <PaintElementPath> (path),
+    newValue (newValue_),
+    oldValue (path->isNonZeroWinding())
     {
     }
 
@@ -840,9 +840,9 @@ class AddPointAction   : public PaintElementUndoableAction <PaintElementPath>
 {
 public:
     AddPointAction (PaintElementPath* path, int pointIndexToAddItAfter_)
-        : PaintElementUndoableAction <PaintElementPath> (path),
-          indexAdded (-1),
-          pointIndexToAddItAfter (pointIndexToAddItAfter_)
+    : PaintElementUndoableAction <PaintElementPath> (path),
+    indexAdded (-1),
+    pointIndexToAddItAfter (pointIndexToAddItAfter_)
     {
     }
 
@@ -903,7 +903,7 @@ PathPoint* PaintElementPath::addPoint (int pointIndexToAddItAfter, const bool un
     if (points [pointIndexToAddItAfter + 1] != nullptr)
     {
         if (points [pointIndexToAddItAfter + 1]->type == Path::Iterator::closePath
-             || points [pointIndexToAddItAfter + 1]->type == Path::Iterator::startNewSubPath)
+            || points [pointIndexToAddItAfter + 1]->type == Path::Iterator::startNewSubPath)
         {
             int i = pointIndexToAddItAfter;
             while (i > 0)
@@ -945,9 +945,9 @@ class DeletePointAction   : public PaintElementUndoableAction <PaintElementPath>
 {
 public:
     DeletePointAction (PaintElementPath* const path, const int indexToRemove_)
-        : PaintElementUndoableAction <PaintElementPath> (path),
-          indexToRemove (indexToRemove_),
-          oldValue (*path->getPoint (indexToRemove))
+    : PaintElementUndoableAction <PaintElementPath> (path),
+    indexToRemove (indexToRemove_),
+    oldValue (*path->getPoint (indexToRemove))
     {
     }
 
@@ -1040,66 +1040,66 @@ int PaintElementPath::findSegmentAtXY (int x, int y) const
 
         switch (p->type)
         {
-        case Path::Iterator::startNewSubPath:
-            p->pos[0].getXY (lastX, lastY, area, layout);
-            subPathStartX = lastX;
-            subPathStartY = lastY;
-            subpathStartIndex = i;
-            break;
+            case Path::Iterator::startNewSubPath:
+                p->pos[0].getXY (lastX, lastY, area, layout);
+                subPathStartX = lastX;
+                subPathStartY = lastY;
+                subpathStartIndex = i;
+                break;
 
-        case Path::Iterator::lineTo:
-            p->pos[0].getXY (x1, y1, area, layout);
+            case Path::Iterator::lineTo:
+                p->pos[0].getXY (x1, y1, area, layout);
 
-            segmentPath.addLineSegment (Line<float> ((float) lastX, (float) lastY, (float) x1, (float) y1), thickness);
-            if (segmentPath.contains ((float) x, (float) y))
-                return i;
+                segmentPath.addLineSegment (Line<float> ((float) lastX, (float) lastY, (float) x1, (float) y1), thickness);
+                if (segmentPath.contains ((float) x, (float) y))
+                    return i;
 
-            lastX = x1;
-            lastY = y1;
-            break;
+                lastX = x1;
+                lastY = y1;
+                break;
 
-        case Path::Iterator::quadraticTo:
-            p->pos[0].getXY (x1, y1, area, layout);
-            p->pos[1].getXY (x2, y2, area, layout);
+            case Path::Iterator::quadraticTo:
+                p->pos[0].getXY (x1, y1, area, layout);
+                p->pos[1].getXY (x2, y2, area, layout);
 
-            segmentPath.startNewSubPath ((float) lastX, (float) lastY);
-            segmentPath.quadraticTo ((float) x1, (float) y1, (float) x2, (float) y2);
-            PathStrokeType (thickness).createStrokedPath (segmentPath, segmentPath);
+                segmentPath.startNewSubPath ((float) lastX, (float) lastY);
+                segmentPath.quadraticTo ((float) x1, (float) y1, (float) x2, (float) y2);
+                PathStrokeType (thickness).createStrokedPath (segmentPath, segmentPath);
 
-            if (segmentPath.contains ((float) x, (float) y))
-                return i;
+                if (segmentPath.contains ((float) x, (float) y))
+                    return i;
 
-            lastX = x2;
-            lastY = y2;
-            break;
+                lastX = x2;
+                lastY = y2;
+                break;
 
-        case Path::Iterator::cubicTo:
-            p->pos[0].getXY (x1, y1, area, layout);
-            p->pos[1].getXY (x2, y2, area, layout);
-            p->pos[2].getXY (x3, y3, area, layout);
+            case Path::Iterator::cubicTo:
+                p->pos[0].getXY (x1, y1, area, layout);
+                p->pos[1].getXY (x2, y2, area, layout);
+                p->pos[2].getXY (x3, y3, area, layout);
 
-            segmentPath.startNewSubPath ((float) lastX, (float) lastY);
-            segmentPath.cubicTo ((float) x1, (float) y1, (float) x2, (float) y2, (float) x3, (float) y3);
-            PathStrokeType (thickness).createStrokedPath (segmentPath, segmentPath);
+                segmentPath.startNewSubPath ((float) lastX, (float) lastY);
+                segmentPath.cubicTo ((float) x1, (float) y1, (float) x2, (float) y2, (float) x3, (float) y3);
+                PathStrokeType (thickness).createStrokedPath (segmentPath, segmentPath);
 
-            if (segmentPath.contains ((float) x, (float) y))
-                return i;
+                if (segmentPath.contains ((float) x, (float) y))
+                    return i;
 
-            lastX = x3;
-            lastY = y3;
-            break;
+                lastX = x3;
+                lastY = y3;
+                break;
 
-        case Path::Iterator::closePath:
-            segmentPath.addLineSegment (Line<float> ((float) lastX, (float) lastY, (float) subPathStartX, (float) subPathStartY), thickness);
-            if (segmentPath.contains ((float) x, (float) y))
-                return subpathStartIndex;
+            case Path::Iterator::closePath:
+                segmentPath.addLineSegment (Line<float> ((float) lastX, (float) lastY, (float) subPathStartX, (float) subPathStartY), thickness);
+                if (segmentPath.contains ((float) x, (float) y))
+                    return subpathStartIndex;
 
-            lastX = subPathStartX;
-            lastY = subPathStartY;
-            break;
+                lastX = subPathStartX;
+                lastY = subPathStartY;
+                break;
 
-        default:
-            jassertfalse; break;
+            default:
+                jassertfalse; break;
         }
     }
 
@@ -1182,14 +1182,14 @@ void PaintElementPath::setPoint (int index, int pointNumber, const RelativePosit
 
 //==============================================================================
 class PathPointTypeProperty : public ChoicePropertyComponent,
-                              public ChangeListener
+public ChangeListener
 {
 public:
     PathPointTypeProperty (PaintElementPath* const owner_,
                            const int index_)
-        : ChoicePropertyComponent ("point type"),
-          owner (owner_),
-          index (index_)
+    : ChoicePropertyComponent ("point type"),
+    owner (owner_),
+    index (index_)
     {
         choices.add ("Start of sub-path");
         choices.add ("Line");
@@ -1297,13 +1297,13 @@ private:
 
 //==============================================================================
 class PathPointClosedProperty   : public ChoicePropertyComponent,
-                                  private ChangeListener
+private ChangeListener
 {
 public:
     PathPointClosedProperty (PaintElementPath* const owner_, const int index_)
-        : ChoicePropertyComponent ("openness"),
-          owner (owner_),
-          index (index_)
+    : ChoicePropertyComponent ("openness"),
+    owner (owner_),
+    index (index_)
     {
         owner->getDocument()->addChangeListener (this);
 
@@ -1341,9 +1341,9 @@ class AddNewPointProperty   : public ButtonPropertyComponent
 {
 public:
     AddNewPointProperty (PaintElementPath* const owner_, const int index_)
-        : ButtonPropertyComponent ("new point", false),
-          owner (owner_),
-          index (index_)
+    : ButtonPropertyComponent ("new point", false),
+    owner (owner_),
+    index (index_)
     {
     }
 
@@ -1362,13 +1362,13 @@ private:
 
 //==============================================================================
 PathPoint::PathPoint (PaintElementPath* const owner_)
-    : owner (owner_)
+: owner (owner_)
 {
 }
 
 PathPoint::PathPoint (const PathPoint& other)
-    : owner (other.owner),
-      type (other.type)
+: owner (other.owner),
+type (other.type)
 {
     pos [0] = other.pos [0];
     pos [1] = other.pos [1];
@@ -1422,7 +1422,7 @@ PathPoint PathPoint::withChangedPointType (const Path::Iterator::PathElementType
             if (PathPoint* lastPoint = owner->points [index - 1])
             {
                 lastPoint->pos [lastPoint->getNumPoints() - 1]
-                            .getRectangleDouble (lastX, lastY, w, h, parentArea, owner->getDocument()->getComponentLayout());
+                .getRectangleDouble (lastX, lastY, w, h, parentArea, owner->getDocument()->getComponentLayout());
             }
             else
             {
@@ -1529,12 +1529,12 @@ void PathPoint::deleteFromPath()
 PathPointComponent::PathPointComponent (PaintElementPath* const path_,
                                         const int index_,
                                         const int pointNumber_)
-    : ElementSiblingComponent (path_),
-      path (path_),
-      routine (path_->getOwner()),
-      index (index_),
-      pointNumber (pointNumber_),
-      selected (false)
+: ElementSiblingComponent (path_),
+path (path_),
+routine (path_->getOwner()),
+index (index_),
+pointNumber (pointNumber_),
+selected (false)
 {
     setSize (11, 11);
     setRepaintsOnMouseActivity (true);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
@@ -52,7 +52,7 @@ public:
                           const bool undoable);
 
     void deleteFromPath();
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected );  // D STENNING);
 
 private:
     PathPoint withChangedPointType (const Path::Iterator::PathElementType newType,
@@ -98,7 +98,7 @@ public:
     void setNonZeroWinding (const bool nonZero, const bool undoable);
 
     //==============================================================================
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected);
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode);
     void applyCustomPaintSnippets (StringArray& snippets);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h
@@ -67,9 +67,9 @@ public:
         }
     }
 
-    void getEditableProperties (Array <PropertyComponent*>& props)
+    void getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected) // D STENNING
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelected);
 
         props.add (new ShapeToPathProperty (this));
     }

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
@@ -39,7 +39,7 @@ public:
         cornerSize = 10.0;
     }
 
-    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea)
+    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea) override
     {
         double x, y, w, h;
         position.getRectangleDouble (x, y, w, h, parentArea, layout);
@@ -56,11 +56,11 @@ public:
         }
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelection ) override // D STENNING
     {
         props.add (new CornerSizeProperty (this));
 
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelection);
 
         props.add (new ShapeToPathProperty (this));
     }
@@ -114,7 +114,7 @@ public:
     double getCornerSize() const noexcept                         { return cornerSize; }
 
     //==============================================================================
-    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
+    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) override
     {
         if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
             return;
@@ -156,7 +156,7 @@ public:
         paintMethodCode += s;
     }
 
-    void applyCustomPaintSnippets (StringArray& snippets)
+    void applyCustomPaintSnippets (StringArray& snippets) override
     {
         customPaintCode.clear();
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
@@ -66,9 +66,12 @@ public:
         return s;
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props, multipleSelected);
+
+        if ( multipleSelected ) // D STENNING
+            return;
 
         props.add (new TextProperty (this));
         props.add (new FontNameProperty (this));

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -33,11 +33,11 @@
 
 //==============================================================================
 /**
-    Base class for a property that edits the x, y, w, or h of a PositionedRectangle.
-*/
+ Base class for a property that edits the x, y, w, or h of a PositionedRectangle.
+ */
 class PositionPropertyBase  : public PropertyComponent,
-                              protected ChangeListener,
-                              private ButtonListener
+protected ChangeListener,
+private ButtonListener
 {
 public:
     //    enum ComponentPositionDimension  D STENNING
@@ -54,13 +54,13 @@ public:
                           const bool includeAnchorOptions_,
                           const bool allowRelativeOptions_,
                           ComponentLayout* layout_)
-        : PropertyComponent (name),
-          layout (layout_),
-          button ("mode"),
-          component (comp),
-          dimension (dimension_),
-          includeAnchorOptions (includeAnchorOptions_),
-          allowRelativeOptions (allowRelativeOptions_)
+    : PropertyComponent (name),
+    layout (layout_),
+    button ("mode"),
+    component (comp),
+    dimension (dimension_),
+    includeAnchorOptions (includeAnchorOptions_),
+    allowRelativeOptions (allowRelativeOptions_)
     {
         addAndMakeVisible (button);
         button.addListener (this);
@@ -189,7 +189,7 @@ public:
         String relCompName ("parent");
 
         if (Component* const relComp = compLayout != nullptr ? compLayout->getComponentRelativePosTarget (component, (int) dimension)
-                                                             : nullptr)
+            : nullptr)
             relCompName = compLayout->getComponentMemberVariableName (relComp);
 
         jassert (relCompName.isNotEmpty());
@@ -428,8 +428,8 @@ protected:
 
     public:
         PositionPropLabel (PositionPropertyBase& owner_)
-            : Label (String(), String()),
-              owner (owner_)
+        : Label (String(), String()),
+        owner (owner_)
         {
             setEditable (true, true, false);
             lookAndFeelChanged();

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
@@ -29,6 +29,8 @@
 #include "../ui/jucer_PaintRoutineEditor.h"
 #include "../ui/jucer_ComponentLayoutEditor.h"
 
+#include "../jucer_ComponentLayout.h"  // D STENNING
+
 //==============================================================================
 /**
     Base class for a property that edits the x, y, w, or h of a PositionedRectangle.
@@ -38,17 +40,17 @@ class PositionPropertyBase  : public PropertyComponent,
                               private ButtonListener
 {
 public:
-    enum ComponentPositionDimension
-    {
-        componentX          = 0,
-        componentY          = 1,
-        componentWidth      = 2,
-        componentHeight     = 3
-    };
+    //    enum ComponentPositionDimension  D STENNING
+    //    {
+    //        componentX          = 0,
+    //        componentY          = 1,
+    //        componentWidth      = 2,
+    //        componentHeight     = 3
+    //    };
 
     PositionPropertyBase (Component* comp,
                           const String& name,
-                          ComponentPositionDimension dimension_,
+                          ComponentLayout::ComponentPositionDimension dimension_, //D STENNING
                           const bool includeAnchorOptions_,
                           const bool allowRelativeOptions_,
                           ComponentLayout* layout_)
@@ -76,28 +78,28 @@ public:
 
         switch (dimension)
         {
-        case componentX:
+        case ComponentLayout::componentX:
             if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
                 s << valueToString (p.getX() * 100.0) << '%';
             else
                 s << valueToString (p.getX());
             break;
 
-        case componentY:
+        case ComponentLayout::componentY:
             if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
                 s << valueToString (p.getY() * 100.0) << '%';
             else
                 s << valueToString (p.getY());
             break;
 
-        case componentWidth:
+        case ComponentLayout::componentWidth:
             if (p.getWidthMode() == PositionedRectangle::proportionalSize)
                 s << valueToString (p.getWidth() * 100.0) << '%';
             else
                 s << valueToString (p.getWidth());
             break;
 
-        case componentHeight:
+        case ComponentLayout::componentHeight:
             if (p.getHeightMode() == PositionedRectangle::proportionalSize)
                 s << valueToString (p.getHeight() * 100.0) << '%';
             else
@@ -125,28 +127,28 @@ public:
 
         switch (dimension)
         {
-        case componentX:
+        case ComponentLayout::componentX:
             if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
                 p.setX (value / 100.0);
             else
                 p.setX (value);
             break;
 
-        case componentY:
+        case ComponentLayout::componentY:
             if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
                 p.setY (value / 100.0);
             else
                 p.setY (value);
             break;
 
-        case componentWidth:
+        case ComponentLayout::componentWidth:
             if (p.getWidthMode() == PositionedRectangle::proportionalSize)
                 p.setWidth (value / 100.0);
             else
                 p.setWidth (value);
             break;
 
-        case componentHeight:
+        case ComponentLayout::componentHeight:
             if (p.getHeightMode() == PositionedRectangle::proportionalSize)
                 p.setHeight (value / 100.0);
             else
@@ -161,7 +163,9 @@ public:
         if (p != rpr.rect)
         {
             rpr.rect = p;
-            setPosition (rpr);
+            //  setPosition (rpr);  // OLD D STENNING
+            setSingleDimension(true,value , dimension);  // NEW D STENNING
+
         }
     }
 
@@ -192,56 +196,56 @@ public:
 
         PopupMenu m;
 
-        if (dimension == componentX || dimension == componentY)
+        if (dimension == ComponentLayout::componentX || dimension == ComponentLayout::componentY)
         {
-            const PositionedRectangle::PositionMode posMode = (dimension == componentX) ? xMode : yMode;
+            const PositionedRectangle::PositionMode posMode = (dimension == ComponentLayout::componentX) ? xMode : yMode;
 
-            m.addItem (10, ((dimension == componentX) ? "Absolute distance from left of "
-                                                      : "Absolute distance from top of ") + relCompName,
+            m.addItem (10, ((dimension == ComponentLayout::componentX) ? "Absolute distance from left of "
+                                                                       : "Absolute distance from top of ") + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentTopLeft);
 
-            m.addItem (11, ((dimension == componentX) ? "Absolute distance from right of "
-                                                      : "Absolute distance from bottom of ") + relCompName,
+            m.addItem (11, ((dimension == ComponentLayout::componentX) ? "Absolute distance from right of "
+                                                                       : "Absolute distance from bottom of ") + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentBottomRight);
 
             m.addItem (12, "Absolute distance from centre of " + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentCentre);
 
-            m.addItem (13, ((dimension == componentX) ? "Percentage of width of "
-                                                      : "Percentage of height of ") + relCompName,
+            m.addItem (13, ((dimension == ComponentLayout::componentX) ? "Percentage of width of "
+                                                                       : "Percentage of height of ") + relCompName,
                        true, posMode == PositionedRectangle::proportionOfParentSize);
 
             m.addSeparator();
 
             if (includeAnchorOptions)
             {
-                const PositionedRectangle::AnchorPoint anchor = (dimension == componentX) ? xAnchor : yAnchor;
+                const PositionedRectangle::AnchorPoint anchor = (dimension == ComponentLayout::componentX) ? xAnchor : yAnchor;
 
-                m.addItem (14, (dimension == componentX) ? "Anchored at left of component"
-                                                         : "Anchored at top of component",
+                m.addItem (14, (dimension == ComponentLayout::componentX) ? "Anchored at left of component"
+                                                                          : "Anchored at top of component",
                            true, anchor == PositionedRectangle::anchorAtLeftOrTop);
 
                 m.addItem (15, "Anchored at centre of component", true, anchor == PositionedRectangle::anchorAtCentre);
 
-                m.addItem (16, (dimension == componentX) ? "Anchored at right of component"
-                                                         : "Anchored at bottom of component",
+                m.addItem (16, (dimension == ComponentLayout::componentX) ? "Anchored at right of component"
+                                                                          : "Anchored at bottom of component",
                            true, anchor == PositionedRectangle::anchorAtRightOrBottom);
             }
         }
         else
         {
-            const PositionedRectangle::SizeMode sizeMode = (dimension == componentWidth) ? sizeW : sizeH;
+            const PositionedRectangle::SizeMode sizeMode = (dimension == ComponentLayout::componentWidth) ? sizeW : sizeH;
 
-            m.addItem (20, (dimension == componentWidth) ? "Absolute width"
-                                                         : "Absolute height",
+            m.addItem (20, (dimension == ComponentLayout::componentWidth) ? "Absolute width"
+                                                                          : "Absolute height",
                        true, sizeMode == PositionedRectangle::absoluteSize);
 
-            m.addItem (21, ((dimension == componentWidth) ? "Percentage of width of "
-                                                          : "Percentage of height of ") + relCompName,
+            m.addItem (21, ((dimension == ComponentLayout::componentWidth) ? "Percentage of width of "
+                                                                           : "Percentage of height of ") + relCompName,
                        true, sizeMode == PositionedRectangle::proportionalSize);
 
-            m.addItem (22, ((dimension == componentWidth) ? "Subtracted from width of "
-                                                          : "Subtracted from height of ") + relCompName,
+            m.addItem (22, ((dimension == ComponentLayout::componentWidth) ? "Subtracted from width of "
+                                                                           : "Subtracted from height of ") + relCompName,
                        true, sizeMode == PositionedRectangle::parentSizeMinusAbsolute);
         }
 
@@ -262,70 +266,70 @@ public:
         switch (menuResult)
         {
         case 10:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentTopLeft;
             else
                 yMode = PositionedRectangle::absoluteFromParentTopLeft;
             break;
 
         case 11:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentBottomRight;
             else
                 yMode = PositionedRectangle::absoluteFromParentBottomRight;
             break;
 
         case 12:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentCentre;
             else
                 yMode = PositionedRectangle::absoluteFromParentCentre;
             break;
 
         case 13:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::proportionOfParentSize;
             else
                 yMode = PositionedRectangle::proportionOfParentSize;
             break;
 
         case 14:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtLeftOrTop;
             else
                 yAnchor = PositionedRectangle::anchorAtLeftOrTop;
             break;
 
         case 15:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtCentre;
             else
                 yAnchor = PositionedRectangle::anchorAtCentre;
             break;
 
         case 16:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtRightOrBottom;
             else
                 yAnchor = PositionedRectangle::anchorAtRightOrBottom;
             break;
 
         case 20:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::absoluteSize;
             else
                 sizeH = PositionedRectangle::absoluteSize;
             break;
 
         case 21:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::proportionalSize;
             else
                 sizeH = PositionedRectangle::proportionalSize;
             break;
 
         case 22:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::parentSizeMinusAbsolute;
             else
                 sizeH = PositionedRectangle::parentSizeMinusAbsolute;
@@ -406,6 +410,15 @@ public:
     //==============================================================================
     virtual void setPosition (const RelativePositionedRectangle& newPos) = 0;
 
+    virtual void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim) =0;
+    //    {
+    //        // control shouldnt be getting here
+    //        (void)undoable;
+    //        (void)value;
+    //        (void)dim;
+    //        JUCE_BREAK_IN_DEBUGGER;
+    //    }
+
     virtual RelativePositionedRectangle getPosition() const = 0;
 
 protected:
@@ -447,6 +460,6 @@ protected:
     TextButton button;
 
     Component* component;
-    ComponentPositionDimension dimension;
+    ComponentLayout::ComponentPositionDimension dimension;  // D STENNING
     const bool includeAnchorOptions, allowRelativeOptions;
 };

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
@@ -102,14 +102,17 @@ private:
         {
             clear();
 
-            if (layout.getSelectedSet().getNumSelected() == 1) // xxx need to cope with multiple
-            {
-                if (Component* comp = layout.getSelectedSet().getSelectedItem (0))
-                    if (ComponentTypeHandler* const type = ComponentTypeHandler::getHandlerFor (*comp))
-                        type->addPropertiesToPropertyPanel (comp, document, propsPanel);
-            }
-        }
+            if (layout.getSelectedSet().getNumSelected() == 0)
+                return;
 
+            bool multipleSelected = ( layout.getSelectedSet().getNumSelected() > 1 );
+
+            // D STENNING 30/6/17
+            if (Component* comp = layout.getSelectedSet().getSelectedItem (0))
+                if (ComponentTypeHandler* const type = ComponentTypeHandler::getHandlerFor (*comp))
+                    type->addPropertiesToPropertyPanel (comp, document, propsPanel,multipleSelected);
+
+        }
     private:
         JucerDocument& document;
         ComponentLayout& layout;

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #pragma once
 
@@ -36,10 +36,10 @@ class ComponentLayoutPanel  : public EditingPanelBase
 public:
     //==============================================================================
     ComponentLayoutPanel (JucerDocument& doc, ComponentLayout& l)
-        : EditingPanelBase (doc,
-                            new LayoutPropsPanel (doc, l),
-                            new ComponentLayoutEditor (doc, l)),
-          layout (l)
+    : EditingPanelBase (doc,
+                        new LayoutPropsPanel (doc, l),
+                        new ComponentLayoutEditor (doc, l)),
+    layout (l)
     {
     }
 
@@ -67,11 +67,11 @@ public:
 
 private:
     class LayoutPropsPanel  : public Component,
-                              public ChangeListener
+    public ChangeListener
     {
     public:
         LayoutPropsPanel (JucerDocument& doc, ComponentLayout& l)
-            : document (doc), layout (l)
+        : document (doc), layout (l)
         {
             layout.getSelectedSet().addChangeListener (this);
             addAndMakeVisible (propsPanel);

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
@@ -58,6 +58,13 @@ namespace JucerCommandIDs
 
         newDocumentBase        = 0xf32001,
         newComponentBase       = 0xf30001,
-        newElementBase         = 0xf31001
+        newElementBase         = 0xf31001,
+
+        alignLeft              = 0xf33000, // D STENNING
+        alignRight             = 0xf33001, // D STENNING
+        alignTop               = 0xf33002, // D STENNING
+        alignBottom            = 0xf33003 // D STENNING
+
+
     };
 }

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
@@ -1,32 +1,32 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 /**
-    A namespace to hold all the possible command IDs.
-*/
+ A namespace to hold all the possible command IDs.
+ */
 namespace JucerCommandIDs
 {
     enum

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
@@ -630,6 +630,12 @@ void JucerDocumentEditor::getAllCommands (Array <CommandID>& commands)
         JucerCommandIDs::compOverlay33,
         JucerCommandIDs::compOverlay66,
         JucerCommandIDs::compOverlay100,
+
+        JucerCommandIDs::alignRight,  // D STENNING
+        JucerCommandIDs::alignLeft,
+        JucerCommandIDs::alignTop,
+        JucerCommandIDs::alignBottom, // D STENNING
+
         StandardApplicationCommandIDs::undo,
         StandardApplicationCommandIDs::redo,
         StandardApplicationCommandIDs::cut,
@@ -637,7 +643,8 @@ void JucerDocumentEditor::getAllCommands (Array <CommandID>& commands)
         StandardApplicationCommandIDs::paste,
         StandardApplicationCommandIDs::del,
         StandardApplicationCommandIDs::selectAll,
-        StandardApplicationCommandIDs::deselectAll
+        StandardApplicationCommandIDs::deselectAll,
+
     };
 
     commands.addArray (ids, numElementsInArray (ids));
@@ -810,6 +817,24 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
             result.setActive (currentPaintRoutine != nullptr && document->getComponentLayout() != nullptr);
             result.setTicked (amount == currentAmount);
         }
+        break;
+
+
+    case JucerCommandIDs::alignTop:       // D STENNING
+        result.setInfo (TRANS("Align Top"), TRANS("xxxxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignBottom:
+        result.setInfo (TRANS("Align Bottom"), TRANS("xxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignLeft:
+        result.setInfo (TRANS("Align Left"), TRANS("xxxxxx."), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignRight:
+        result.setInfo (TRANS("Align Right"), TRANS("xxxxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
         break;
 
     case StandardApplicationCommandIDs::undo:
@@ -994,6 +1019,33 @@ bool JucerDocumentEditor::perform (const InvocationInfo& info)
                 currentPaintRoutine->selectedToBack();
 
             break;
+
+
+        case JucerCommandIDs::alignLeft:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignLeft();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignLeft();
+            break;
+        case JucerCommandIDs::alignRight:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignRight();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignRight();
+            break;
+        case JucerCommandIDs::alignTop:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignTop();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignTop();
+            break;
+        case JucerCommandIDs::alignBottom:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignBottom();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignBottom();
+            break;
+
 
         case JucerCommandIDs::group:
             if (currentPaintRoutine != nullptr)

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "../../Application/jucer_AppearanceSettings.h"
@@ -40,13 +40,13 @@
 
 //==============================================================================
 class ExtraMethodsList  : public PropertyComponent,
-                          public ListBoxModel,
-                          public ChangeListener
+public ListBoxModel,
+public ChangeListener
 {
 public:
     ExtraMethodsList (JucerDocument& doc)
-        : PropertyComponent ("extra callbacks", 250),
-          document (doc)
+    : PropertyComponent ("extra callbacks", 250),
+    document (doc)
     {
         addAndMakeVisible (listBox = new ListBox (String(), this));
         listBox->setRowHeight (22);
@@ -135,11 +135,11 @@ private:
 
 //==============================================================================
 class ClassPropertiesPanel  : public Component,
-                              private ChangeListener
+private ChangeListener
 {
 public:
     ClassPropertiesPanel (JucerDocument& doc)
-        : document (doc)
+    : document (doc)
     {
         addAndMakeVisible (panel1);
         addAndMakeVisible (panel2);
@@ -197,7 +197,7 @@ private:
     {
     public:
         ComponentClassNameProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Class name", 128, false, 0, doc)
+        : ComponentTextProperty <Component> ("Class name", 128, false, 0, doc)
         {}
 
         void setText (const String& newText) override    { document.setClassName (newText); }
@@ -209,7 +209,7 @@ private:
     {
     public:
         ComponentCompNameProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Component name", 200, false, 0, doc)
+        : ComponentTextProperty <Component> ("Component name", 200, false, 0, doc)
         {}
 
         void setText (const String& newText) override    { document.setComponentName (newText); }
@@ -221,7 +221,7 @@ private:
     {
     public:
         ComponentParentClassesProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Parent classes", 512, false, 0, doc)
+        : ComponentTextProperty <Component> ("Parent classes", 512, false, 0, doc)
         {}
 
         void setText (const String& newText) override    { document.setParentClasses (newText); }
@@ -233,7 +233,7 @@ private:
     {
     public:
         ComponentConstructorParamsProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Constructor params", 2048, false, 0, doc)
+        : ComponentTextProperty <Component> ("Constructor params", 2048, false, 0, doc)
         {}
 
         void setText (const String& newText) override    { document.setConstructorParams (newText); }
@@ -245,7 +245,7 @@ private:
     {
     public:
         ComponentInitialisersProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Member initialisers", 16384, true, 0, doc)
+        : ComponentTextProperty <Component> ("Member initialisers", 16384, true, 0, doc)
         {
             preferredHeight = 24 * 3;
         }
@@ -260,10 +260,10 @@ private:
     {
     public:
         ComponentInitialSizeProperty (JucerDocument& doc, const bool isWidth_)
-            : ComponentTextProperty <Component> (isWidth_ ? "Initial width"
-                                                          : "Initial height",
-                                     10, false, 0, doc),
-              isWidth (isWidth_)
+        : ComponentTextProperty <Component> (isWidth_ ? "Initial width"
+                                             : "Initial height",
+                                             10, false, 0, doc),
+        isWidth (isWidth_)
         {}
 
         void setText (const String& newText) override
@@ -277,7 +277,7 @@ private:
         String getText() const override
         {
             return String (isWidth ? document.getInitialWidth()
-                                   : document.getInitialHeight());
+                           : document.getInitialHeight());
         }
 
     private:
@@ -289,7 +289,7 @@ private:
     {
     public:
         FixedSizeProperty (JucerDocument& doc)
-            : ComponentChoiceProperty <Component> ("Fixed size", 0, doc)
+        : ComponentChoiceProperty <Component> ("Fixed size", 0, doc)
         {
             choices.add ("Resize component to fit workspace");
             choices.add ("Keep component size fixed");
@@ -304,7 +304,7 @@ private:
     {
     public:
         TemplateFileProperty (JucerDocument& doc)
-            : ComponentTextProperty <Component> ("Template file", 2048, false, 0, doc)
+        : ComponentTextProperty <Component> ("Template file", 2048, false, 0, doc)
         {}
 
         void setText (const String& newText) override    { document.setTemplateFile (newText); }
@@ -322,8 +322,8 @@ static SourceCodeEditor* createCodeEditor (const File& file, SourceCodeDocument&
 
 //==============================================================================
 JucerDocumentEditor::JucerDocumentEditor (JucerDocument* const doc)
-    : document (doc),
-      tabbedComponent (doc)
+: document (doc),
+tabbedComponent (doc)
 {
     setOpaque (true);
 
@@ -389,7 +389,7 @@ void JucerDocumentEditor::updateTabs()
     for (int i = tabbedComponent.getNumTabs(); --i >= 0;)
     {
         if (dynamic_cast<PaintRoutinePanel*> (tabbedComponent.getTabContentComponent (i)) != 0
-             && ! paintRoutineNames.contains (tabbedComponent.getTabNames() [i]))
+            && ! paintRoutineNames.contains (tabbedComponent.getTabNames() [i]))
         {
             tabbedComponent.removeTab (i);
         }
@@ -665,7 +665,7 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
     const int shift = ModifierKeys::shiftModifier;
 
     if (commandID >= JucerCommandIDs::newComponentBase
-         && commandID < JucerCommandIDs::newComponentBase + ObjectTypes::numComponentTypes)
+        && commandID < JucerCommandIDs::newComponentBase + ObjectTypes::numComponentTypes)
     {
         const int index = commandID - JucerCommandIDs::newComponentBase;
 
@@ -676,7 +676,7 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
     }
 
     if (commandID >= JucerCommandIDs::newElementBase
-         && commandID < JucerCommandIDs::newElementBase + ObjectTypes::numElementTypes)
+        && commandID < JucerCommandIDs::newElementBase + ObjectTypes::numElementTypes)
     {
         const int index = commandID - JucerCommandIDs::newElementBase;
 
@@ -690,96 +690,96 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
 
     switch (commandID)
     {
-    case JucerCommandIDs::toFront:
-        result.setInfo (TRANS("Bring to front"), TRANS("Brings the currently selected component to the front."), CommandCategories::editing, 0);
-        result.setActive (isSomethingSelected());
-        result.defaultKeypresses.add (KeyPress ('f', cmd, 0));
-        break;
+        case JucerCommandIDs::toFront:
+            result.setInfo (TRANS("Bring to front"), TRANS("Brings the currently selected component to the front."), CommandCategories::editing, 0);
+            result.setActive (isSomethingSelected());
+            result.defaultKeypresses.add (KeyPress ('f', cmd, 0));
+            break;
 
-    case JucerCommandIDs::toBack:
-        result.setInfo (TRANS("Send to back"), TRANS("Sends the currently selected component to the back."), CommandCategories::editing, 0);
-        result.setActive (isSomethingSelected());
-        result.defaultKeypresses.add (KeyPress ('b', cmd, 0));
-        break;
+        case JucerCommandIDs::toBack:
+            result.setInfo (TRANS("Send to back"), TRANS("Sends the currently selected component to the back."), CommandCategories::editing, 0);
+            result.setActive (isSomethingSelected());
+            result.defaultKeypresses.add (KeyPress ('b', cmd, 0));
+            break;
 
-    case JucerCommandIDs::group:
-        result.setInfo (TRANS("Group selected items"), TRANS("Turns the currently selected elements into a single group object."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr && currentPaintRoutine->getSelectedElements().getNumSelected() > 1);
-        result.defaultKeypresses.add (KeyPress ('k', cmd, 0));
-        break;
+        case JucerCommandIDs::group:
+            result.setInfo (TRANS("Group selected items"), TRANS("Turns the currently selected elements into a single group object."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr && currentPaintRoutine->getSelectedElements().getNumSelected() > 1);
+            result.defaultKeypresses.add (KeyPress ('k', cmd, 0));
+            break;
 
-    case JucerCommandIDs::ungroup:
-        result.setInfo (TRANS("Ungroup selected items"), TRANS("Turns the currently selected elements into a single group object."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr
-                           && currentPaintRoutine->getSelectedElements().getNumSelected() == 1
-                           && currentPaintRoutine->getSelectedElements().getSelectedItem (0)->getTypeName() == "Group");
-        result.defaultKeypresses.add (KeyPress ('k', cmd | shift, 0));
-        break;
+        case JucerCommandIDs::ungroup:
+            result.setInfo (TRANS("Ungroup selected items"), TRANS("Turns the currently selected elements into a single group object."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr
+                              && currentPaintRoutine->getSelectedElements().getNumSelected() == 1
+                              && currentPaintRoutine->getSelectedElements().getSelectedItem (0)->getTypeName() == "Group");
+            result.defaultKeypresses.add (KeyPress ('k', cmd | shift, 0));
+            break;
 
-    case JucerCommandIDs::test:
-        result.setInfo (TRANS("Test component..."), TRANS("Runs the current component interactively."), CommandCategories::view, 0);
-        result.defaultKeypresses.add (KeyPress ('t', cmd, 0));
-        break;
+        case JucerCommandIDs::test:
+            result.setInfo (TRANS("Test component..."), TRANS("Runs the current component interactively."), CommandCategories::view, 0);
+            result.defaultKeypresses.add (KeyPress ('t', cmd, 0));
+            break;
 
-    case JucerCommandIDs::enableSnapToGrid:
-        result.setInfo (TRANS("Enable snap-to-grid"), TRANS("Toggles whether components' positions are aligned to a grid."), CommandCategories::view, 0);
-        result.setTicked (document != nullptr && document->isSnapActive (false));
-        result.defaultKeypresses.add (KeyPress ('g', cmd, 0));
-        break;
+        case JucerCommandIDs::enableSnapToGrid:
+            result.setInfo (TRANS("Enable snap-to-grid"), TRANS("Toggles whether components' positions are aligned to a grid."), CommandCategories::view, 0);
+            result.setTicked (document != nullptr && document->isSnapActive (false));
+            result.defaultKeypresses.add (KeyPress ('g', cmd, 0));
+            break;
 
-    case JucerCommandIDs::showGrid:
-        result.setInfo (TRANS("Show snap-to-grid"), TRANS("Toggles whether the snapping grid is displayed on-screen."), CommandCategories::view, 0);
-        result.setTicked (document != nullptr && document->isSnapShown());
-        result.defaultKeypresses.add (KeyPress ('g', cmd | shift, 0));
-        break;
+        case JucerCommandIDs::showGrid:
+            result.setInfo (TRANS("Show snap-to-grid"), TRANS("Toggles whether the snapping grid is displayed on-screen."), CommandCategories::view, 0);
+            result.setTicked (document != nullptr && document->isSnapShown());
+            result.defaultKeypresses.add (KeyPress ('g', cmd | shift, 0));
+            break;
 
-    case JucerCommandIDs::editCompLayout:
-        result.setInfo (TRANS("Edit sub-component layout"), TRANS("Switches to the sub-component editor view."), CommandCategories::view, 0);
-        result.setTicked (currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('n', cmd, 0));
-        break;
+        case JucerCommandIDs::editCompLayout:
+            result.setInfo (TRANS("Edit sub-component layout"), TRANS("Switches to the sub-component editor view."), CommandCategories::view, 0);
+            result.setTicked (currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('n', cmd, 0));
+            break;
 
-    case JucerCommandIDs::editCompGraphics:
-        result.setInfo (TRANS("Edit background graphics"), TRANS("Switches to the background graphics editor view."), CommandCategories::view, 0);
-        result.setTicked (currentPaintRoutine != nullptr);
-        result.defaultKeypresses.add (KeyPress ('m', cmd, 0));
-        break;
+        case JucerCommandIDs::editCompGraphics:
+            result.setInfo (TRANS("Edit background graphics"), TRANS("Switches to the background graphics editor view."), CommandCategories::view, 0);
+            result.setTicked (currentPaintRoutine != nullptr);
+            result.defaultKeypresses.add (KeyPress ('m', cmd, 0));
+            break;
 
-    case JucerCommandIDs::bringBackLostItems:
-        result.setInfo (TRANS("Retrieve offscreen items"), TRANS("Moves any items that are lost beyond the edges of the screen back to the centre."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('m', cmd, 0));
-        break;
+        case JucerCommandIDs::bringBackLostItems:
+            result.setInfo (TRANS("Retrieve offscreen items"), TRANS("Moves any items that are lost beyond the edges of the screen back to the centre."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('m', cmd, 0));
+            break;
 
-    case JucerCommandIDs::zoomIn:
-        result.setInfo (TRANS("Zoom in"), TRANS("Zooms in on the current component."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress (']', cmd, 0));
-        break;
+        case JucerCommandIDs::zoomIn:
+            result.setInfo (TRANS("Zoom in"), TRANS("Zooms in on the current component."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress (']', cmd, 0));
+            break;
 
-    case JucerCommandIDs::zoomOut:
-        result.setInfo (TRANS("Zoom out"), TRANS("Zooms out on the current component."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('[', cmd, 0));
-        break;
+        case JucerCommandIDs::zoomOut:
+            result.setInfo (TRANS("Zoom out"), TRANS("Zooms out on the current component."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('[', cmd, 0));
+            break;
 
-    case JucerCommandIDs::zoomNormal:
-        result.setInfo (TRANS("Zoom to 100%"), TRANS("Restores the zoom level to normal."), CommandCategories::editing, 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('1', cmd, 0));
-        break;
+        case JucerCommandIDs::zoomNormal:
+            result.setInfo (TRANS("Zoom to 100%"), TRANS("Restores the zoom level to normal."), CommandCategories::editing, 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('1', cmd, 0));
+            break;
 
-    case JucerCommandIDs::spaceBarDrag:
-        result.setInfo (TRANS("Scroll while dragging mouse"), TRANS("When held down, this key lets you scroll around by dragging with the mouse."),
-                        CommandCategories::view, ApplicationCommandInfo::wantsKeyUpDownCallbacks);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress (KeyPress::spaceKey, 0, 0));
-        break;
+        case JucerCommandIDs::spaceBarDrag:
+            result.setInfo (TRANS("Scroll while dragging mouse"), TRANS("When held down, this key lets you scroll around by dragging with the mouse."),
+                            CommandCategories::view, ApplicationCommandInfo::wantsKeyUpDownCallbacks);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress (KeyPress::spaceKey, 0, 0));
+            break;
 
-    case JucerCommandIDs::compOverlay0:
-    case JucerCommandIDs::compOverlay33:
-    case JucerCommandIDs::compOverlay66:
-    case JucerCommandIDs::compOverlay100:
+        case JucerCommandIDs::compOverlay0:
+        case JucerCommandIDs::compOverlay33:
+        case JucerCommandIDs::compOverlay66:
+        case JucerCommandIDs::compOverlay100:
         {
             int amount = 0, num = 0;
 
@@ -810,8 +810,8 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
                 currentAmount = 33;
 
             result.setInfo (commandID == JucerCommandIDs::compOverlay0
-                                ? TRANS("No component overlay")
-                                : TRANS("Overlay with opacity of 123%").replace ("123", String (amount)),
+                            ? TRANS("No component overlay")
+                            : TRANS("Overlay with opacity of 123%").replace ("123", String (amount)),
                             TRANS("Changes the opacity of the components that are shown over the top of the graphics editor."),
                             CommandCategories::view, 0);
             result.setActive (currentPaintRoutine != nullptr && document->getComponentLayout() != nullptr);
@@ -881,27 +881,28 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
             result.setActive (canPaste);
         }
 
-        break;
+            break;
 
-    case StandardApplicationCommandIDs::del:
-        result.setInfo (TRANS ("Delete"), String(), "Editing", 0);
-        result.setActive (isSomethingSelected());
-        break;
+        case StandardApplicationCommandIDs::del:
+            result.setInfo (TRANS ("Delete"), String(), "Editing", 0);
+            result.setActive (isSomethingSelected());
+            break;
 
-    case StandardApplicationCommandIDs::selectAll:
-        result.setInfo (TRANS ("Select All"), String(), "Editing", 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('a', cmd, 0));
-        break;
+        case StandardApplicationCommandIDs::selectAll:
+            result.setInfo (TRANS ("Select All"), String(), "Editing", 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('a', cmd, 0));
+            break;
 
-    case StandardApplicationCommandIDs::deselectAll:
-        result.setInfo (TRANS ("Deselect All"), String(), "Editing", 0);
-        result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
-        result.defaultKeypresses.add (KeyPress ('d', cmd, 0));
-        break;
+        case StandardApplicationCommandIDs::deselectAll:
+            result.setInfo (TRANS ("Deselect All"), String(), "Editing", 0);
+            result.setActive (currentPaintRoutine != nullptr || currentLayout != nullptr);
+            result.defaultKeypresses.add (KeyPress ('d', cmd, 0));
+            break;
 
-    default:
-        break;
+
+        default:
+            break;
     }
 }
 
@@ -913,14 +914,14 @@ bool JucerDocumentEditor::perform (const InvocationInfo& info)
     document->beginTransaction();
 
     if (info.commandID >= JucerCommandIDs::newComponentBase
-         && info.commandID < JucerCommandIDs::newComponentBase + ObjectTypes::numComponentTypes)
+        && info.commandID < JucerCommandIDs::newComponentBase + ObjectTypes::numComponentTypes)
     {
         addComponent (info.commandID - JucerCommandIDs::newComponentBase);
         return true;
     }
 
     if (info.commandID >= JucerCommandIDs::newElementBase
-         && info.commandID < JucerCommandIDs::newElementBase + ObjectTypes::numElementTypes)
+        && info.commandID < JucerCommandIDs::newElementBase + ObjectTypes::numElementTypes)
     {
         addElement (info.commandID - JucerCommandIDs::newElementBase);
         return true;
@@ -976,18 +977,18 @@ bool JucerDocumentEditor::perform (const InvocationInfo& info)
         case JucerCommandIDs::compOverlay33:
         case JucerCommandIDs::compOverlay66:
         case JucerCommandIDs::compOverlay100:
-            {
-                int amount = 0;
+        {
+            int amount = 0;
 
-                if (info.commandID == JucerCommandIDs::compOverlay33)
-                    amount = 33;
-                else if (info.commandID == JucerCommandIDs::compOverlay66)
-                    amount = 66;
-                else if (info.commandID == JucerCommandIDs::compOverlay100)
-                    amount = 100;
+            if (info.commandID == JucerCommandIDs::compOverlay33)
+                amount = 33;
+            else if (info.commandID == JucerCommandIDs::compOverlay66)
+                amount = 66;
+            else if (info.commandID == JucerCommandIDs::compOverlay100)
+                amount = 100;
 
-                document->setComponentOverlayOpacity (amount * 0.01f);
-            }
+            document->setComponentOverlayOpacity (amount * 0.01f);
+        }
             break;
 
         case JucerCommandIDs::bringBackLostItems:
@@ -1080,21 +1081,21 @@ bool JucerDocumentEditor::perform (const InvocationInfo& info)
             break;
 
         case StandardApplicationCommandIDs::paste:
+        {
+            if (ScopedPointer<XmlElement> doc = XmlDocument::parse (SystemClipboard::getTextFromClipboard()))
             {
-                if (ScopedPointer<XmlElement> doc = XmlDocument::parse (SystemClipboard::getTextFromClipboard()))
+                if (doc->hasTagName (ComponentLayout::clipboardXmlTag))
                 {
-                    if (doc->hasTagName (ComponentLayout::clipboardXmlTag))
-                    {
-                        if (currentLayout != nullptr)
-                            currentLayout->paste();
-                    }
-                    else if (doc->hasTagName (PaintRoutine::clipboardXmlTag))
-                    {
-                        if (currentPaintRoutine != nullptr)
-                            currentPaintRoutine->paste();
-                    }
+                    if (currentLayout != nullptr)
+                        currentLayout->paste();
+                }
+                else if (doc->hasTagName (PaintRoutine::clipboardXmlTag))
+                {
+                    if (currentPaintRoutine != nullptr)
+                        currentPaintRoutine->paste();
                 }
             }
+        }
             break;
 
         case StandardApplicationCommandIDs::del:
@@ -1147,7 +1148,7 @@ JucerDocumentEditor* JucerDocumentEditor::getActiveDocumentHolder()
 {
     ApplicationCommandInfo info (0);
     return dynamic_cast<JucerDocumentEditor*> (ProjucerApplication::getCommandManager()
-                                                  .getTargetForCommand (JucerCommandIDs::editCompLayout, info));
+                                               .getTargetForCommand (JucerCommandIDs::editCompLayout, info));
 }
 
 Image JucerDocumentEditor::createComponentLayerSnapshot() const

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
@@ -125,26 +125,29 @@ public:
         if (state != nullptr)
             propsPanel->restoreOpennessState (*state);
 
-        if (paintRoutine.getSelectedElements().getNumSelected() == 1) // xxx need to cope with multiple
-        {
-            if (PaintElement* const pe = paintRoutine.getSelectedElements().getSelectedItem (0))
-            {
-                if (paintRoutine.containsElement (pe))
-                {
-                    Array <PropertyComponent*> props;
-                    pe->getEditableProperties (props);
+        if (paintRoutine.getSelectedElements().getNumSelected() == 0 )
+            return;  // D STENNING
 
-                    propsPanel->addSection (pe->getTypeName(), props);
-                }
+        bool multipleSelected = (paintRoutine.getSelectedElements().getNumSelected() > 1 );
+
+        if (PaintElement* const pe = paintRoutine.getSelectedElements().getSelectedItem (0))
+        {
+            if (paintRoutine.containsElement (pe))
+            {
+                Array <PropertyComponent*> props;
+                pe->getEditableProperties (props, multipleSelected);
+
+                propsPanel->addSection (pe->getTypeName(), props);
             }
         }
+
 
         if (paintRoutine.getSelectedPoints().getNumSelected() == 1) // xxx need to cope with multiple
         {
             if (PathPoint* const point = paintRoutine.getSelectedPoints().getSelectedItem (0))
             {
                 Array <PropertyComponent*> props;
-                point->getEditableProperties (props);
+                point->getEditableProperties (props, false );
 
                 propsPanel->addSection ("Path segment", props);
             }

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
@@ -1,28 +1,28 @@
 /*
-  ==============================================================================
+ ==============================================================================
 
-   This file is part of the JUCE library.
-   Copyright (c) 2017 - ROLI Ltd.
+ This file is part of the JUCE library.
+ Copyright (c) 2017 - ROLI Ltd.
 
-   JUCE is an open source library subject to commercial or open-source
-   licensing.
+ JUCE is an open source library subject to commercial or open-source
+ licensing.
 
-   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
-   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
-   27th April 2017).
+ By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+ Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+ 27th April 2017).
 
-   End User License Agreement: www.juce.com/juce-5-licence
-   Privacy Policy: www.juce.com/juce-5-privacy-policy
+ End User License Agreement: www.juce.com/juce-5-licence
+ Privacy Policy: www.juce.com/juce-5-privacy-policy
 
-   Or: You may also use this code under the terms of the GPL v3 (see
-   www.gnu.org/licenses).
+ Or: You may also use this code under the terms of the GPL v3 (see
+ www.gnu.org/licenses).
 
-   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
-   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
-   DISCLAIMED.
+ JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+ EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+ DISCLAIMED.
 
-  ==============================================================================
-*/
+ ==============================================================================
+ */
 
 #include "../../jucer_Headers.h"
 #include "jucer_PaintRoutinePanel.h"
@@ -32,14 +32,14 @@
 
 //==============================================================================
 class ComponentBackgroundColourProperty    : public JucerColourPropertyComponent,
-                                             private ChangeListener
+private ChangeListener
 {
 public:
     ComponentBackgroundColourProperty (JucerDocument& doc,
                                        PaintRoutine& routine_)
-        : JucerColourPropertyComponent ("background", false),
-          document (doc),
-          routine (routine_)
+    : JucerColourPropertyComponent ("background", false),
+    document (doc),
+    routine (routine_)
     {
         document.addChangeListener (this);
     }
@@ -70,13 +70,13 @@ protected:
 
 //==============================================================================
 class GraphicsPropsPanel  : public Component,
-                            public ChangeListener
+public ChangeListener
 {
 public:
     GraphicsPropsPanel (PaintRoutine& paintRoutine_,
                         JucerDocument* doc)
-        : paintRoutine (paintRoutine_),
-          document (doc)
+    : paintRoutine (paintRoutine_),
+    document (doc)
     {
         paintRoutine.getSelectedElements().addChangeListener (this);
         paintRoutine.getSelectedPoints().addChangeListener (this);
@@ -111,6 +111,7 @@ public:
     void updateList()
     {
         ScopedPointer<XmlElement> state (propsPanel->getOpennessState());
+
 
         clear();
 
@@ -165,10 +166,10 @@ private:
 //==============================================================================
 PaintRoutinePanel::PaintRoutinePanel (JucerDocument& doc, PaintRoutine& pr,
                                       JucerDocumentEditor* documentHolder)
-    : EditingPanelBase (doc,
-                        new GraphicsPropsPanel (pr, &doc),
-                        new PaintRoutineEditor (pr, doc, documentHolder)),
-      routine (pr)
+: EditingPanelBase (doc,
+                    new GraphicsPropsPanel (pr, &doc),
+                    new PaintRoutineEditor (pr, doc, documentHolder)),
+routine (pr)
 {
 }
 


### PR DESCRIPTION
…rder to add the following functionality focused around setting width, height , x and y coordinates to more than one selected object at one time.

The operations added are:

** Align Left, Right, Top Bottom,  achieved by means of four new menu items added to the contextual menu when more than one object is highlighted.

** setting the width, height , x and y coordinates to more than one highlighted object by means of the properties inspector at the right hand side.

Whenever more than one object is selected the list of editable properties shown reduces to just those shared by all the highlighted objects - namely x,y, height and width.

All the source files changed were in subdirectories of Projucer/ComponentEditor.
Many methods have had an extra argument added to achieve this : bool multipleSelected.

In addition I had to move the enum ComponentPositionDimension into a different header file  - namely jucer_ComponentLayout.h

Files changed:

jucer_PaintRoutine.cpp
jucer_JucerDocumentEditor.cpp
jucer_HyperlinkButtonHandler.h
jucer_ViewportHandler.h
jucer_TreeViewHandler.h
jucer_ToggleButtonHandler.h
jucer_TextEditorHandler.h
jucer_TextButtonHandler.h
jucer_TabbedComponentHandler.h
jucer_SliderHandler.h
jucer_PositionPropertyBase.h
jucer_PaintRoutinePanel.cpp
jucer_PaintRoutine.h
jucer_PaintElementText.h
jucer_PaintElementRoundedRectangle.h
jucer_PaintElementRectangle.h
jucer_PaintElementPath.h
jucer_PaintElementPath.cpp
jucer_PaintElementGroup.h
jucer_PaintElementEllipse.h
jucer_PaintElement.h
jucer_PaintElement.cpp
jucer_LabelHandler.h
jucer_JucerComponentHandler.h
jucer_JucerCommandIDs.h
jucer_ImageButtonHandler.h
jucer_GroupComponentHandler.h
jucer_GenericComponentHandler.h