### PR TITLE
Added access to AudioProcessorValueTreeState::Parameter's valueToText…

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
@@ -225,6 +225,21 @@ NormalisableRange<float> AudioProcessorValueTreeState::getParameterRange (String
     return NormalisableRange<float>();
 }
 
+std::function<String (float)> AudioProcessorValueTreeState::getValueToTextFunction (StringRef paramID) const noexcept
+{
+    if (Parameter* p = Parameter::getParameterForID (processor, paramID))
+        return p->valueToTextFunction;
+    return nullptr;
+}
+
+
+std::function<float (const String&)> AudioProcessorValueTreeState::getTextToValueFunction (StringRef paramID) const noexcept
+{
+    if (Parameter* p = Parameter::getParameterForID (processor, paramID))
+        return p->textToValueFunction;
+    return nullptr;
+}
+
 AudioProcessorParameterWithID* AudioProcessorValueTreeState::getParameter (StringRef paramID) const noexcept
 {
     return Parameter::getParameterForID (processor, paramID);
@@ -424,6 +439,9 @@ struct AudioProcessorValueTreeState::SliderAttachment::Pimpl  : private Attached
         NormalisableRange<float> range (s.getParameterRange (paramID));
         slider.setRange (range.start, range.end, range.interval);
         slider.setSkewFactor (range.skew, range.symmetricSkew);
+
+        slider.convertTextFromValue = state.getValueToTextFunction (paramID);
+        slider.convertValueFromText = state.getTextToValueFunction (paramID);
 
         if (AudioProcessorParameter* param = state.getParameter (paramID))
             slider.setDoubleClickReturnValue (true, range.convertFrom0to1 (param->getDefaultValue()));

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
@@ -130,6 +130,12 @@ public:
     /** Returns the range that was set when the given parameter was created. */
     NormalisableRange<float> getParameterRange (StringRef parameterID) const noexcept;
 
+    /** Returns the value to text function that was set when the given parameter was created. */
+    std::function<String (float)> getValueToTextFunction (StringRef parameterID) const noexcept;
+
+    /** Returns the text to value function that was set when the given parameter was created. */
+    std::function<float (const String&)> getTextToValueFunction (StringRef parameterID) const noexcept;
+
     /** Returns a copy of the state value tree.
 
         The AudioProcessorValueTreeState's ValueTree is updated internally on the

--- a/modules/juce_gui_basics/widgets/juce_Slider.cpp
+++ b/modules/juce_gui_basics/widgets/juce_Slider.cpp
@@ -1552,6 +1552,9 @@ String Slider::getTextValueSuffix() const
 
 String Slider::getTextFromValue (double v)
 {
+    if (convertTextFromValue)
+        return convertTextFromValue (v);
+
     if (getNumDecimalPlacesToDisplay() > 0)
         return String (v, getNumDecimalPlacesToDisplay()) + getTextValueSuffix();
 
@@ -1560,6 +1563,9 @@ String Slider::getTextFromValue (double v)
 
 double Slider::getValueFromText (const String& text)
 {
+    if (convertValueFromText)
+        return convertValueFromText (text);
+
     auto t = text.trimStart();
 
     if (t.endsWith (getTextValueSuffix()))

--- a/modules/juce_gui_basics/widgets/juce_Slider.h
+++ b/modules/juce_gui_basics/widgets/juce_Slider.h
@@ -596,6 +596,12 @@ public:
     /** You can assign a lambda to this callback object to have it called when the slider's drag ends. */
     std::function<void()> onDragEnd;
 
+    /** You can assign a lambda to customise how a value is converted for the text box. */
+    std::function<float(const String&)> convertValueFromText;
+
+    /** You can assign a lambda to customise how a text from the text box is converted into a value. */
+    std::function<String(float)> convertTextFromValue;
+
     //==============================================================================
     /** This lets you choose whether double-clicking moves the slider to a given position.
 

--- a/modules/juce_gui_basics/widgets/juce_Slider.h
+++ b/modules/juce_gui_basics/widgets/juce_Slider.h
@@ -596,10 +596,10 @@ public:
     /** You can assign a lambda to this callback object to have it called when the slider's drag ends. */
     std::function<void()> onDragEnd;
 
-    /** You can assign a lambda to customise how a value is converted for the text box. */
+    /** You can assign a lambda to customise how the text in the text box is converted to a value. */
     std::function<float(const String&)> convertValueFromText;
 
-    /** You can assign a lambda to customise how a text from the text box is converted into a value. */
+    /** You can assign a lambda to customise how a value is displayed in the text box. */
     std::function<String(float)> convertTextFromValue;
 
     //==============================================================================


### PR DESCRIPTION
…Function and propagate via SliderAttachment

* Exposes the lambdas in the AudioProcessorValueTreeState::Parameter
* Adds lambdas to the Slider to convert value to text and vice versa
* AudioProcessorValueTreeState::SliderAttachment propagagtes the lambdas to the slider on creation

A slider connected via an AudioProcessorValueTreeState::SliderAttachment will automatically use the lambdas of the connected Parameter to display the text and to convert it back