### PR TITLE
Changes to Projucer Component Editor and Graphics element editor in o…

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ButtonHandler.h
@@ -36,9 +36,12 @@ public:
                                 defaultWidth_, defaultHeight_)
     {}
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Button* const b = dynamic_cast<Button*> (component);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComboBoxHandler.h
@@ -73,9 +73,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         ComboBox* const c = dynamic_cast<ComboBox*> (component);
         jassert (c != nullptr);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.cpp
@@ -87,6 +87,11 @@ void ComponentTypeHandler::showPopupMenu (Component*, ComponentLayout&)
     m.addCommandItem (commandManager, JucerCommandIDs::toFront);
     m.addCommandItem (commandManager, JucerCommandIDs::toBack);
     m.addSeparator();
+    m.addCommandItem (commandManager, JucerCommandIDs::alignLeft);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignRight);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignTop);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignBottom);
+    m.addSeparator();
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::cut);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::copy);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::paste);
@@ -330,7 +335,7 @@ public:
     ComponentPositionProperty (Component* comp,
                                JucerDocument& doc,
                                const String& name,
-                               ComponentPositionDimension dimension_)
+                               ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
         : PositionPropertyBase (comp, name, dimension_,
                                 true, true,
                                 doc.getComponentLayout()),
@@ -347,6 +352,11 @@ public:
     void setPosition (const RelativePositionedRectangle& newPos)
     {
         document.getComponentLayout()->setComponentPosition (component, newPos, true);
+    }
+
+    void setSingleDimension(bool undoable, const double newValue , ComponentLayout::ComponentPositionDimension dim)// D STENNING
+    {
+        document.getComponentLayout()->setSingleDimension ( undoable, newValue,dim );
     }
 
     RelativePositionedRectangle getPosition() const
@@ -413,27 +423,33 @@ private:
 //==============================================================================
 void ComponentTypeHandler::getEditableProperties (Component* component,
                                                   JucerDocument& document,
-                                                  Array<PropertyComponent*>& props)
+                                                  Array<PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new ComponentMemberNameProperty (component, document));
-    props.add (new ComponentNameProperty (component, document));
-    props.add (new ComponentVirtualClassProperty (component, document));
+    if ( ! multipleSelected )
+    {
+        props.add (new ComponentMemberNameProperty (component, document));
+        props.add (new ComponentNameProperty (component, document));
+        props.add (new ComponentVirtualClassProperty (component, document));
+    }
 
-    props.add (new ComponentPositionProperty (component, document, "x", ComponentPositionProperty::componentX));
-    props.add (new ComponentPositionProperty (component, document, "y", ComponentPositionProperty::componentY));
-    props.add (new ComponentPositionProperty (component, document, "width", ComponentPositionProperty::componentWidth));
-    props.add (new ComponentPositionProperty (component, document, "height", ComponentPositionProperty::componentHeight));
+    props.add (new ComponentPositionProperty (component, document, "x", ComponentLayout::componentX));  // D STENNING
+    props.add (new ComponentPositionProperty (component, document, "y", ComponentLayout::componentY));
+    props.add (new ComponentPositionProperty (component, document, "width", ComponentLayout::componentWidth));
+    props.add (new ComponentPositionProperty (component, document, "height", ComponentLayout::componentHeight));
 
-    if (dynamic_cast<SettableTooltipClient*> (component) != nullptr)
-        props.add (new TooltipProperty (component, document));
+    if ( ! multipleSelected )
+    {
+        if (dynamic_cast<SettableTooltipClient*> (component) != nullptr)
+            props.add (new TooltipProperty (component, document));
 
-    props.add (new FocusOrderProperty (component, document));
+        props.add (new FocusOrderProperty (component, document));
+    }
 }
 
-void ComponentTypeHandler::addPropertiesToPropertyPanel (Component* comp, JucerDocument& document, PropertyPanel& panel)
+void ComponentTypeHandler::addPropertiesToPropertyPanel (Component* comp, JucerDocument& document, PropertyPanel& panel, bool multipleSelected)  //  D STENNING
 {
     Array <PropertyComponent*> props;
-    getEditableProperties (comp, document, props);
+    getEditableProperties (comp, document, props, multipleSelected);
 
     panel.addSection (getClassName (comp), props);
 }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ComponentTypeHandler.h
@@ -63,11 +63,12 @@ public:
 
     virtual void getEditableProperties (Component* component,
                                         JucerDocument& document,
-                                        Array<PropertyComponent*>& props);
+                                        Array<PropertyComponent*>& props, bool multipleSelected);  // D STENNING
 
     virtual void addPropertiesToPropertyPanel (Component* component,
                                                JucerDocument& document,
-                                               PropertyPanel& panel);
+                                               PropertyPanel& panel,
+                                               bool multipleSelected);  // D STENNING
 
 
     void registerEditableColour (int colourId,

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GenericComponentHandler.h
@@ -99,9 +99,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new GenericCompClassProperty (dynamic_cast<GenericComponent*> (component), document));
         props.add (new GenericCompParamsProperty (dynamic_cast<GenericComponent*> (component), document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_GroupComponentHandler.h
@@ -99,9 +99,12 @@ public:
         code.constructorCode += s;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new GroupTitleProperty ((GroupComponent*) component, document));
         props.add (new GroupJustificationProperty ((GroupComponent*) component, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_HyperlinkButtonHandler.h
@@ -41,10 +41,14 @@ public:
         return hb;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
         HyperlinkButton* const hb = (HyperlinkButton*) component;
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         props.add (new HyperlinkURLProperty (hb, document));
         addColourProperties (component, document, props);
     }

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ImageButtonHandler.h
@@ -45,9 +45,12 @@ public:
         return new ImageButton ("new button");
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         addColourProperties (component, document, props);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_JucerComponentHandler.h
@@ -88,11 +88,14 @@ public:
         return jucerCompClassName;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
         TestComponent* const tc = dynamic_cast<TestComponent*> (component);
 
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new JucerCompFileProperty (tc, document));
         props.add (new ConstructorParamsProperty (tc, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_LabelHandler.h
@@ -169,9 +169,12 @@ public:
         }
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Label* const l = dynamic_cast<Label*> (component);
         props.add (new LabelTextProperty          (l, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_SliderHandler.h
@@ -172,9 +172,12 @@ struct SliderHandler  : public ComponentTypeHandler
         }
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props) override
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected) override
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Slider* s = dynamic_cast<Slider*> (component);
         jassert (s != 0);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TabbedComponentHandler.h
@@ -90,9 +90,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& doc, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& doc, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, doc, props);
+        ComponentTypeHandler::getEditableProperties (component, doc, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         TabbedComponent* const t = dynamic_cast<TabbedComponent*> (component);
 
@@ -108,9 +111,9 @@ public:
             props.add (new TabRemoveTabProperty (t, doc));
     }
 
