### PR TITLE
Projucer: Change ComboBox outline colour to TextButton outline colour

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/Components/jucer_TextButtonHandler.h
+++ b/extras/Projucer/Source/ComponentEditor/Components/jucer_TextButtonHandler.h
@@ -38,6 +38,7 @@ public:
         registerColour (TextButton::buttonOnColourId, "background (on)", "bgColOn");
         registerColour (TextButton::textColourOffId, "text colour (normal)", "textCol");
         registerColour (TextButton::textColourOnId, "text colour (on)", "textColOn");
+        registerColour (TextButton::outlineColourId, "outline", "outlineCol");
     }
 
     Component* createNewComponent (JucerDocument*) override

--- a/extras/Projucer/Source/Utility/UI/jucer_ProjucerLookAndFeel.cpp
+++ b/extras/Projucer/Source/Utility/UI/jucer_ProjucerLookAndFeel.cpp
@@ -128,11 +128,16 @@ void ProjucerLookAndFeel::drawButtonBackground (Graphics& g,
                                   ! button.isConnectedOnRight());
 
         g.fillPath (path);
+        g.setColour (button.findColour (TextButton::outlineColourId));
+        g.strokePath (path, PathStrokeType (1.0f));
     }
     else
     {
         g.fillRoundedRectangle (bounds, cornerSize);
+        g.setColour (button.findColour (TextButton::outlineColourId));
+        g.drawRoundedRectangle (bounds, cornerSize, 1.0f);
     }
+    
 }
 
 void ProjucerLookAndFeel::drawButtonText (Graphics& g, TextButton& button, bool isMouseOverButton, bool isButtonDown)

--- a/modules/juce_gui_basics/buttons/juce_TextButton.cpp
+++ b/modules/juce_gui_basics/buttons/juce_TextButton.cpp
@@ -38,6 +38,7 @@ TextButton::TextButton (const String& name) : Button (name)
 TextButton::TextButton (const String& name, const String& toolTip)  : Button (name)
 {
     setTooltip (toolTip);
+    setColour (TextButton::outlineColourId, Colours::transparentBlack);
 }
 
 TextButton::~TextButton()

--- a/modules/juce_gui_basics/buttons/juce_TextButton.h
+++ b/modules/juce_gui_basics/buttons/juce_TextButton.h
@@ -76,7 +76,8 @@ public:
                                                            'on'). The look-and-feel class might re-interpret this to add
                                                            effects, etc. */
         textColourOffId                 = 0x1000102,  /**< The colour to use for the button's text when the button's toggle state is "off". */
-        textColourOnId                  = 0x1000103   /**< The colour to use for the button's text.when the button's toggle state is "on". */
+        textColourOnId                  = 0x1000103,  /**< The colour to use for the button's text when the button's toggle state is "on". */
+        outlineColourId                 = 0x1000104   /**< The colour to use for drawing the line around the edge. */
     };
 
     //==============================================================================

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
@@ -306,14 +306,14 @@ void LookAndFeel_V4::drawButtonBackground (Graphics& g,
 
         g.fillPath (path);
 
-        g.setColour (button.findColour (ComboBox::outlineColourId));
+        g.setColour (button.findColour (TextButton::outlineColourId));
         g.strokePath (path, PathStrokeType (1.0f));
     }
     else
     {
         g.fillRoundedRectangle (bounds, cornerSize);
 
-        g.setColour (button.findColour (ComboBox::outlineColourId));
+        g.setColour (button.findColour (TextButton::outlineColourId));
         g.drawRoundedRectangle (bounds, cornerSize, 1.0f);
     }
 }
@@ -1295,6 +1295,7 @@ void LookAndFeel_V4::initialiseColours()
         TextButton::buttonOnColourId,               currentColourScheme.getUIColour (ColourScheme::UIColour::highlightedFill).getARGB(),
         TextButton::textColourOnId,                 currentColourScheme.getUIColour (ColourScheme::UIColour::highlightedText).getARGB(),
         TextButton::textColourOffId,                currentColourScheme.getUIColour (ColourScheme::UIColour::defaultText).getARGB(),
+        TextButton::outlineColourId,                currentColourScheme.getUIColour (ColourScheme::UIColour::outline).getARGB(),
 
         ToggleButton::textColourId,                 currentColourScheme.getUIColour (ColourScheme::UIColour::defaultText).getARGB(),
         ToggleButton::tickColourId,                 currentColourScheme.getUIColour (ColourScheme::UIColour::defaultText).getARGB(),


### PR DESCRIPTION
Hi ROLI,

When I create a TextButton component in GUI, the TextButton outline doesn't equal preview in Projucer.

I think it is because LookAndFeelV4 use ComboBox::outlineColourId in drawButtonBackground (..) .

So firstly I added TextButton::outlineColourId in juce_TextButton.
And I revised some code to change button's outline in Projucer directly.

Please let me know if something is wrong.

Thanks,

Andrew Kwon.