### PR TITLE
Added detection of Cubase 8.5 and 9

### DIFF
--- a/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
@@ -66,6 +66,7 @@ public:
         SteinbergCubase7,
         SteinbergCubase8,
         SteinbergCubase8_5,
+        SteinbergCubase9,
         SteinbergCubaseGeneric,
         SteinbergNuendo3,
         SteinbergNuendo4,
@@ -92,7 +93,7 @@ public:
     bool isAdobeAudition() const noexcept     { return type == AdobeAudition; }
     bool isArdour() const noexcept            { return type == Ardour; }
     bool isBitwigStudio() const noexcept      { return type == BitwigStudio; }
-    bool isCubase() const noexcept            { return type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase5Bridged || type == SteinbergCubase6 || type == SteinbergCubase7 || type == SteinbergCubase8 || type == SteinbergCubase8_5 || type == SteinbergCubaseGeneric; }
+    bool isCubase() const noexcept            { return type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase5Bridged || type == SteinbergCubase6 || type == SteinbergCubase7 || type == SteinbergCubase8 || type == SteinbergCubase8_5 || type == SteinbergCubase9 || type == SteinbergCubaseGeneric; }
     bool isCubase7orLater() const noexcept    { return isCubase() && ! (type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase6); }
     bool isCubaseBridged() const noexcept     { return type == SteinbergCubase5Bridged; }
     bool isDaVinciResolve() const noexcept    { return type == DaVinciResolve; }
@@ -153,6 +154,7 @@ public:
             case SteinbergCubase7:         return "Steinberg Cubase 7";
             case SteinbergCubase8:         return "Steinberg Cubase 8";
             case SteinbergCubase8_5:       return "Steinberg Cubase 8.5";
+            case SteinbergCubase9:         return "Steinberg Cubase 9";
             case SteinbergCubaseGeneric:   return "Steinberg Cubase";
             case SteinbergNuendo3:         return "Steinberg Nuendo 3";
             case SteinbergNuendo4:         return "Steinberg Nuendo 4";
@@ -233,6 +235,7 @@ private:
         if (hostFilename.containsIgnoreCase   ("Cubase 7"))          return SteinbergCubase7;
         if (hostPath.containsIgnoreCase       ("Cubase 8.app"))      return SteinbergCubase8;
         if (hostPath.containsIgnoreCase       ("Cubase 8.5.app"))    return SteinbergCubase8_5;
+        if (hostPath.containsIgnoreCase       ("Cubase 9.app"))      return SteinbergCubase9;   // also matches the scanner inside the Cubase 9.app bundle
         if (hostFilename.containsIgnoreCase   ("Cubase"))            return SteinbergCubaseGeneric;
         if (hostPath.containsIgnoreCase       ("Wavelab 7"))         return SteinbergWavelab7;
         if (hostPath.containsIgnoreCase       ("Wavelab 8"))         return SteinbergWavelab8;
@@ -270,6 +273,9 @@ private:
         if (hostFilename.containsIgnoreCase   ("Cubase7"))           return SteinbergCubase7;
         if (hostFilename.containsIgnoreCase   ("Cubase8.exe"))       return SteinbergCubase8;
         if (hostFilename.containsIgnoreCase   ("Cubase8.5.exe"))     return SteinbergCubase8_5;
+        if (hostFilename.containsIgnoreCase   ("Cubase9.exe")
+            || (hostFilename.containsIgnoreCase ("vst2xscanner.exe")
+                && hostPath.containsIgnoreCase ("Cubase 9")))        return SteinbergCubase9;   // also matches the scanner inside the Cubase 9 folder
         if (hostFilename.containsIgnoreCase   ("Cubase"))            return SteinbergCubaseGeneric;
         if (hostFilename.containsIgnoreCase   ("VSTBridgeApp"))      return SteinbergCubase5Bridged;
         if (hostPath.containsIgnoreCase       ("Wavelab 5"))         return SteinbergWavelab5;

--- a/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
@@ -65,6 +65,7 @@ public:
         SteinbergCubase6,
         SteinbergCubase7,
         SteinbergCubase8,
+        SteinbergCubase8_5,
         SteinbergCubaseGeneric,
         SteinbergNuendo3,
         SteinbergNuendo4,
