### PR TITLE
Changed parameter name

### DIFF
--- a/modules/juce_dsp/processors/juce_Oscillator.h
+++ b/modules/juce_dsp/processors/juce_Oscillator.h
@@ -61,7 +61,7 @@ public:
 
     //==============================================================================
     /** Sets the frequency of the oscillator. */
-    void setFrequency (NumericType newGain) noexcept             { frequency.setValue (newGain); }
+    void setFrequency (NumericType newFrequency) noexcept             { frequency.setValue (newFrequency); }
 
     /** Returns the current frequency of the oscillator. */
     NumericType getFrequency() const noexcept                    { return frequency.getTargetValue(); }


### PR DESCRIPTION
Just a very minor fix: Changed parameter name in `juce::dsp::Oscillator` from `newGain` to `newFrequency `.