### PR TITLE
Correct order of initialisation

### DIFF
--- a/modules/juce_core/streams/juce_MemoryOutputStream.h
+++ b/modules/juce_core/streams/juce_MemoryOutputStream.h
@@ -114,8 +114,8 @@ public:
 
 private:
     //==============================================================================
+    MemoryBlock internalBlock;    
     MemoryBlock* const blockToUse;
-    MemoryBlock internalBlock;
     void* externalData;
     size_t position, size, availableSize;
 


### PR DESCRIPTION
If members are not declared in this order, use of the constructor 
```
MemoryOutputStream::MemoryOutputStream (const size_t initialSize)
  : blockToUse (&internalBlock), externalData (nullptr),
    position (0), size (0), availableSize (0)
{
    internalBlock.setSize (initialSize, false);
}
```

will lead to an allocation error, as the address of a not yet allocated object (internalBlock) is used in
```
blockToUse (&internalBlock)
```