### PR TITLE
List Info Chunk original spec compliance

### DIFF
--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
@@ -71,6 +71,7 @@ const char* const WavAudioFormat::riffInfoArtist                = "IART";
 const char* const WavAudioFormat::riffInfoBaseURL               = "IBSU";
 const char* const WavAudioFormat::riffInfoCinematographer       = "ICNM";
 const char* const WavAudioFormat::riffInfoComment               = "CMNT";
+const char* const WavAudioFormat::riffInfoComment2              = "ICMT";
 const char* const WavAudioFormat::riffInfoComments              = "COMM";
 const char* const WavAudioFormat::riffInfoCommissioned          = "ICMS";
 const char* const WavAudioFormat::riffInfoCopyright             = "ICOP";
@@ -111,6 +112,7 @@ const char* const WavAudioFormat::riffInfoNumberOfParts         = "PRT2";
 const char* const WavAudioFormat::riffInfoOrganisation          = "TORG";
 const char* const WavAudioFormat::riffInfoPart                  = "PRT1";
 const char* const WavAudioFormat::riffInfoProducedBy            = "IPRO";
+const char* const WavAudioFormat::riffInfoProductName		    = "IPRD";
 const char* const WavAudioFormat::riffInfoProductionDesigner    = "IPDS";
 const char* const WavAudioFormat::riffInfoProductionStudio      = "ISDT";
 const char* const WavAudioFormat::riffInfoRate                  = "RATE";
@@ -136,6 +138,7 @@ const char* const WavAudioFormat::riffInfoTechnician            = "ITCH";
 const char* const WavAudioFormat::riffInfoThirdLanguage         = "IAS3";
 const char* const WavAudioFormat::riffInfoTimeCode              = "ISMP";
 const char* const WavAudioFormat::riffInfoTitle                 = "INAM";
+const char* const WavAudioFormat::riffInfoTrackNo				= "IPRT";
 const char* const WavAudioFormat::riffInfoTrackNumber           = "TRCK";
 const char* const WavAudioFormat::riffInfoURL                   = "TURL";
 const char* const WavAudioFormat::riffInfoVegasVersionMajor     = "VMAJ";
@@ -562,6 +565,7 @@ namespace WavFileHelpers
             WavAudioFormat::riffInfoCinematographer,
             WavAudioFormat::riffInfoComment,
             WavAudioFormat::riffInfoComments,
+			WavAudioFormat::riffInfoComment2,
             WavAudioFormat::riffInfoCommissioned,
             WavAudioFormat::riffInfoCopyright,
             WavAudioFormat::riffInfoCostumeDesigner,
@@ -601,6 +605,7 @@ namespace WavFileHelpers
             WavAudioFormat::riffInfoOrganisation,
             WavAudioFormat::riffInfoPart,
             WavAudioFormat::riffInfoProducedBy,
+            WavAudioFormat::riffInfoProductName,
             WavAudioFormat::riffInfoProductionDesigner,
             WavAudioFormat::riffInfoProductionStudio,
             WavAudioFormat::riffInfoRate,
@@ -626,6 +631,7 @@ namespace WavFileHelpers
             WavAudioFormat::riffInfoThirdLanguage,
             WavAudioFormat::riffInfoTimeCode,
             WavAudioFormat::riffInfoTitle,
+            WavAudioFormat::riffInfoTrackNo,
             WavAudioFormat::riffInfoTrackNumber,
             WavAudioFormat::riffInfoURL,
             WavAudioFormat::riffInfoVegasVersionMajor,

--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.h
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.h
@@ -94,6 +94,7 @@ public:
     static const char* const riffInfoBaseURL;               /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoCinematographer;       /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoComment;               /**< Metadata property name used in INFO chunks. */
+	static const char* const riffInfoComment2;              /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoComments;              /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoCommissioned;          /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoCopyright;             /**< Metadata property name used in INFO chunks. */
@@ -134,6 +135,7 @@ public:
     static const char* const riffInfoOrganisation;          /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoPart;                  /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoProducedBy;            /**< Metadata property name used in INFO chunks. */
+    static const char* const riffInfoProductName;           /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoProductionDesigner;    /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoProductionStudio;      /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoRate;                  /**< Metadata property name used in INFO chunks. */
@@ -159,6 +161,7 @@ public:
     static const char* const riffInfoThirdLanguage;         /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoTimeCode;              /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoTitle;                 /**< Metadata property name used in INFO chunks. */
+    static const char* const riffInfoTrackNo;	            /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoTrackNumber;           /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoURL;                   /**< Metadata property name used in INFO chunks. */
     static const char* const riffInfoVegasVersionMajor;     /**< Metadata property name used in INFO chunks. */


### PR DESCRIPTION
Small change. Added extra fields to List Info Chunk to include original and official ICMT (comment) and IPRD (product or album name), and unoffical IPRT (another track number) but used by radios.
This solves a compatibility issue, original LIST Info Chunk spec (1991) and initial implementation of it i Juce did include ICMT and IPRD fields. And at the moment, there is no way to specify album name without IPRD.