-    void addPropertiesToPropertyPanel (Component* comp, JucerDocument& doc, PropertyPanel& panel)
+    void addPropertiesToPropertyPanel (Component* comp, JucerDocument& doc, PropertyPanel& panel, bool multipleSelected)
     {
-        ComponentTypeHandler::addPropertiesToPropertyPanel (comp, doc, panel);
+        ComponentTypeHandler::addPropertiesToPropertyPanel(comp, doc, panel, multipleSelected);
 
         TabbedComponent* const t = dynamic_cast<TabbedComponent*> (comp);
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextButtonHandler.h
@@ -41,9 +41,13 @@ public:
         return new TextButton ("new button", String());
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         addColourProperties (component, document, props);
     }
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TextEditorHandler.h
@@ -81,9 +81,13 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
 
         TextEditor* const t = dynamic_cast<TextEditor*> (component);
         jassert (t != nullptr);

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ToggleButtonHandler.h
@@ -38,9 +38,12 @@ public:
         return new ToggleButton ("new toggle button");
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ButtonHandler::getEditableProperties (component, document, props);
+        ButtonHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         props.add (new ToggleButtonStateProperty ((ToggleButton*) component, document));
 

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_TreeViewHandler.h
@@ -64,9 +64,13 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
+
         TreeView* const t = dynamic_cast<TreeView*> (component);
 
         props.add (new TreeViewRootItemProperty (t, document));

--- a/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/components/jucer_ViewportHandler.h
@@ -76,9 +76,12 @@ public:
         return true;
     }
 
-    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props)
+    void getEditableProperties (Component* component, JucerDocument& document, Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ComponentTypeHandler::getEditableProperties (component, document, props);
+        ComponentTypeHandler::getEditableProperties (component, document, props, multipleSelected);
+
+        if ( multipleSelected)  // D STENNING
+            return;
 
         Viewport* const v = dynamic_cast<Viewport*> (component);
 

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.cpp
@@ -574,8 +574,193 @@ void ComponentLayout::setComponentPosition (Component* comp,
             changed();
         }
     }
+
 }
 
