### PR TITLE
juce::String::naturalStringCompare orders strings in unexpected order

### DIFF
--- a/modules/juce_core/text/juce_String.cpp
+++ b/modules/juce_core/text/juce_String.cpp
@@ -681,7 +681,11 @@ static int naturalStringCompare (String::CharPointerType s1, String::CharPointer
         const bool hasSpace2 = s2.isWhitespace();
 
         if ((! firstLoop) && (hasSpace1 ^ hasSpace2))
+        {
+            if (s1[0] == 0) return -1;
+            if (s2[0] == 0) return 1;
             return hasSpace2 ? 1 : -1;
+        }
 
         firstLoop = false;
 


### PR DESCRIPTION
I had the following sample code:
```
    std::vector<String> list = {"C", "B", "A", "Test string", "Test string 2", "String Aaa", "StringCcc", "String Bbb",  };

    jassert(list[0] == "C");
    jassert(list[3] == "Test string");
    
    std::sort(list.begin(), list.end(), [](const String& a, const String& b){ return a.compareNatural(b)<0; });
    
    jassert(list[0] == "A");
    jassert(list[3] == "Test string");

    return 0;
```

Expecting the list in the end to contain the following items in order:

- A
- B
- C
- String Aaa
- String Bbb
- StringCcc
- Test string
- Test string 2

But I got without this patch:
- A
- B
- C
- String Aaa
- String Bbb
- StringCcc
- **Test string 2**
- **Test string**

So it seems that in the case that at time of comparison when one of the strings has whitespace it should have checked that the other string is not empty as that is a different case.