### PR TITLE
remove duplicate gridItemPanel

### DIFF
--- a/examples/Demo/Source/Demos/GridDemo.cpp
+++ b/examples/Demo/Source/Demos/GridDemo.cpp
@@ -34,7 +34,6 @@
      GridDemo()
      {
          addGridItemPanel (Colours::aquamarine, "0");
-         addGridItemPanel (Colours::aquamarine, "0");
          addGridItemPanel (Colours::red,        "1");
          addGridItemPanel (Colours::blue,       "2");
          addGridItemPanel (Colours::green,      "3");


### PR DESCRIPTION
having two panels with `0` in them makes it slightly confusing to parse what's happening in the demo.