### PR TITLE
Use JucePlugin_Name as (preferred) fallback jack-client name

### DIFF
--- a/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
@@ -105,7 +105,11 @@ namespace
 
 //==============================================================================
 #ifndef JUCE_JACK_CLIENT_NAME
- #define JUCE_JACK_CLIENT_NAME "JUCEJack"
+ #ifdef JucePlugin_Name
+ # define JUCE_JACK_CLIENT_NAME JucePlugin_Name
+ #else
+ # define JUCE_JACK_CLIENT_NAME "JUCEJack"
+ #endif
 #endif
 
 struct JackPortIterator


### PR DESCRIPTION
and use the literal "*JUCEJack*" only as a last resort.

this will make a plugin named `FooBar` appear as "*FooBar*" in jack (rather than as "*JUCEJack*")

Closes: https://github.com/WeAreROLI/JUCE/issues/331