### PR TITLE
Add 'isIdentity' flag in TranslationOrTransform

### DIFF
--- a/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.cpp
@@ -1608,7 +1608,11 @@ public:
 
                 Point<float> pos (trans.getTranslationX(), trans.getTranslationY());
 
-                if (transform.isOnlyTranslated)
+                if (transform.isIdentity)
+                {
+                    cache.drawGlyph (*this, font, glyphNumber, pos);
+                }
+                else if (transform.isOnlyTranslated)
                 {
                     cache.drawGlyph (*this, font, glyphNumber, pos + transform.offset.toFloat());
                 }


### PR DESCRIPTION
This flag allows to avoid unnecessary transform or data duplication in the software based renderer.
See commit comments.