### PR TITLE
Add capability for Value to be updated synchronously

### DIFF
--- a/modules/juce_data_structures/values/juce_ValueTree.cpp
+++ b/modules/juce_data_structures/values/juce_ValueTree.cpp
@@ -783,8 +783,8 @@ class ValueTreePropertyValueSource  : public Value::ValueSource,
                                       private ValueTree::Listener
 {
 public:
-    ValueTreePropertyValueSource (const ValueTree& vt, const Identifier& prop, UndoManager* um)
-        : tree (vt), property (prop), undoManager (um)
+    ValueTreePropertyValueSource (const ValueTree& vt, const Identifier& prop, UndoManager* um, bool sync)
+        : tree (vt), property (prop), undoManager (um), shouldUpdateSynchronously(sync)
     {
         tree.addListener (this);
     }
@@ -801,11 +801,12 @@ private:
     ValueTree tree;
     const Identifier property;
     UndoManager* const undoManager;
+    bool shouldUpdateSynchronously;
 
     void valueTreePropertyChanged (ValueTree& changedTree, const Identifier& changedProperty) override
     {
         if (tree == changedTree && property == changedProperty)
-            sendChangeMessage (false);
+            sendChangeMessage (shouldUpdateSynchronously);
     }
 
     void valueTreeChildAdded (ValueTree&, ValueTree&) override {}
@@ -816,9 +817,9 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ValueTreePropertyValueSource)
 };
 
-Value ValueTree::getPropertyAsValue (const Identifier& name, UndoManager* const undoManager)
+Value ValueTree::getPropertyAsValue (const Identifier& name, UndoManager* const undoManager, bool shouldUpdateSynchronously)
 {
-    return Value (new ValueTreePropertyValueSource (*this, name, undoManager));
+    return Value (new ValueTreePropertyValueSource (*this, name, undoManager, shouldUpdateSynchronously));
 }
 
 //==============================================================================

--- a/modules/juce_data_structures/values/juce_ValueTree.h
+++ b/modules/juce_data_structures/values/juce_ValueTree.h
@@ -209,8 +209,10 @@ public:
         The Value object will maintain a reference to this tree, and will use the undo manager when
         it needs to change the value. Attaching a Value::Listener to the value object will provide
         callbacks whenever the property changes.
+        If shouldUpdateSynchronously is true the Value::Listener will be updated synchronously
+        @see ValueSource::sendChangeMessage(bool)
     */
-    Value getPropertyAsValue (const Identifier& name, UndoManager* undoManager);
+    Value getPropertyAsValue (const Identifier& name, UndoManager* undoManager, bool shouldUpdateSynchronously = false);
 
     /** Overwrites all the properties in this tree with the properties of the source tree.
         Any properties that already exist will be updated; and new ones will be added, and


### PR DESCRIPTION
This is a non-breaking change that adds an additional parameter to getPropertyAsValue() allowing any Value::Listeners attached to the returned Value to be updated synchronously if desired.