### PR TITLE
Changed some code to use Graphics::ScopedSaveState where appropriate.

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -1960,12 +1960,10 @@ void Component::paintComponentAndChildren (Graphics& g)
     }
     else
     {
-        g.saveState();
+        const Graphics::ScopedSaveState sss (g);
 
         if (! (ComponentHelpers::clipObscuredRegions (*this, g, clipBounds, {}) && g.isClipEmpty()))
             paint (g);
-
-        g.restoreState();
     }
 
     for (int i = 0; i < childComponentList.size(); ++i)
@@ -1976,17 +1974,15 @@ void Component::paintComponentAndChildren (Graphics& g)
         {
             if (child.affineTransform != nullptr)
             {
-                g.saveState();
+                const Graphics::ScopedSaveState sss (g);
                 g.addTransform (*child.affineTransform);
 
                 if ((child.flags.dontClipGraphicsFlag && ! g.isClipEmpty()) || g.reduceClipRegion (child.getBounds()))
                     child.paintWithinParentContext (g);
-
-                g.restoreState();
             }
             else if (clipBounds.intersects (child.getBounds()))
             {
-                g.saveState();
+                const Graphics::ScopedSaveState sss (g);
 
                 if (child.flags.dontClipGraphicsFlag)
                 {
@@ -2010,15 +2006,12 @@ void Component::paintComponentAndChildren (Graphics& g)
                     if (nothingClipped || ! g.isClipEmpty())
                         child.paintWithinParentContext (g);
                 }
-
-                g.restoreState();
             }
         }
     }
 
-    g.saveState();
+    const Graphics::ScopedSaveState sss (g);
     paintOverChildren (g);
-    g.restoreState();
 }
 
 void Component::paintEntireComponent (Graphics& g, const bool ignoreAlphaLevel)
@@ -2050,10 +2043,9 @@ void Component::paintEntireComponent (Graphics& g, const bool ignoreAlphaLevel)
             paintComponentAndChildren (g2);
         }
 
-        g.saveState();
+        const Graphics::ScopedSaveState sss (g);
         g.addTransform (AffineTransform::scale (1.0f / scale));
         effect->applyEffect (effectImage, g, scale, ignoreAlphaLevel ? 1.0f : getAlpha());
-        g.restoreState();
     }
     else if (componentTransparency > 0 && ! ignoreAlphaLevel)
     {

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -1727,7 +1727,7 @@ void LookAndFeel_V2::drawResizableFrame (Graphics& g, int w, int h, const Border
         const Rectangle<int> fullSize (0, 0, w, h);
         const Rectangle<int> centreArea (border.subtractedFrom (fullSize));
 
-        g.saveState();
+        const Graphics::ScopedSaveState sss (g);
 
         g.excludeClipRegion (centreArea);
 
@@ -1736,8 +1736,6 @@ void LookAndFeel_V2::drawResizableFrame (Graphics& g, int w, int h, const Border
 
         g.setColour (Colour (0x19000000));
         g.drawRect (centreArea.expanded (1, 1));
-
-        g.restoreState();
     }
 }
 
@@ -2780,7 +2778,7 @@ void LookAndFeel_V2::drawBevel (Graphics& g, const int x, const int y, const int
     if (g.clipRegionIntersects (Rectangle<int> (x, y, width, height)))
     {
         LowLevelGraphicsContext& context = g.getInternalContext();
-        context.saveState();
+        const Graphics::ScopedSaveState sss (g);
 
         for (int i = bevelThickness; --i >= 0;)
         {
@@ -2796,8 +2794,6 @@ void LookAndFeel_V2::drawBevel (Graphics& g, const int x, const int y, const int
             context.setFill (bottomRightColour.withMultipliedAlpha (op  * 0.75f));
             context.fillRect (Rectangle<int> (x + width - i - 1, y + i + 1, 1, height - i * 2 - 2), false);
         }
-
-        context.restoreState();
     }
 }
 
@@ -2970,11 +2966,10 @@ void LookAndFeel_V2::drawGlassLozenge (Graphics& g,
 
     if (! (flatOnLeft || flatOnTop || flatOnBottom))
     {
-        g.saveState();
+        const Graphics::ScopedSaveState sss (g);
         g.setGradientFill (cg);
         g.reduceClipRegion (intX, intY, intEdge, intH);
         g.fillPath (outline);
-        g.restoreState();
     }
 
     if (! (flatOnRight || flatOnTop || flatOnBottom))
@@ -2982,11 +2977,10 @@ void LookAndFeel_V2::drawGlassLozenge (Graphics& g,
         cg.point1.setX (x + width - edgeBlurRadius);
         cg.point2.setX (x + width);
 
-        g.saveState();
+        const Graphics::ScopedSaveState sss (g);
         g.setGradientFill (cg);
         g.reduceClipRegion (intX + intW - intEdge, intY, 2 + intEdge, intH);
         g.fillPath (outline);
-        g.restoreState();
     }
 
     {


### PR DESCRIPTION
This PR is mainly a tidying up to better demonstrate good RAII practices, and to demonstrate the `ScopedSaveState` class itself.