+
+
+void ComponentLayout::setComponentSingleDimension( Component* comp, const bool undoable, const double value, ComponentLayout::ComponentPositionDimension dimension) // D STENNING)
+{
+    RelativePositionedRectangle newPos = ComponentTypeHandler::getComponentPosition (comp);
+    PositionedRectangle p (newPos.rect);
+
+    switch (dimension)
+    {
+        case ComponentLayout::componentX:
+            if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                p.setX (value / 100.0);
+            else
+                p.setX (value);
+            break;
+
+        case ComponentLayout::componentY:
+            if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+                p.setY (value / 100.0);
+            else
+                p.setY (value);
+            break;
+
+        case ComponentLayout::componentWidth:
+            if (p.getWidthMode() == PositionedRectangle::proportionalSize)
+                p.setWidth (value / 100.0);
+            else
+                p.setWidth (value);
+            break;
+
+        case ComponentLayout::componentHeight:
+            if (p.getHeightMode() == PositionedRectangle::proportionalSize)
+                p.setHeight (value / 100.0);
+            else
+                p.setHeight (value);
+            break;
+
+        default:
+            jassertfalse;
+            break;
+    };
+
+    if (p != newPos.rect)
+    {
+        newPos.rect = p;
+
+        if (undoable)
+        {
+            perform (new ChangeCompPositionAction (comp, *this, newPos), "Move components");
+        }
+        else
+        {
+            ComponentTypeHandler::setComponentPosition (comp, newPos, this);
+            changed();
+        }
+    }
+}
+
+void ComponentLayout::setSingleDimension(const bool undoable,const double value ,ComponentPositionDimension dimension) // D STENNING
+{
+    for (auto c : selected)
+    {
+        setComponentSingleDimension( c,undoable, value, dimension);
+    }
+
+}
+
+void ComponentLayout::alignLeft()  // D STENNING
+{
+    ComponentPositionDimension dimension = componentX;
+    if ( components.size() > -1 )
+    {
+        Component* const comp = components[0];
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getX() * 100.0;
+        else
+            value =  p.getX();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void ComponentLayout::alignRight()
+{
+    ComponentPositionDimension dimension = componentX;
+
+    if ( selected.getNumSelected() > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        PositionedRectangle p (newPos.rect);
+
+        double rightX =  p.getX()+p.getWidth();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            rightX =  (p.getX()+p.getWidth()) * 100.0;
+
+
+
+        for (auto c : selected)
+        {
+            if (c != comp)
+            {
+                RelativePositionedRectangle compPos (ComponentTypeHandler::getComponentPosition (c));
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldW =  oldPR.getWidth();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                {
+                    oldW *=  100.0;
+                }
+
+                double value = rightX - oldW;
+
+                setComponentSingleDimension( c,true, value, dimension);
+            }
+        }
+
+    }
+
+
+}
+void ComponentLayout::alignTop()
+{
+    ComponentPositionDimension dimension = componentY;
+    if ( selected.getNumSelected()  > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getY() * 100.0;
+        else
+            value =  p.getY();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void ComponentLayout::alignBottom() // D STENNING
+{
+    ComponentPositionDimension dimension = componentY;
+
+    if ( selected.getNumSelected() > -1 )
+    {
+        Component* const comp = selected.getSelectedItem(0);
+        RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));
+        PositionedRectangle p (newPos.rect);
+
+        double bottomY =  p.getY()+p.getHeight();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            bottomY *= 100.0;
+
+        for (auto c : selected)
+        {
+            if (c != comp)
+            {
+                RelativePositionedRectangle compPos (ComponentTypeHandler::getComponentPosition (c));
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldH =  oldPR.getHeight();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                    oldH *=  100.0;
+
+                double value = bottomY - oldH;
+
+                setComponentSingleDimension( c,true, value, dimension);
+            }
+        }
+    }
+
+}
+
+
+//=========================================================================================
 void ComponentLayout::updateStoredComponentPosition (Component* comp, const bool undoable)
 {
     RelativePositionedRectangle newPos (ComponentTypeHandler::getComponentPosition (comp));

--- a/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_ComponentLayout.h
@@ -39,6 +39,16 @@ class JucerDocument;
 class ComponentLayout
 {
 public:
+
+    enum ComponentPositionDimension // D STENNING
+    {
+        componentX          = 0,
+        componentY          = 1,
+        componentWidth      = 2,
+        componentHeight     = 3
+    };
+
+
     //==============================================================================
     ComponentLayout();
     ~ComponentLayout();
@@ -66,6 +76,9 @@ public:
 
     void setComponentPosition (Component* comp, const RelativePositionedRectangle& newPos, const bool undoable);
     void updateStoredComponentPosition (Component* comp, const bool undoable);
+
+    void setComponentSingleDimension(Component* comp,const bool undoable, const double value , ComponentPositionDimension dim); // D STENNING)
+    void setSingleDimension( const bool undoable, const double value , ComponentPositionDimension dim); // D STENNING
 
     //==============================================================================
     Component* getComponentRelativePosTarget (Component* comp, int whichDimension) const;
@@ -95,6 +108,11 @@ public:
 
     void selectedToFront();
     void selectedToBack();
+
+    void alignLeft();  // D STENNING
+    void alignRight();
+    void alignTop();
+    void alignBottom();
 
     void startDragging();
     void dragSelectedComps (int dxFromDragStart, int dyFromDragStart, const bool allowSnap = true);

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.cpp
@@ -360,6 +360,180 @@ void PaintRoutine::selectAll()
     }
 }
 
+
+void PaintRoutine::setSingleDimension(const bool undoable,const double value, ComponentLayout::ComponentPositionDimension dimension) // D STENNING
+{
+    for (auto e : selectedElements)
+    {
+        setElementSingleDimension( e,undoable, value, dimension);
+    }
+
+}
+
+void PaintRoutine::setElementSingleDimension(PaintElement* e,const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dimension)// D STENNING)
+{
+    RelativePositionedRectangle newPos = e->getPosition();
+    PositionedRectangle p (newPos.rect);
+
+    switch (dimension)
+    {
+        case ComponentLayout::componentX:
+            if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                p.setX (value / 100.0);
+            else
+                p.setX (value);
+            break;
+
+        case ComponentLayout::componentY:
+            if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+                p.setY (value / 100.0);
+            else
+                p.setY (value);
+            break;
+
+        case ComponentLayout::componentWidth:
+            if (p.getWidthMode() == PositionedRectangle::proportionalSize)
+                p.setWidth (value / 100.0);
+            else
+                p.setWidth (value);
+            break;
+
+        case ComponentLayout::componentHeight:
+            if (p.getHeightMode() == PositionedRectangle::proportionalSize)
+                p.setHeight (value / 100.0);
+            else
+                p.setHeight (value);
+            break;
+
+        default:
+            jassertfalse;
+            break;
+    };
+
+    if (p != newPos.rect)
+    {
+        newPos.rect = p;
+        e->setPosition(newPos, undoable);
+    }
+}
+
+void PaintRoutine::alignLeft()  // D STENNING
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentX;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        double value;
+        PositionedRectangle p (newPos.rect);
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getX() * 100.0;
+        else
+            value =  p.getX();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+
+
+void PaintRoutine::alignRight()
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentX;
+
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+
+        double rightX =  p.getX()+p.getWidth();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            rightX =  (p.getX()+p.getWidth()) * 100.0;
+
+        for (auto c : selectedElements)
+        {
+            if (c != e)
+            {
+                RelativePositionedRectangle compPos = c->getPosition();
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldW =  oldPR.getWidth();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                {
+                    oldW *=  100.0;
+                }
+
+                double value = rightX - oldW;
+
+                setElementSingleDimension( c,true, value, dimension);
+            }
+        }
+
+    }
+
+
+}
+void PaintRoutine::alignTop()
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentY;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+        double value;
+
+        if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
+            value =  p.getY() * 100.0;
+        else
+            value =  p.getY();
+
+        setSingleDimension( true, value, dimension );
+
+    }
+
+}
+void PaintRoutine::alignBottom() // D STENNING
+{
+    ComponentLayout::ComponentPositionDimension dimension = ComponentLayout::componentY;
+    if ( selectedElements.getNumSelected() > -1 )
+    {
+        auto e = selectedElements.getSelectedItem(0);
+        RelativePositionedRectangle newPos = e->getPosition();
+        PositionedRectangle p (newPos.rect);
+
+        double bottomY =  p.getY()+p.getHeight();
+
+        if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+            bottomY *= 100.0;
+
+        for (auto c : selectedElements)
+        {
+            if (c != e)
+            {
+                RelativePositionedRectangle compPos =  c->getPosition();
+                PositionedRectangle oldPR (compPos.rect);
+
+                double oldH =  oldPR.getHeight();
+                if (oldPR.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
+                    oldH *=  100.0;
+
+                double value = bottomY - oldH;
+
+                setElementSingleDimension( c,true, value, dimension);
+            }
+        }
+    }
+
+}
+
+//=========================================================================================
+
+
 void PaintRoutine::selectedToFront()
 {
     const SelectedItemSet<PaintElement*> temp (selectedElements);

--- a/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
+++ b/extras/Projucer/Source/ComponentEditor/jucer_PaintRoutine.h
@@ -62,6 +62,16 @@ public:
     void elementToFront (PaintElement* element, const bool undoable);
     void elementToBack (PaintElement* element, const bool undoable);
 
+
+    void setSingleDimension(const bool undoable,const double value, ComponentLayout::ComponentPositionDimension dimension); // D STENNING
+    void setElementSingleDimension(PaintElement* e,const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim); // D STENNING)
+
+    void alignLeft();  // D STENNING
+    void alignRight();
+    void alignTop();
+    void alignBottom();
+
+
     const Colour getBackgroundColour() const noexcept                       { return backgroundColour; }
     void setBackgroundColour (Colour newColour) noexcept;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.cpp
@@ -167,7 +167,7 @@ class ElementFillPositionProperty   : public PositionPropertyBase
 public:
     ElementFillPositionProperty (ColouredElement* const owner_,
                                  const String& name,
-                                 ComponentPositionDimension dimension_,
+                                 ComponentLayout::ComponentPositionDimension dimension_,
                                  const bool isStart_,
                                  const bool isForStroke_)
      : PositionPropertyBase (owner_, name, dimension_, false, false,
@@ -193,6 +193,15 @@ public:
             listener.owner->setFillType (fill, true);
         else
             listener.owner->setStrokeFill (fill, true);
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -397,7 +406,7 @@ class ImageBrushPositionProperty    : public PositionPropertyBase
 public:
     ImageBrushPositionProperty (ColouredElement* const owner_,
                                 const String& name,
-                                ComponentPositionDimension dimension_,
+                                ComponentLayout::ComponentPositionDimension dimension_,
                                 const bool isForStroke_)
         : PositionPropertyBase (owner_, name, dimension_, false, false,
                                 owner_->getDocument()->getComponentLayout()),
@@ -421,6 +430,15 @@ public:
             type.imageAnchor = newPos;
             listener.owner->setFillType (type, true);
         }
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -506,10 +524,11 @@ ColouredElement::~ColouredElement()
 }
 
 //==============================================================================
-void ColouredElement::getEditableProperties (Array <PropertyComponent*>& props)
+void ColouredElement::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected) // D STENNING
 {
-    PaintElement::getEditableProperties (props);
-    getColourSpecificProperties (props);
+    PaintElement::getEditableProperties (props, multipleSelected);
+    if( !multipleSelected)
+        getColourSpecificProperties (props);
 }
 
 void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& props)
