### PR TITLE
Fix and cleanup module dependencies

### DIFF
--- a/modules/juce_audio_processors/juce_audio_processors.h
+++ b/modules/juce_audio_processors/juce_audio_processors.h
@@ -41,7 +41,7 @@
   website:          http://www.juce.com/juce
   license:          GPL/Commercial
 
-  dependencies:     juce_gui_extra, juce_audio_basics
+  dependencies:     juce_gui_basics, juce_audio_basics
   OSXFrameworks:    CoreAudio CoreMIDI AudioToolbox
   iOSFrameworks:    AudioToolbox
 

--- a/modules/juce_audio_utils/juce_audio_utils.h
+++ b/modules/juce_audio_utils/juce_audio_utils.h
@@ -41,7 +41,7 @@
   website:          http://www.juce.com/juce
   license:          GPL/Commercial
 
-  dependencies:     juce_gui_basics, juce_audio_basics, juce_audio_processors, juce_audio_formats, juce_audio_devices
+  dependencies:     juce_gui_basics, juce_audio_processors, juce_audio_formats, juce_audio_devices
   OSXFrameworks:    DiscRecording
   iOSFrameworks:    CoreAudioKit
 

--- a/modules/juce_audio_utils/juce_audio_utils.h
+++ b/modules/juce_audio_utils/juce_audio_utils.h
@@ -41,7 +41,7 @@
   website:          http://www.juce.com/juce
   license:          GPL/Commercial
 
-  dependencies:     juce_gui_extra, juce_audio_basics, juce_audio_processors, juce_audio_formats, juce_audio_devices
+  dependencies:     juce_gui_basics, juce_audio_basics, juce_audio_processors, juce_audio_formats, juce_audio_devices
   OSXFrameworks:    DiscRecording
   iOSFrameworks:    CoreAudioKit
 

--- a/modules/juce_dsp/juce_dsp.h
+++ b/modules/juce_dsp/juce_dsp.h
@@ -43,7 +43,7 @@
   license:            GPL/Commercial
   minimumCppStandard: 14
 
-  dependencies:       juce_core, juce_audio_basics, juce_audio_formats
+  dependencies:       juce_audio_basics, juce_audio_formats
   OSXFrameworks:      Accelerate
   iOSFrameworks:      Accelerate
 

--- a/modules/juce_gui_basics/juce_gui_basics.h
+++ b/modules/juce_gui_basics/juce_gui_basics.h
@@ -41,7 +41,7 @@
   website:          http://www.juce.com/juce
   license:          GPL/Commercial
 
-  dependencies:     juce_events juce_graphics juce_data_structures
+  dependencies:     juce_graphics juce_data_structures
   OSXFrameworks:    Cocoa Carbon QuartzCore
   iOSFrameworks:    UIKit MobileCoreServices
   linuxPackages:    x11 xinerama xext

--- a/modules/juce_video/juce_video.h
+++ b/modules/juce_video/juce_video.h
@@ -42,7 +42,7 @@
   website:          http://www.juce.com/juce
   license:          GPL/Commercial
 
-  dependencies:     juce_data_structures juce_cryptography
+  dependencies:     juce_gui_extra
   OSXFrameworks:    AVKit AVFoundation CoreMedia
   iOSFrameworks:    AVKit AVFoundation CoreMedia
 


### PR DESCRIPTION
While working on CMake support inside JUCE, I looked at the header file of each JUCE module and I found some weird things in the module dependencies.

@julianstorer @tpoole 