### PR TITLE
VST3 SDK v3.6.8 update patch

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -2597,7 +2597,7 @@ struct JucePluginFactory  : public IPluginFactory3
     {
         *obj = nullptr;
 
-        FUID sourceFuid = sourceIid;
+        FUID sourceFuid = FUID::fromTUID(sourceIid); // TODO: not sure about this one
 
         if (cid == nullptr || sourceIid == nullptr || ! sourceFuid.isValid())
         {

--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -265,7 +265,7 @@ static inline Steinberg::Vst::SpeakerArrangement getVst3SpeakerArrangement (cons
     else if (channels == AudioChannelSet::create7point0SDDS())   return k70Cine;
     else if (channels == AudioChannelSet::create7point1())       return k71CineSideFill;
     else if (channels == AudioChannelSet::create7point1SDDS())   return k71Cine;
-    else if (channels == AudioChannelSet::ambisonic())           return kBFormat;
+    else if (channels == AudioChannelSet::ambisonic())           return kAmbi1stOrderACN;
     else if (channels == AudioChannelSet::quadraphonic())        return k40Music;
     else if (channels == AudioChannelSet::create7point0point2()) return k71_2 & ~(Steinberg::Vst::kSpeakerLfe);
     else if (channels == AudioChannelSet::create7point1point2()) return k71_2;
@@ -300,7 +300,7 @@ static inline AudioChannelSet getChannelSetForSpeakerArrangement (Steinberg::Vst
     else if (arr == k70Cine)                                  return AudioChannelSet::create7point0SDDS();
     else if (arr == k71CineSideFill)                          return AudioChannelSet::create7point1();
     else if (arr == k71Cine)                                  return AudioChannelSet::create7point1SDDS();
-    else if (arr == kBFormat)                                 return AudioChannelSet::ambisonic();
+    else if (arr == kAmbi1stOrderACN)                         return AudioChannelSet::ambisonic();
     else if (arr == k40Music)                                 return AudioChannelSet::quadraphonic();
     else if (arr == k71_2)                                    return AudioChannelSet::create7point1point2();
     else if (arr == (k71_2 & ~(Steinberg::Vst::kSpeakerLfe))) return AudioChannelSet::create7point0point2();

--- a/modules/juce_audio_processors/format_types/juce_VST3Headers.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Headers.h
@@ -95,12 +95,14 @@
  #include <base/source/fobject.cpp>
  #include <base/source/fstreamer.cpp>
  #include <base/source/fstring.cpp>
- #include <base/source/flock.cpp>
  #include <base/source/updatehandler.cpp>
+ #include <base/thread/source/flock.cpp>
+ #include <base/thread/source/fcondition.cpp>
  #include <pluginterfaces/base/conststringtable.cpp>
  #include <pluginterfaces/base/funknown.cpp>
  #include <pluginterfaces/base/ipluginbase.h>
  #include <pluginterfaces/base/ustring.cpp>
+ #include <pluginterfaces/base/coreiids.cpp>
  #include <pluginterfaces/gui/iplugview.h>
  #include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
  #include <pluginterfaces/vst/ivstmidicontrollers.h>
@@ -122,7 +124,6 @@ namespace Steinberg
     DEF_CLASS_IID (IPluginBase)
     DEF_CLASS_IID (IPlugView)
     DEF_CLASS_IID (IPlugFrame)
-    DEF_CLASS_IID (IBStream)
     DEF_CLASS_IID (IPluginFactory)
     DEF_CLASS_IID (IPluginFactory2)
     DEF_CLASS_IID (IPluginFactory3)


### PR DESCRIPTION
Here is most of the work that is needed for supporting the new VST3 SDK.
The sole part that remains to fix is the one with a `// TODO` in `juce_VST3_Wrapper.cpp`: it runs but I suspect that it works by accident.