@@ -525,17 +544,17 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
     case JucerFillType::linearGradient:
     case JucerFillType::radialGradient:
         props.add (new ElementFillColourProperty ("colour 1", this, ElementFillColourProperty::gradientColour1, false));
-        props.add (new ElementFillPositionProperty (this, "x1", PositionPropertyBase::componentX, true, false));
-        props.add (new ElementFillPositionProperty (this, "y1", PositionPropertyBase::componentY, true, false));
+        props.add (new ElementFillPositionProperty (this, "x1", ComponentLayout::componentX, true, false));
+        props.add (new ElementFillPositionProperty (this, "y1", ComponentLayout::componentY, true, false));
         props.add (new ElementFillColourProperty ("colour 2", this, ElementFillColourProperty::gradientColour2, false));
-        props.add (new ElementFillPositionProperty (this, "x2", PositionPropertyBase::componentX, false, false));
-        props.add (new ElementFillPositionProperty (this, "y2", PositionPropertyBase::componentY, false, false));
+        props.add (new ElementFillPositionProperty (this, "x2", ComponentLayout::componentX, false, false));
+        props.add (new ElementFillPositionProperty (this, "y2", ComponentLayout::componentY, false, false));
         break;
 
     case JucerFillType::imageBrush:
         props.add (new ImageBrushResourceProperty (this, false));
-        props.add (new ImageBrushPositionProperty (this, "anchor x", PositionPropertyBase::componentX, false));
-        props.add (new ImageBrushPositionProperty (this, "anchor y", PositionPropertyBase::componentY, false));
+        props.add (new ImageBrushPositionProperty (this, "anchor x", ComponentLayout::componentX, false));
+        props.add (new ImageBrushPositionProperty (this, "anchor y", ComponentLayout::componentY, false));
         props.add (new ImageBrushOpacityProperty (this, false));
         break;
 
@@ -569,17 +588,17 @@ void ColouredElement::getColourSpecificProperties (Array <PropertyComponent*>& p
                 case JucerFillType::linearGradient:
                 case JucerFillType::radialGradient:
                     props.add (new ElementFillColourProperty ("colour 1", this, ElementFillColourProperty::gradientColour1, true));
-                    props.add (new ElementFillPositionProperty (this, "x1", PositionPropertyBase::componentX, true, true));
-                    props.add (new ElementFillPositionProperty (this, "y1", PositionPropertyBase::componentY, true, true));
+                    props.add (new ElementFillPositionProperty (this, "x1", ComponentLayout::componentX, true, true)); // D STENNING
+                    props.add (new ElementFillPositionProperty (this, "y1", ComponentLayout::componentY, true, true));
                     props.add (new ElementFillColourProperty ("colour 2", this, ElementFillColourProperty::gradientColour2, true));
-                    props.add (new ElementFillPositionProperty (this, "x2", PositionPropertyBase::componentX, false, true));
-                    props.add (new ElementFillPositionProperty (this, "y2", PositionPropertyBase::componentY, false, true));
+                    props.add (new ElementFillPositionProperty (this, "x2", ComponentLayout::componentX, false, true));
+                    props.add (new ElementFillPositionProperty (this, "y2", ComponentLayout::componentY, false, true));
                     break;
 
                 case JucerFillType::imageBrush:
                     props.add (new ImageBrushResourceProperty (this, true));
-                    props.add (new ImageBrushPositionProperty (this, "stroke anchor x", PositionPropertyBase::componentX, true));
-                    props.add (new ImageBrushPositionProperty (this, "stroke anchor y", PositionPropertyBase::componentY, true));
+                    props.add (new ImageBrushPositionProperty (this, "stroke anchor x", ComponentLayout::componentX, true));
+                    props.add (new ImageBrushPositionProperty (this, "stroke anchor y", ComponentLayout::componentY, true));
                     props.add (new ImageBrushOpacityProperty (this, true));
                     break;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_ColouredElement.h
@@ -47,9 +47,8 @@ public:
     ~ColouredElement();
 
     //==============================================================================
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected); //D STENNING
     void getColourSpecificProperties (Array<PropertyComponent*>& props);
-
     //==============================================================================
     const JucerFillType& getFillType() noexcept;
     void setFillType (const JucerFillType& newType, const bool undoable);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.cpp
@@ -137,6 +137,17 @@ void PaintElement::setPosition (const RelativePositionedRectangle& newPosition, 
     }
 }
 
+
+void PaintElement::setSingleDimension( const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim) // D STENNING
+{
+    (void)undoable;
+    (void)value;
+    (void)dim;
+
+    JUCE_BREAK_IN_DEBUGGER;
+
+}
+
 //==============================================================================
 Rectangle<int> PaintElement::getCurrentBounds (const Rectangle<int>& parentArea) const
 {
@@ -178,7 +189,7 @@ class ElementPositionProperty   : public PositionPropertyBase
 {
 public:
     ElementPositionProperty (PaintElement* e, const String& name,
-                             ComponentPositionDimension dimension_)
+                             ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
        : PositionPropertyBase (e, name, dimension_, true, false,
                                e->getDocument()->getComponentLayout()),
          listener (e)
@@ -191,6 +202,14 @@ public:
         listener.owner->setPosition (newPos, true);
     }
 
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        JucerDocument* jd = listener.owner->getDocument();
+        jd->getPaintRoutine(0)->setSingleDimension ( undoable, value,dim );
+
+    }
+
     RelativePositionedRectangle getPosition() const
     {
         return listener.owner->getPosition();
@@ -200,12 +219,14 @@ public:
 };
 
 //==============================================================================
