### PR TITLE
cURL crash hotfix

### DIFF
--- a/modules/juce_core/native/juce_curl_Network.cpp
+++ b/modules/juce_core/native/juce_curl_Network.cpp
@@ -149,6 +149,7 @@ public:
         if (curl_easy_setopt (curl, CURLOPT_URL, address.toRawUTF8()) == CURLE_OK
             && curl_easy_setopt (curl, CURLOPT_WRITEDATA, this) == CURLE_OK
             && curl_easy_setopt (curl, CURLOPT_WRITEFUNCTION, StaticCurlWrite) == CURLE_OK
+            && curl_easy_setopt (curl, CURLOPT_NOSIGNAL, 1) == CURLE_OK
             && curl_easy_setopt (curl, CURLOPT_MAXREDIRS, static_cast<long> (maxRedirects)) == CURLE_OK
             && curl_easy_setopt (curl, CURLOPT_USERAGENT, userAgent.toRawUTF8()) == CURLE_OK
             && curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, (maxRedirects > 0 ? 1 : 0)) == CURLE_OK)


### PR DESCRIPTION
Hi folks,
there's an issue with libcurl crashing on HTTPS calls in a JUCE-based app:
```
#0  0x00007ffff5e11a18 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007ffff5e12e9a in __GI_abort () at abort.c:89
#2  0x00007ffff5e4e4c0 in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0x7ffff5f40dbb "*** %s ***: %s terminated\n") at ../sysdeps/posix/libc_fatal.c:175
#3  0x00007ffff5ed66e7 in __GI___fortify_fail (msg=0x7ffff5f40d7a <longjmp_msg> "longjmp causes uninitialized stack frame") at fortify_fail.c:30
#4  0x00007ffff5ed661d in ____longjmp_chk () at ../sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S:100
#5  0x00007ffff5ed6579 in __longjmp_chk (env=0x7ffff783b580, val=1) at ../setjmp/longjmp.c:38
#6  0x00007ffff75e0b95 in ?? () from /usr/lib64/libcurl.so.4
#7  <signal handler called>
#8  0x00007ffff5ebd32d in poll () at ../sysdeps/unix/syscall-template.S:84
#9  0x0000000000566721 in main ()
```

Related StackOverflow questions ([1](https://stackoverflow.com/questions/3281373/segmentation-fault-in-libcurl-multithreaded), [2](https://stackoverflow.com/questions/9191668/error-longjmp-causes-uninitialized-stack-frame), [3](https://stackoverflow.com/questions/21887264/why-libcurl-needs-curlopt-nosignal-option-and-what-are-side-effects-when-it-is)) all say that setting CURLOPT_NOSIGNAL to 1 is a must when accessing HTTPS URLs in a multi-threaded manner.

The proposed change seems to fix the issue.