### PR TITLE
Listing MIDI inputs on Linux shows outputs.

### DIFF
--- a/modules/juce_audio_devices/native/juce_linux_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_Midi.cpp
@@ -390,7 +390,7 @@ static AlsaClient::Port* iterateMidiClient (const AlsaClient::Ptr& client,
     {
         if (snd_seq_query_next_port (seqHandle, portInfo) == 0
             && (snd_seq_port_info_get_capability (portInfo)
-                & (forInput ? SND_SEQ_PORT_CAP_SUBS_WRITE : SND_SEQ_PORT_CAP_SUBS_READ)) != 0)
+                & (forInput ? SND_SEQ_PORT_CAP_SUBS_READ : SND_SEQ_PORT_CAP_SUBS_WRITE)) != 0)
         {
             const String portName = snd_seq_port_info_get_name(portInfo);
 


### PR DESCRIPTION
Got a report that Linux MIDI outputs were appearing in the MIDI inputs list. They traced it back here.
https://github.com/mtytel/helm/issues/176
https://github.com/mtytel/helm/issues/177