### PR TITLE
Fixes to Filter copy constructors

### DIFF
--- a/modules/juce_dsp/processors/juce_FIRFilter.h
+++ b/modules/juce_dsp/processors/juce_FIRFilter.h
@@ -66,8 +66,10 @@ namespace FIR
         Filter (Coefficients<NumericType>* coefficientsToUse)  : coefficients (coefficientsToUse)   { reset(); }
 
         /** Creates a copy of another filter. */
-        Filter (const Filter&) = default;
-
+        :   coefficients (cpy.coefficients)
+        {
+            reset();
+        }
         /** Creates a copy of another filter. */
         Filter (Filter&&) = default;
 

--- a/modules/juce_dsp/processors/juce_FIRFilter.h
+++ b/modules/juce_dsp/processors/juce_FIRFilter.h
@@ -66,6 +66,7 @@ namespace FIR
         Filter (Coefficients<NumericType>* coefficientsToUse)  : coefficients (coefficientsToUse)   { reset(); }
 
         /** Creates a copy of another filter. */
+        Filter (Filter& cpy)
         :   coefficients (cpy.coefficients)
         {
             reset();

--- a/modules/juce_dsp/processors/juce_IIRFilter.h
+++ b/modules/juce_dsp/processors/juce_IIRFilter.h
@@ -69,7 +69,7 @@ namespace IIR
         Filter (Coefficients<NumericType>* coefficientsToUse);
 
         /** Creates a copy of another filter. */
-        Filter (const Filter&) = default;
+        Filter (const Filter&);
 
         /** Move constructor. */
         Filter (Filter&&) = default;

--- a/modules/juce_dsp/processors/juce_IIRFilter_Impl.h
+++ b/modules/juce_dsp/processors/juce_IIRFilter_Impl.h
@@ -49,6 +49,13 @@ Filter<SampleType>::Filter (Coefficients<typename Filter<SampleType>::NumericTyp
 }
 
 template <typename SampleType>
+Filter<SampleType>::Filter (const Filter<SampleType>& cpy)
+:   coefficients (cpy.coefficients)
+{
+    reset();
+}
+  
+template <typename SampleType>
 void Filter<SampleType>::reset (SampleType resetToValue)
 {
     auto newOrder = coefficients->getFilterOrder();

--- a/modules/juce_dsp/processors/juce_StateVariableFilter.h
+++ b/modules/juce_dsp/processors/juce_StateVariableFilter.h
@@ -62,8 +62,11 @@ namespace StateVariableFilter
         Filter (Parameters<NumericType>* paramtersToUse) : parameters (paramtersToUse) { reset(); }
 
         /** Creates a copy of another filter. */
-        Filter (const Filter&) = default;
-
+        Filter (const Filter& cpy)
+        :   parameters (cpy.parameters)
+        {
+            reset();
+        };
         /** Move constructor */
         Filter (Filter&&) = default;
 


### PR DESCRIPTION
Closed the old PR because this is more comprehensive. 

The copy constructors of FIR::Filter and IIR::Filter will cause compilation failure because they internally use the HeapBlock class, which has an explicitly deleted copy constructor. This fix works by copying the coefficients from the original instance and resets the filter to zero-state. 

I changed StateVariableFilter along with the others so the copy behavior resets the filter to zero state, which to me makes more sense than copying the filter state to a new instance which could be dropped on a different channel than the original. 