### PR TITLE
Update juce_Analytics.h

### DIFF
--- a/modules/juce_analytics/analytics/juce_Analytics.h
+++ b/modules/juce_analytics/analytics/juce_Analytics.h
@@ -80,11 +80,12 @@ public:
     void setSuspended (bool shouldBeSuspended);
 
 
-    juce_DeclareSingleton (Analytics, true)
+    juce_DeclareSingleton (Analytics, false)
 
 private:
     //==============================================================================
     Analytics() = default;
+    ~Analytics() { clearSingletonInstance(); }
 
     String userId;
     StringPairArray userProperties;


### PR DESCRIPTION
When using the analytics module in a Pro Tools plugin it always crashed. This fix should solve it.