### PR TITLE
Fixed OpenGL 3 detection on Windows.

### DIFF
--- a/modules/juce_opengl/juce_opengl.h
+++ b/modules/juce_opengl/juce_opengl.h
@@ -78,6 +78,7 @@
   #include <GL/gl.h>
  #else
   #include <gl/GL.h>
+  #define JUCE_OPENGL3 1
  #endif
 
  #ifdef CLEAR_TEMP_WINGDIAPI


### PR DESCRIPTION
[Related forum post: Windows & OpenGL 3 fix](https://forum.juce.com/t/windows-opengl-3-fix/22912/9)