### PR TITLE
Use constexpr for juce_Point.h constructors and methods when available

### DIFF
--- a/modules/juce_graphics/geometry/juce_Point.h
+++ b/modules/juce_graphics/geometry/juce_Point.h
@@ -25,6 +25,10 @@
 */
 
 #pragma once
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#pragma push_macro("constexpr")
+#define constexpr /*constexpr*/
+#endif                          // defined(_MSC_VER) && _MSC_VER < 1910
 
 
 //==============================================================================
@@ -41,32 +45,32 @@ class Point
 {
 public:
     /** Creates a point at the origin */
-    Point() noexcept : x(), y() {}
+    constexpr Point() noexcept : x(), y() {}
 
     /** Creates a copy of another point. */
-    Point (const Point& other) noexcept : x (other.x), y (other.y)  {}
+    constexpr Point (const Point& other) noexcept : x (other.x), y (other.y)  {}
 
     /** Creates a point from an (x, y) position. */
-    Point (ValueType initialX, ValueType initialY) noexcept : x (initialX), y (initialY) {}
+    constexpr Point (ValueType initialX, ValueType initialY) noexcept : x (initialX), y (initialY) {}
 
     //==============================================================================
     /** Copies this point from another one. */
     Point& operator= (const Point& other) noexcept                  { x = other.x; y = other.y; return *this; }
 
-    inline bool operator== (Point other) const noexcept             { return x == other.x && y == other.y; }
-    inline bool operator!= (Point other) const noexcept             { return x != other.x || y != other.y; }
+    constexpr inline bool operator== (Point other) const noexcept             { return x == other.x && y == other.y; }
+    constexpr inline bool operator!= (Point other) const noexcept             { return x != other.x || y != other.y; }
 
     /** Returns true if the point is (0, 0). */
-    bool isOrigin() const noexcept                                  { return x == ValueType() && y == ValueType(); }
+    constexpr bool isOrigin() const noexcept                                  { return x == ValueType() && y == ValueType(); }
 
     /** Returns true if the coordinates are finite values. */
-    inline bool isFinite() const noexcept                           { return juce_isfinite(x) && juce_isfinite(y); }
+    constexpr inline bool isFinite() const noexcept                           { return juce_isfinite(x) && juce_isfinite(y); }
 
     /** Returns the point's x coordinate. */
-    inline ValueType getX() const noexcept                          { return x; }
+    constexpr inline ValueType getX() const noexcept                          { return x; }
 
     /** Returns the point's y coordinate. */
-    inline ValueType getY() const noexcept                          { return y; }
+    constexpr inline ValueType getY() const noexcept                          { return y; }
 
     /** Sets the point's x coordinate. */
     inline void setX (ValueType newX) noexcept                      { x = newX; }
@@ -75,10 +79,10 @@ public:
     inline void setY (ValueType newY) noexcept                      { y = newY; }
 
     /** Returns a point which has the same Y position as this one, but a new X. */
-    Point withX (ValueType newX) const noexcept                     { return Point (newX, y); }
+    constexpr Point withX (ValueType newX) const noexcept                     { return Point (newX, y); }
 
     /** Returns a point which has the same X position as this one, but a new Y. */
-    Point withY (ValueType newY) const noexcept                     { return Point (x, newY); }
+    constexpr Point withY (ValueType newY) const noexcept                     { return Point (x, newY); }
 
     /** Changes the point's x and y coordinates. */
     void setXY (ValueType newX, ValueType newY) noexcept            { x = newX; y = newY; }
@@ -88,23 +92,23 @@ public:
 
     //==============================================================================
     /** Returns a point with a given offset from this one. */
-    Point translated (ValueType deltaX, ValueType deltaY) const noexcept    { return Point (x + deltaX, y + deltaY); }
+    constexpr Point translated (ValueType deltaX, ValueType deltaY) const noexcept    { return Point (x + deltaX, y + deltaY); }
 
     /** Adds two points together */
-    Point operator+ (Point other) const noexcept                    { return Point (x + other.x, y + other.y); }
+    constexpr Point operator+ (Point other) const noexcept                    { return Point (x + other.x, y + other.y); }
 
     /** Adds another point's coordinates to this one */
     Point& operator+= (Point other) noexcept                        { x += other.x; y += other.y; return *this; }
 
     /** Subtracts one points from another */
-    Point operator- (Point other) const noexcept                    { return Point (x - other.x, y - other.y); }
+    constexpr Point operator- (Point other) const noexcept                    { return Point (x - other.x, y - other.y); }
 
     /** Subtracts another point's coordinates to this one */
     Point& operator-= (Point other) noexcept                        { x -= other.x; y -= other.y; return *this; }
 
     /** Multiplies two points together */
     template <typename OtherType>
-    Point operator* (Point<OtherType> other) const noexcept         { return Point ((ValueType) (x * other.x), (ValueType) (y * other.y)); }
+    constexpr Point operator* (Point<OtherType> other) const noexcept         { return Point ((ValueType) (x * other.x), (ValueType) (y * other.y)); }
 
     /** Multiplies another point's coordinates to this one */
     template <typename OtherType>
@@ -112,7 +116,7 @@ public:
 
     /** Divides one point by another */
     template <typename OtherType>
-    Point operator/ (Point<OtherType> other) const noexcept         { return Point ((ValueType) (x / other.x), (ValueType) (y / other.y)); }
+    constexpr Point operator/ (Point<OtherType> other) const noexcept         { return Point ((ValueType) (x / other.x), (ValueType) (y / other.y)); }
 
     /** Divides this point's coordinates by another */
     template <typename OtherType>
@@ -120,11 +124,11 @@ public:
 
     /** Returns a point whose coordinates are multiplied by a given scalar value. */
     template <typename FloatType>
-    Point operator* (FloatType multiplier) const noexcept           { return Point ((ValueType) (x * multiplier), (ValueType) (y * multiplier)); }
+    constexpr Point operator* (FloatType multiplier) const noexcept           { return Point ((ValueType) (x * multiplier), (ValueType) (y * multiplier)); }
 
     /** Returns a point whose coordinates are divided by a given scalar value. */
     template <typename FloatType>
-    Point operator/ (FloatType divisor) const noexcept              { return Point ((ValueType) (x / divisor), (ValueType) (y / divisor)); }
+    constexpr Point operator/ (FloatType divisor) const noexcept              { return Point ((ValueType) (x / divisor), (ValueType) (y / divisor)); }
 
     /** Multiplies the point's coordinates by a scalar value. */
     template <typename FloatType>
@@ -135,7 +139,7 @@ public:
     Point& operator/= (FloatType divisor) noexcept                  { x = (ValueType) (x / divisor); y = (ValueType) (y / divisor); return *this; }
 
     /** Returns the inverse of this point. */
-    Point operator-() const noexcept                                { return Point (-x, -y); }
+    constexpr Point operator-() const noexcept                                { return Point (-x, -y); }
 
     //==============================================================================
     /** This type will be double if the Point's type is double, otherwise it will be float. */
@@ -239,3 +243,8 @@ public:
 /** Multiplies the point's coordinates by a scalar value. */
 template <typename ValueType>
 Point<ValueType> operator* (ValueType value, Point<ValueType> p) noexcept       { return p * value; }
+
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#undef constexpr
+#pragma pop_macro("constexpr")
+#endif // defined(_MSC_VER) && _MSC_VER < 1910


### PR DESCRIPTION
See https://forum.juce.com/t/constexpr-for-point-constructors-and-many-of-its-methods/22565/2 for discussion of this. I used the macro developed by Microsoft to detect earlier versions of Visual Studio to disable the constexpr keyword when necessary. The Microsoft code is under the MIT license, so merging it here won't cause license issues. See https://github.com/Microsoft/GSL/blob/master/include/gsl/gsl for the source of the macro.