-void PaintElement::getEditableProperties (Array <PropertyComponent*>& props)
+void PaintElement::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new ElementPositionProperty (this, "x", PositionPropertyBase::componentX));
-    props.add (new ElementPositionProperty (this, "y", PositionPropertyBase::componentY));
-    props.add (new ElementPositionProperty (this, "width", PositionPropertyBase::componentWidth));
-    props.add (new ElementPositionProperty (this, "height", PositionPropertyBase::componentHeight));
+    (void)multipleSelected;
+
+    props.add (new ElementPositionProperty (this, "x", ComponentLayout::componentX));
+    props.add (new ElementPositionProperty (this, "y", ComponentLayout::componentY));
+    props.add (new ElementPositionProperty (this, "width", ComponentLayout::componentWidth));
+    props.add (new ElementPositionProperty (this, "height", ComponentLayout::componentHeight));
 }
 
 //==============================================================================
@@ -480,6 +501,11 @@ void PaintElement::showPopupMenu()
 
     m.addCommandItem (commandManager, JucerCommandIDs::toFront);
     m.addCommandItem (commandManager, JucerCommandIDs::toBack);
+    m.addSeparator();
+    m.addCommandItem (commandManager, JucerCommandIDs::alignTop); // D STENNING
+    m.addCommandItem (commandManager, JucerCommandIDs::alignBottom);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignLeft);
+    m.addCommandItem (commandManager, JucerCommandIDs::alignRight);
     m.addSeparator();
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::cut);
     m.addCommandItem (commandManager, StandardApplicationCommandIDs::copy);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElement.h
@@ -28,6 +28,8 @@
 
 #include "../jucer_GeneratedCode.h"
 #include "../ui/jucer_RelativePositionedRectangle.h"
+#include "../jucer_ComponentLayout.h" // D STENNING
+
 class FillType;
 class PaintRoutine;
 class JucerDocument;
@@ -56,6 +58,7 @@ public:
 
     const RelativePositionedRectangle& getPosition() const;
     void setPosition (const RelativePositionedRectangle& newPosition, const bool undoable);
+    void setSingleDimension( const bool undoable, const double value , ComponentLayout::ComponentPositionDimension dim); // D STENNING
 
     void updateBounds (const Rectangle<int>& activeArea);
 
@@ -69,7 +72,7 @@ public:
 
     virtual void drawExtraEditorGraphics (Graphics& g, const Rectangle<int>& relativeTo);
 
-    virtual void getEditableProperties (Array<PropertyComponent*>& props);
+    virtual void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected);
 
     virtual void showPopupMenu();
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementEllipse.h
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea)
+    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea) override
     {
         fillType.setFillType (g, getDocument(), parentArea);
 
@@ -54,13 +54,13 @@ public:
         }
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props,bool multipleSelection) override // D STENNING
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelection);
         props.add (new ShapeToPathProperty (this));
     }
 
-    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
+    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) override
     {
         if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
             return;

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementGroup.h
@@ -168,9 +168,10 @@ public:
             subElements.getUnchecked(i)->draw (g, layout, parentArea);
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelection) // D STENNING
     {
-        props.add (new UngroupProperty (this));
+        if( !multipleSelection )
+            props.add (new UngroupProperty (this));
     }
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementImage.h
@@ -83,9 +83,9 @@ public:
     }
 
     //==============================================================================
-    void getEditableProperties (Array <PropertyComponent*>& props)
+    void getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
     {
-        PaintElement::getEditableProperties (props);
+        PaintElement::getEditableProperties (props, multipleSelected);
 
         props.add (new ImageElementResourceProperty (this));
         props.add (new StretchModeProperty (this));

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.cpp
@@ -349,10 +349,13 @@ void PaintElementPath::pointListChanged()
 }
 
 //==============================================================================
-void PaintElementPath::getEditableProperties (Array <PropertyComponent*>& props)
+void PaintElementPath::getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected)
 {
-    props.add (new PathWindingModeProperty (this));
-    getColourSpecificProperties (props);
+    if( !multipleSelected)
+    {
+        props.add (new PathWindingModeProperty (this));
+        getColourSpecificProperties (props);
+    }
 }
 
 //==============================================================================
@@ -1253,7 +1256,7 @@ public:
     PathPointPositionProperty (PaintElementPath* const owner_,
                                const int index_, const int pointNumber_,
                                const String& name,
-                               ComponentPositionDimension dimension_)
+                               ComponentLayout::ComponentPositionDimension dimension_) // D STENNING
         : PositionPropertyBase (owner_, name, dimension_, false, false,
                                 owner_->getDocument()->getComponentLayout()),
           owner (owner_),
@@ -1271,6 +1274,15 @@ public:
     void setPosition (const RelativePositionedRectangle& newPos)
     {
         owner->setPoint (index, pointNumber, newPos, true);
+    }
+
+    void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim)
+    {
+        // control shouldnt be getting here
+        (void)undoable;
+        (void)value;
+        (void)dim;
+        JUCE_BREAK_IN_DEBUGGER;
     }
 
     RelativePositionedRectangle getPosition() const
@@ -1453,16 +1465,20 @@ void PathPoint::changePointType (const Path::Iterator::PathElementType newType,
     }
 }
 
-void PathPoint::getEditableProperties (Array<PropertyComponent*>& props)
+void PathPoint::getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected )  // D STENNING
 {
+
+    if ( multipleSelected) // D STENNING
+        return;
+
     const int index = owner->points.indexOf (this);
     jassert (index >= 0);
 
     switch (type)
     {
         case Path::Iterator::startNewSubPath:
-            props.add (new PathPointPositionProperty (owner, index, 0, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "x", ComponentLayout::componentX));  // D STENNING
+            props.add (new PathPointPositionProperty (owner, index, 0, "y", ComponentLayout::componentY));
 
             props.add (new PathPointClosedProperty (owner, index));
             props.add (new AddNewPointProperty (owner, index));
@@ -1470,28 +1486,28 @@ void PathPoint::getEditableProperties (Array<PropertyComponent*>& props)
 
         case Path::Iterator::lineTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 
         case Path::Iterator::quadraticTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 1, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 1, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 1, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 1, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 
         case Path::Iterator::cubicTo:
             props.add (new PathPointTypeProperty (owner, index));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 y", PositionPropertyBase::componentY));
-            props.add (new PathPointPositionProperty (owner, index, 2, "x", PositionPropertyBase::componentX));
-            props.add (new PathPointPositionProperty (owner, index, 2, "y", PositionPropertyBase::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 0, "control pt1 y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 1, "control pt2 y", ComponentLayout::componentY));
+            props.add (new PathPointPositionProperty (owner, index, 2, "x", ComponentLayout::componentX));
+            props.add (new PathPointPositionProperty (owner, index, 2, "y", ComponentLayout::componentY));
             props.add (new AddNewPointProperty (owner, index));
             break;
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementPath.h
@@ -52,7 +52,7 @@ public:
                           const bool undoable);
 
     void deleteFromPath();
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected );  // D STENNING);
 
 private:
     PathPoint withChangedPointType (const Path::Iterator::PathElementType newType,
@@ -98,7 +98,7 @@ public:
     void setNonZeroWinding (const bool nonZero, const bool undoable);
 
     //==============================================================================
-    void getEditableProperties (Array<PropertyComponent*>& props);
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected);
 
     void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode);
     void applyCustomPaintSnippets (StringArray& snippets);

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRectangle.h
@@ -67,9 +67,9 @@ public:
         }
     }
 