@@ -91,7 +92,7 @@ public:
     bool isAdobeAudition() const noexcept     { return type == AdobeAudition; }
     bool isArdour() const noexcept            { return type == Ardour; }
     bool isBitwigStudio() const noexcept      { return type == BitwigStudio; }
-    bool isCubase() const noexcept            { return type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase5Bridged || type == SteinbergCubase6 || type == SteinbergCubase7 || type == SteinbergCubase8 || type == SteinbergCubaseGeneric; }
+    bool isCubase() const noexcept            { return type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase5Bridged || type == SteinbergCubase6 || type == SteinbergCubase7 || type == SteinbergCubase8 || type == SteinbergCubase8_5 || type == SteinbergCubaseGeneric; }
     bool isCubase7orLater() const noexcept    { return isCubase() && ! (type == SteinbergCubase4 || type == SteinbergCubase5 || type == SteinbergCubase6); }
     bool isCubaseBridged() const noexcept     { return type == SteinbergCubase5Bridged; }
     bool isDaVinciResolve() const noexcept    { return type == DaVinciResolve; }
@@ -151,6 +152,7 @@ public:
             case SteinbergCubase6:         return "Steinberg Cubase 6";
             case SteinbergCubase7:         return "Steinberg Cubase 7";
             case SteinbergCubase8:         return "Steinberg Cubase 8";
+            case SteinbergCubase8_5:       return "Steinberg Cubase 8.5";
             case SteinbergCubaseGeneric:   return "Steinberg Cubase";
             case SteinbergNuendo3:         return "Steinberg Nuendo 3";
             case SteinbergNuendo4:         return "Steinberg Nuendo 4";
@@ -229,7 +231,8 @@ private:
         if (hostFilename.containsIgnoreCase   ("Cubase 5"))          return SteinbergCubase5;
         if (hostFilename.containsIgnoreCase   ("Cubase 6"))          return SteinbergCubase6;
         if (hostFilename.containsIgnoreCase   ("Cubase 7"))          return SteinbergCubase7;
-        if (hostFilename.containsIgnoreCase   ("Cubase 8"))          return SteinbergCubase8;
+        if (hostPath.containsIgnoreCase       ("Cubase 8.app"))      return SteinbergCubase8;
+        if (hostPath.containsIgnoreCase       ("Cubase 8.5.app"))    return SteinbergCubase8_5;
         if (hostFilename.containsIgnoreCase   ("Cubase"))            return SteinbergCubaseGeneric;
         if (hostPath.containsIgnoreCase       ("Wavelab 7"))         return SteinbergWavelab7;
         if (hostPath.containsIgnoreCase       ("Wavelab 8"))         return SteinbergWavelab8;
@@ -265,7 +268,8 @@ private:
         if (hostFilename.containsIgnoreCase   ("Cubase5"))           return SteinbergCubase5;
         if (hostFilename.containsIgnoreCase   ("Cubase6"))           return SteinbergCubase6;
         if (hostFilename.containsIgnoreCase   ("Cubase7"))           return SteinbergCubase7;
-        if (hostFilename.containsIgnoreCase   ("Cubase8"))           return SteinbergCubase8;
+        if (hostFilename.containsIgnoreCase   ("Cubase8.exe"))       return SteinbergCubase8;
+        if (hostFilename.containsIgnoreCase   ("Cubase8.5.exe"))     return SteinbergCubase8_5;
         if (hostFilename.containsIgnoreCase   ("Cubase"))            return SteinbergCubaseGeneric;
         if (hostFilename.containsIgnoreCase   ("VSTBridgeApp"))      return SteinbergCubase5Bridged;
         if (hostPath.containsIgnoreCase       ("Wavelab 5"))         return SteinbergWavelab5;


### PR DESCRIPTION
(Cubase 8.5 is marketed as a separate product, exactly as Cubase 8 and Cubase 9)

This also takes care of preventing that:

`hostFilename.containsIgnoreCase ("Cubase 8")`

mistakenly classifies "Cubase 8.5" as "Cubase 8" instead

As for Cubase 9, it seems that starting with this version the scanning of plug-ins happens using an external executable named “vst2xscanner”, which is located inside the “Cubase 9.app” bundle on macOS, and inside the installation directory “C:\Program Files\Steinberg\Cubase 9” on Windows.

These changes take into account that, and also detects that scanner as Cubase 9 because it wouldn’t make sense to have a different behavior if you are running in the scanner rather than into the “real” Cubase 9.