### PR TITLE
NS_AVAILABLE instead of MACROS (Features enabled/disabled on runtime instead of during compilation time)

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
@@ -111,6 +111,8 @@ public:
         this callback.
     */
     virtual void audioDeviceError (const String& errorMessage);
+
+  virtual void setAudioTimestamp (void *time) {} //UVI
 };
 
 
@@ -294,6 +296,9 @@ public:
         If the device doesn't support this operation, it'll return false.
     */
     virtual bool setAudioPreprocessingEnabled (bool shouldBeEnabled);
+
+  /*UVI*/
+  virtual void *getNativeAudioEngine() {return nullptr;}
 
     //==============================================================================
     /** Returns the number of under- or over runs reported by the OS since

--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -269,6 +269,8 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
         close();
     }
 
+    virtual void *getNativeAudioEngine() {return &audioUnit;}
+
     static void setAudioSessionCategory (NSString* category)
     {
         NSUInteger options = 0;
@@ -867,6 +869,7 @@ struct iOSAudioIODevice::Pimpl      : public AudioPlayHead,
                 for (int i = 0; i < channelData.inputs->numActiveChannels; ++i)
                     zeromem (inputData, sizeof (float) * numFrames);
             }
+            callback->setAudioTimestamp((void*)time);
 
             callback->audioDeviceIOCallback ((const float**) inputData,  channelData.inputs ->numActiveChannels,
                                                              outputData, channelData.outputs->numActiveChannels,
@@ -1322,10 +1325,10 @@ void iOSAudioIODevice::close()                                      { pimpl->clo
 
 void iOSAudioIODevice::start (AudioIODeviceCallback* callbackToUse) { pimpl->start (callbackToUse); }
 void iOSAudioIODevice::stop()                                       { pimpl->stop(); }
-
+void *iOSAudioIODevice::getNativeAudioEngine() {return pimpl->getNativeAudioEngine();} //UVI
 Array<double> iOSAudioIODevice::getAvailableSampleRates()           { return pimpl->availableSampleRates; }
 Array<int> iOSAudioIODevice::getAvailableBufferSizes()              { return pimpl->availableBufferSizes; }
-
+  
 bool iOSAudioIODevice::setAudioPreprocessingEnabled (bool enabled)  { return pimpl->setAudioPreprocessingEnabled (enabled); }
 
 bool iOSAudioIODevice::isPlaying()                                  { return pimpl->isRunning && pimpl->callback != nullptr; }

--- a/modules/juce_audio_devices/native/juce_ios_Audio.h
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.h
@@ -64,6 +64,8 @@ public:
 
     int getXRunCount() const noexcept override;
 
+      void *getNativeAudioEngine() override;
+      
     //==============================================================================
     void setMidiMessageCollector (MidiMessageCollector*);
     AudioPlayHead* getAudioPlayHead() const;

--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -1412,12 +1412,11 @@ private:
            #endif
 
             midiMessages.clear();
+
+          // copy back
+          audioBuffer.pop (*outBusBuffers[(int) outputBusNumber]->get(),
+                           mapper.get (false, (int) outputBusNumber));
         }
-
-        // copy back
-        audioBuffer.pop (*outBusBuffers[(int) outputBusNumber]->get(),
-                         mapper.get (false, (int) outputBusNumber));
-
         return noErr;
     }
 


### PR DESCRIPTION
I suggest using NS_AVAILABLE instead of the macros : JUCE_AUV3_VIEW_CONFIG_SUPPORTED and  JUCE_AUV3_MIDI_OUTPUT_SUPPORTED

The reason is that it would allow to use MIDI OUTPUT and VIEW CONFIG without changing the Deployment Target to the minimum required for the features. The features would be enabled only if the version of the OS is correct.

You might need to add a getter to replace the MACROS to know if the features are available in case some people need this info in their app.

Thanks you