-    void getEditableProperties (Array <PropertyComponent*>& props)
+    void getEditableProperties (Array <PropertyComponent*>& props, bool multipleSelected) // D STENNING
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelected);
 
         props.add (new ShapeToPathProperty (this));
     }

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementRoundedRectangle.h
@@ -39,7 +39,7 @@ public:
         cornerSize = 10.0;
     }
 
-    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea)
+    void draw (Graphics& g, const ComponentLayout* layout, const Rectangle<int>& parentArea) override
     {
         double x, y, w, h;
         position.getRectangleDouble (x, y, w, h, parentArea, layout);
@@ -56,11 +56,11 @@ public:
         }
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelection ) override // D STENNING
     {
         props.add (new CornerSizeProperty (this));
 
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props,multipleSelection);
 
         props.add (new ShapeToPathProperty (this));
     }
@@ -114,7 +114,7 @@ public:
     double getCornerSize() const noexcept                         { return cornerSize; }
 
     //==============================================================================
-    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode)
+    void fillInGeneratedCode (GeneratedCode& code, String& paintMethodCode) override
     {
         if (fillType.isInvisible() && (strokeType.isInvisible() || ! isStrokePresent))
             return;
@@ -156,7 +156,7 @@ public:
         paintMethodCode += s;
     }
 
-    void applyCustomPaintSnippets (StringArray& snippets)
+    void applyCustomPaintSnippets (StringArray& snippets) override
     {
         customPaintCode.clear();
 

--- a/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
+++ b/extras/Projucer/Source/ComponentEditor/paintelements/jucer_PaintElementText.h
@@ -66,9 +66,12 @@ public:
         return s;
     }
 
