### PR TITLE
Projucer: Enable Framework paths relative to project in XCode exporter

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Xcode.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Xcode.h
@@ -2723,7 +2723,7 @@ private:
     String addFramework (const String& frameworkName) const
     {
         auto path = frameworkName;
-        if (! File::isAbsolutePath (path))
+        if (! File::isAbsolutePath (path) && ! path.startsWithChar('.'))
             path = "System/Library/Frameworks/" + path;
 
         if (! path.endsWithIgnoreCase (".framework"))
@@ -2731,7 +2731,7 @@ private:
 
         auto fileRefID = createFileRefID (path);
 
-        addFileReference ((File::isAbsolutePath (frameworkName) ? "" : "${SDKROOT}/") + path);
+        addFileReference ((File::isAbsolutePath (frameworkName) || path.startsWithChar('.') ? "" : "${SDKROOT}/") + path);
         frameworkFileIDs.add (fileRefID);
 
         return addBuildFile (path, fileRefID, false, false);


### PR DESCRIPTION
This allows relative paths to specify Framework locations in XCode as set out in [this JUCE forum post](https://forum.juce.com/t/projucer-xcode-exporter-relative-framework-paths/26968)