### PR TITLE
Make SparseSet<>::operator==/!= const

### DIFF
--- a/modules/juce_core/containers/juce_SparseSet.h
+++ b/modules/juce_core/containers/juce_SparseSet.h
@@ -261,12 +261,12 @@ public:
     }
 
     //==============================================================================
-    bool operator== (const SparseSet<Type>& other) noexcept
+    bool operator== (const SparseSet<Type>& other) const noexcept
     {
         return values == other.values;
     }
 
-    bool operator!= (const SparseSet<Type>& other) noexcept
+    bool operator!= (const SparseSet<Type>& other) const noexcept
     {
         return values != other.values;
     }


### PR DESCRIPTION
SparseSet<>::operator== and != should be const, as they only rely on the underlying Array comparison operators, which are const.