### PR TITLE
Ignore some Autotools files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ xcuserdata
 contents.xcworkspacedata
 .DS_Store
 .svn
+.deps/
+.dirstamp
 profile
 **/MacOSX/build
 **/iOS/build


### PR DESCRIPTION
Ignore `.deps/` folder and `.dirstamp` file, two items generated by Autotools on Linux.