### PR TITLE
VST3 Parameters added to receive MIDI CCs shouldn't be listed as automatable

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -702,7 +702,7 @@ private:
 
                 parameters.addParameter (new Vst::Parameter (toString ("MIDI CC " + String (c) + "|" + String (i)),
                                           static_cast<Vst::ParamID> (p) + parameterToMidiControllerOffset, 0, 0, 0,
-                                          Vst::ParameterInfo::kCanAutomate, Vst::kRootUnitId));
+                                          0, Vst::kRootUnitId));
             }
         }
     }


### PR DESCRIPTION
MIDI CCs should be the only way to control those parameters. What will
happen if they are marked as automatable, and the DAW controls them
both via automation and MIDI CCs? Sure cause of conflicts.

The host applications (SONAR, Cubase, REAPER to say just a few) don't
need these parameters to be marked as automatable at all for them to work.

Please take into account that we're delivering since years plug-ins in VST3 format that receive CCs without problems with this patch applied.

Screenshot below is taken from Presonus Studio One 3

![screen shot 2018-01-08 at 18 02 58](https://user-images.githubusercontent.com/639411/34682194-741641f8-f49e-11e7-869b-4b4cc2d38406.png)
