### PR TITLE
Fix case to match the actual folder name

### DIFF
--- a/extras/Projucer/Projucer.jucer
+++ b/extras/Projucer/Projucer.jucer
@@ -155,12 +155,12 @@
             file="Source/Application/jucer_MainWindow.h"/>
     </GROUP>
     <GROUP id="{8853BD6C-8307-BCF8-65BE-6A2F57093B40}" name="BinaryData">
-      <GROUP id="{01CF24A8-7630-2107-3C44-2D021E8339CC}" name="Gradle">
+      <GROUP id="{01CF24A8-7630-2107-3C44-2D021E8339CC}" name="gradle">
         <FILE id="DtmKLq" name="gradle-wrapper.jar" compile="0" resource="1"
-              file="Source/BinaryData/Gradle/gradle-wrapper.jar"/>
-        <FILE id="h7CWqI" name="gradlew" compile="0" resource="1" file="Source/BinaryData/Gradle/gradlew"/>
-        <FILE id="zLjIme" name="gradlew.bat" compile="0" resource="1" file="Source/BinaryData/Gradle/gradlew.bat"/>
-        <FILE id="c58ZPm" name="LICENSE" compile="0" resource="1" file="Source/BinaryData/Gradle/LICENSE"/>
+              file="Source/BinaryData/gradle/gradle-wrapper.jar"/>
+        <FILE id="h7CWqI" name="gradlew" compile="0" resource="1" file="Source/BinaryData/gradle/gradlew"/>
+        <FILE id="zLjIme" name="gradlew.bat" compile="0" resource="1" file="Source/BinaryData/gradle/gradlew.bat"/>
+        <FILE id="c58ZPm" name="LICENSE" compile="0" resource="1" file="Source/BinaryData/gradle/LICENSE"/>
       </GROUP>
       <GROUP id="{C49A0B44-304A-389D-AAB0-06169AD6ABAD}" name="Icons">
         <FILE id="kyKYL7" name="background_logo.svg" compile="0" resource="1"


### PR DESCRIPTION
In 54029e776d, the case of "gradle" was changed to "Gradle" in `Projucer.jucer`, but not on disk.

@hogliux