### PR TITLE
NS_AVAILABLE instead of MACROS (Features enabled/disabled on runtime instead of during compilation time) + ISSUE FIX

### DIFF
--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -1412,12 +1412,11 @@ private:
            #endif
 
             midiMessages.clear();
+
+          // copy back
+          audioBuffer.pop (*outBusBuffers[(int) outputBusNumber]->get(),
+                           mapper.get (false, (int) outputBusNumber));
         }
-
-        // copy back
-        audioBuffer.pop (*outBusBuffers[(int) outputBusNumber]->get(),
-                         mapper.get (false, (int) outputBusNumber));
-
         return noErr;
     }
 


### PR DESCRIPTION

_Sorry, I had to recreate the pull request as I was previously on the wrong branch._

**PART1:**
I suggest using NS_AVAILABLE instead of the macros when possible, in this case it involves : JUCE_AUV3_VIEW_CONFIG_SUPPORTED and JUCE_AUV3_MIDI_OUTPUT_SUPPORTED 

The reason is that, using NS_AVAILABLE  would allow to use AUV3 MIDI OUTPUT and AUV3 VIEW CONFIG without changing the Deployment Target to the minimum required for the features. The features would be enabled only if the version of the OS is correct. Dynamic VS Static.

_You might need to add public getter to replace the MACROS to check if the feature is available on the running device in case some people need this info in their app._

**PART2:**
I moved "copy back" to the scope above as if this scope is not called there is nothing to copy back.
Cause app to crash at times, needs to be double checked on your side.

**_All this was tested on iOS only._**
