### PR TITLE
Projucer: Fix for null-terminated strings error with BinaryData::namedResourceList[]

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ResourceFile.cpp
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ResourceFile.cpp
@@ -239,8 +239,9 @@ Result ResourceFile::writeCpp (MemoryOutputStream& cpp, const File& headerFile, 
             << "{" << newLine;
 
         for (int j = 0; j < files.size(); ++j)
-            cpp << "    " << variableNames[j].quoted() << (j < files.size() - 1 ? "," : "") << newLine;
+            cpp << "    " << variableNames[j].quoted() << (j < files.size() ? "," : "") << newLine;
 
+		cpp << "    " << "nullptr" << newLine;
         cpp << "};" << newLine;
     }
 


### PR DESCRIPTION
Currently, generated BinaryData::namedResourceList[] property is not ended with nullptr.
It causes the null-terminated strings error in the case like below. 

 `StringArray(BinaryData::namedResourceList) `

I made a change to solve this inconvenience.
If there is no reason for the current implementation, I hope that you will accept this request