-    void getEditableProperties (Array<PropertyComponent*>& props)
+    void getEditableProperties (Array<PropertyComponent*>& props, bool multipleSelected)
     {
-        ColouredElement::getEditableProperties (props);
+        ColouredElement::getEditableProperties (props, multipleSelected);
+
+        if ( multipleSelected ) // D STENNING
+            return;
 
         props.add (new TextProperty (this));
         props.add (new FontNameProperty (this));

--- a/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
+++ b/extras/Projucer/Source/ComponentEditor/properties/jucer_PositionPropertyBase.h
@@ -29,6 +29,8 @@
 #include "../ui/jucer_PaintRoutineEditor.h"
 #include "../ui/jucer_ComponentLayoutEditor.h"
 
+#include "../jucer_ComponentLayout.h"  // D STENNING
+
 //==============================================================================
 /**
     Base class for a property that edits the x, y, w, or h of a PositionedRectangle.
@@ -38,17 +40,17 @@ class PositionPropertyBase  : public PropertyComponent,
                               private ButtonListener
 {
 public:
-    enum ComponentPositionDimension
-    {
-        componentX          = 0,
-        componentY          = 1,
-        componentWidth      = 2,
-        componentHeight     = 3
-    };
+    //    enum ComponentPositionDimension  D STENNING
+    //    {
+    //        componentX          = 0,
+    //        componentY          = 1,
+    //        componentWidth      = 2,
+    //        componentHeight     = 3
+    //    };
 
     PositionPropertyBase (Component* comp,
                           const String& name,
-                          ComponentPositionDimension dimension_,
+                          ComponentLayout::ComponentPositionDimension dimension_, //D STENNING
                           const bool includeAnchorOptions_,
                           const bool allowRelativeOptions_,
                           ComponentLayout* layout_)
@@ -76,28 +78,28 @@ public:
 
         switch (dimension)
         {
-        case componentX:
+        case ComponentLayout::componentX:
             if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
                 s << valueToString (p.getX() * 100.0) << '%';
             else
                 s << valueToString (p.getX());
             break;
 
-        case componentY:
+        case ComponentLayout::componentY:
             if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
                 s << valueToString (p.getY() * 100.0) << '%';
             else
                 s << valueToString (p.getY());
             break;
 
-        case componentWidth:
+        case ComponentLayout::componentWidth:
             if (p.getWidthMode() == PositionedRectangle::proportionalSize)
                 s << valueToString (p.getWidth() * 100.0) << '%';
             else
                 s << valueToString (p.getWidth());
             break;
 
-        case componentHeight:
+        case ComponentLayout::componentHeight:
             if (p.getHeightMode() == PositionedRectangle::proportionalSize)
                 s << valueToString (p.getHeight() * 100.0) << '%';
             else
@@ -125,28 +127,28 @@ public:
 
         switch (dimension)
         {
-        case componentX:
+        case ComponentLayout::componentX:
             if (p.getPositionModeX() == PositionedRectangle::proportionOfParentSize)
                 p.setX (value / 100.0);
             else
                 p.setX (value);
             break;
 
-        case componentY:
+        case ComponentLayout::componentY:
             if (p.getPositionModeY() == PositionedRectangle::proportionOfParentSize)
                 p.setY (value / 100.0);
             else
                 p.setY (value);
             break;
 
-        case componentWidth:
+        case ComponentLayout::componentWidth:
             if (p.getWidthMode() == PositionedRectangle::proportionalSize)
                 p.setWidth (value / 100.0);
             else
                 p.setWidth (value);
             break;
 
-        case componentHeight:
+        case ComponentLayout::componentHeight:
             if (p.getHeightMode() == PositionedRectangle::proportionalSize)
                 p.setHeight (value / 100.0);
             else
@@ -161,7 +163,9 @@ public:
         if (p != rpr.rect)
         {
             rpr.rect = p;
-            setPosition (rpr);
+            //  setPosition (rpr);  // OLD D STENNING
+            setSingleDimension(true,value , dimension);  // NEW D STENNING
+
         }
     }
 
@@ -192,56 +196,56 @@ public:
 
         PopupMenu m;
 
-        if (dimension == componentX || dimension == componentY)
+        if (dimension == ComponentLayout::componentX || dimension == ComponentLayout::componentY)
         {
-            const PositionedRectangle::PositionMode posMode = (dimension == componentX) ? xMode : yMode;
+            const PositionedRectangle::PositionMode posMode = (dimension == ComponentLayout::componentX) ? xMode : yMode;
 
-            m.addItem (10, ((dimension == componentX) ? "Absolute distance from left of "
-                                                      : "Absolute distance from top of ") + relCompName,
+            m.addItem (10, ((dimension == ComponentLayout::componentX) ? "Absolute distance from left of "
+                                                                       : "Absolute distance from top of ") + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentTopLeft);
 
-            m.addItem (11, ((dimension == componentX) ? "Absolute distance from right of "
-                                                      : "Absolute distance from bottom of ") + relCompName,
+            m.addItem (11, ((dimension == ComponentLayout::componentX) ? "Absolute distance from right of "
+                                                                       : "Absolute distance from bottom of ") + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentBottomRight);
 
             m.addItem (12, "Absolute distance from centre of " + relCompName,
                        true, posMode == PositionedRectangle::absoluteFromParentCentre);
 
-            m.addItem (13, ((dimension == componentX) ? "Percentage of width of "
-                                                      : "Percentage of height of ") + relCompName,
+            m.addItem (13, ((dimension == ComponentLayout::componentX) ? "Percentage of width of "
+                                                                       : "Percentage of height of ") + relCompName,
                        true, posMode == PositionedRectangle::proportionOfParentSize);
 
             m.addSeparator();
 
             if (includeAnchorOptions)
             {
-                const PositionedRectangle::AnchorPoint anchor = (dimension == componentX) ? xAnchor : yAnchor;
+                const PositionedRectangle::AnchorPoint anchor = (dimension == ComponentLayout::componentX) ? xAnchor : yAnchor;
 
-                m.addItem (14, (dimension == componentX) ? "Anchored at left of component"
-                                                         : "Anchored at top of component",
+                m.addItem (14, (dimension == ComponentLayout::componentX) ? "Anchored at left of component"
+                                                                          : "Anchored at top of component",
                            true, anchor == PositionedRectangle::anchorAtLeftOrTop);
 
                 m.addItem (15, "Anchored at centre of component", true, anchor == PositionedRectangle::anchorAtCentre);
 
-                m.addItem (16, (dimension == componentX) ? "Anchored at right of component"
-                                                         : "Anchored at bottom of component",
+                m.addItem (16, (dimension == ComponentLayout::componentX) ? "Anchored at right of component"
+                                                                          : "Anchored at bottom of component",
                            true, anchor == PositionedRectangle::anchorAtRightOrBottom);
             }
         }
         else
         {
-            const PositionedRectangle::SizeMode sizeMode = (dimension == componentWidth) ? sizeW : sizeH;
+            const PositionedRectangle::SizeMode sizeMode = (dimension == ComponentLayout::componentWidth) ? sizeW : sizeH;
 
-            m.addItem (20, (dimension == componentWidth) ? "Absolute width"
-                                                         : "Absolute height",
+            m.addItem (20, (dimension == ComponentLayout::componentWidth) ? "Absolute width"
+                                                                          : "Absolute height",
                        true, sizeMode == PositionedRectangle::absoluteSize);
 
-            m.addItem (21, ((dimension == componentWidth) ? "Percentage of width of "
-                                                          : "Percentage of height of ") + relCompName,
+            m.addItem (21, ((dimension == ComponentLayout::componentWidth) ? "Percentage of width of "
+                                                                           : "Percentage of height of ") + relCompName,
                        true, sizeMode == PositionedRectangle::proportionalSize);
 
-            m.addItem (22, ((dimension == componentWidth) ? "Subtracted from width of "
-                                                          : "Subtracted from height of ") + relCompName,
+            m.addItem (22, ((dimension == ComponentLayout::componentWidth) ? "Subtracted from width of "
+                                                                           : "Subtracted from height of ") + relCompName,
                        true, sizeMode == PositionedRectangle::parentSizeMinusAbsolute);
         }
 
@@ -262,70 +266,70 @@ public:
         switch (menuResult)
         {
         case 10:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentTopLeft;
             else
                 yMode = PositionedRectangle::absoluteFromParentTopLeft;
             break;
 
         case 11:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentBottomRight;
             else
                 yMode = PositionedRectangle::absoluteFromParentBottomRight;
             break;
 
         case 12:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::absoluteFromParentCentre;
             else
                 yMode = PositionedRectangle::absoluteFromParentCentre;
             break;
 
         case 13:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xMode = PositionedRectangle::proportionOfParentSize;
             else
                 yMode = PositionedRectangle::proportionOfParentSize;
             break;
 
         case 14:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtLeftOrTop;
             else
                 yAnchor = PositionedRectangle::anchorAtLeftOrTop;
             break;
 
         case 15:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtCentre;
             else
                 yAnchor = PositionedRectangle::anchorAtCentre;
             break;
 
         case 16:
-            if (dimension == componentX)
+            if (dimension == ComponentLayout::componentX)
                 xAnchor = PositionedRectangle::anchorAtRightOrBottom;
             else
                 yAnchor = PositionedRectangle::anchorAtRightOrBottom;
             break;
 
         case 20:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::absoluteSize;
             else
                 sizeH = PositionedRectangle::absoluteSize;
             break;
 
         case 21:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::proportionalSize;
             else
                 sizeH = PositionedRectangle::proportionalSize;
             break;
 
         case 22:
-            if (dimension == componentWidth)
+            if (dimension == ComponentLayout::componentWidth)
                 sizeW = PositionedRectangle::parentSizeMinusAbsolute;
             else
                 sizeH = PositionedRectangle::parentSizeMinusAbsolute;
@@ -406,6 +410,15 @@ public:
     //==============================================================================
     virtual void setPosition (const RelativePositionedRectangle& newPos) = 0;
 
+    virtual void setSingleDimension( bool undoable,const double value , ComponentLayout::ComponentPositionDimension dim) =0;
+    //    {
+    //        // control shouldnt be getting here
+    //        (void)undoable;
+    //        (void)value;
+    //        (void)dim;
+    //        JUCE_BREAK_IN_DEBUGGER;
+    //    }
+
     virtual RelativePositionedRectangle getPosition() const = 0;
 
 protected:
@@ -447,6 +460,6 @@ protected:
     TextButton button;
 
     Component* component;
-    ComponentPositionDimension dimension;
+    ComponentLayout::ComponentPositionDimension dimension;  // D STENNING
     const bool includeAnchorOptions, allowRelativeOptions;
 };

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_ComponentLayoutPanel.h
@@ -102,14 +102,17 @@ private:
         {
             clear();
 
-            if (layout.getSelectedSet().getNumSelected() == 1) // xxx need to cope with multiple
-            {
-                if (Component* comp = layout.getSelectedSet().getSelectedItem (0))
-                    if (ComponentTypeHandler* const type = ComponentTypeHandler::getHandlerFor (*comp))
-                        type->addPropertiesToPropertyPanel (comp, document, propsPanel);
-            }
-        }
+            if (layout.getSelectedSet().getNumSelected() == 0)
+                return;
 
+            bool multipleSelected = ( layout.getSelectedSet().getNumSelected() > 1 );
+
+            // D STENNING 30/6/17
+            if (Component* comp = layout.getSelectedSet().getSelectedItem (0))
+                if (ComponentTypeHandler* const type = ComponentTypeHandler::getHandlerFor (*comp))
+                    type->addPropertiesToPropertyPanel (comp, document, propsPanel,multipleSelected);
+
+        }
     private:
         JucerDocument& document;
         ComponentLayout& layout;

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerCommandIDs.h
@@ -58,6 +58,13 @@ namespace JucerCommandIDs
 
         newDocumentBase        = 0xf32001,
         newComponentBase       = 0xf30001,
-        newElementBase         = 0xf31001
+        newElementBase         = 0xf31001,
+
+        alignLeft              = 0xf33000, // D STENNING
+        alignRight             = 0xf33001, // D STENNING
+        alignTop               = 0xf33002, // D STENNING
+        alignBottom            = 0xf33003 // D STENNING
+
+
     };
 }

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_JucerDocumentEditor.cpp
@@ -630,6 +630,12 @@ void JucerDocumentEditor::getAllCommands (Array <CommandID>& commands)
         JucerCommandIDs::compOverlay33,
         JucerCommandIDs::compOverlay66,
         JucerCommandIDs::compOverlay100,
+
+        JucerCommandIDs::alignRight,  // D STENNING
+        JucerCommandIDs::alignLeft,
+        JucerCommandIDs::alignTop,
+        JucerCommandIDs::alignBottom, // D STENNING
+
         StandardApplicationCommandIDs::undo,
         StandardApplicationCommandIDs::redo,
         StandardApplicationCommandIDs::cut,
@@ -637,7 +643,8 @@ void JucerDocumentEditor::getAllCommands (Array <CommandID>& commands)
         StandardApplicationCommandIDs::paste,
         StandardApplicationCommandIDs::del,
         StandardApplicationCommandIDs::selectAll,
-        StandardApplicationCommandIDs::deselectAll
+        StandardApplicationCommandIDs::deselectAll,
+
     };
 
     commands.addArray (ids, numElementsInArray (ids));
@@ -810,6 +817,24 @@ void JucerDocumentEditor::getCommandInfo (const CommandID commandID, Application
             result.setActive (currentPaintRoutine != nullptr && document->getComponentLayout() != nullptr);
             result.setTicked (amount == currentAmount);
         }
+        break;
+
+
+    case JucerCommandIDs::alignTop:       // D STENNING
+        result.setInfo (TRANS("Align Top"), TRANS("xxxxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignBottom:
+        result.setInfo (TRANS("Align Bottom"), TRANS("xxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignLeft:
+        result.setInfo (TRANS("Align Left"), TRANS("xxxxxx."), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
+        break;
+    case JucerCommandIDs::alignRight:
+        result.setInfo (TRANS("Align Right"), TRANS("xxxxxx"), CommandCategories::editing, 0);
+        result.setActive (isSomethingSelected());
         break;
 
     case StandardApplicationCommandIDs::undo:
@@ -994,6 +1019,33 @@ bool JucerDocumentEditor::perform (const InvocationInfo& info)
                 currentPaintRoutine->selectedToBack();
 
             break;
+
+
+        case JucerCommandIDs::alignLeft:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignLeft();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignLeft();
+            break;
+        case JucerCommandIDs::alignRight:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignRight();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignRight();
+            break;
+        case JucerCommandIDs::alignTop:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignTop();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignTop();
+            break;
+        case JucerCommandIDs::alignBottom:    // D STENNING
+            if (currentLayout != nullptr)
+                currentLayout->alignBottom();
+            else if (currentPaintRoutine != nullptr)
+                currentPaintRoutine->alignBottom();
+            break;
+
 
         case JucerCommandIDs::group:
             if (currentPaintRoutine != nullptr)

--- a/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
+++ b/extras/Projucer/Source/ComponentEditor/ui/jucer_PaintRoutinePanel.cpp
@@ -125,26 +125,29 @@ public:
         if (state != nullptr)
             propsPanel->restoreOpennessState (*state);
 
-        if (paintRoutine.getSelectedElements().getNumSelected() == 1) // xxx need to cope with multiple
-        {
-            if (PaintElement* const pe = paintRoutine.getSelectedElements().getSelectedItem (0))
-            {
-                if (paintRoutine.containsElement (pe))
-                {
-                    Array <PropertyComponent*> props;
-                    pe->getEditableProperties (props);
+        if (paintRoutine.getSelectedElements().getNumSelected() == 0 )
+            return;  // D STENNING
 
-                    propsPanel->addSection (pe->getTypeName(), props);
-                }
+        bool multipleSelected = (paintRoutine.getSelectedElements().getNumSelected() > 1 );
+
+        if (PaintElement* const pe = paintRoutine.getSelectedElements().getSelectedItem (0))
+        {
+            if (paintRoutine.containsElement (pe))
+            {
+                Array <PropertyComponent*> props;
+                pe->getEditableProperties (props, multipleSelected);
+
+                propsPanel->addSection (pe->getTypeName(), props);
             }
         }
+
 
         if (paintRoutine.getSelectedPoints().getNumSelected() == 1) // xxx need to cope with multiple
         {
             if (PathPoint* const point = paintRoutine.getSelectedPoints().getSelectedItem (0))
             {
                 Array <PropertyComponent*> props;
-                point->getEditableProperties (props);
+                point->getEditableProperties (props, false );
 
                 propsPanel->addSection ("Path segment", props);
             }


### PR DESCRIPTION
…rder to add the following functionality focused around setting width, height , x and y coordinates to more than one selected object at one time.

The operations added are:

** Align Left, Right, Top Bottom,  achieved by means of four new menu items added to the contextual menu when more than one object is highlighted.

** setting the width, height , x and y coordinates to more than one highlighted object by means of the properties inspector at the right hand side.

Whenever more than one object is selected the list of editable properties shown reduces to just those shared by all the highlighted objects - namely x,y, height and width.

All the source files changed were in subdirectories of Projucer/ComponentEditor.

Many methods have had an extra argument added to achieve this : bool multipleSelected.

In addition I had to move the enum ComponentPositionDimension into a different header file  - namely jucer_ComponentLayout.h