### PR TITLE
Fix AppConfig.h vs JucerHeader.h confusion wrt. including BinaryData.h

### DIFF
--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -219,7 +219,7 @@ void Project::initialiseProjectValues()
     userNotesValue.referTo                     (projectRoot, Ids::userNotes,  getUndoManager());
 
     maxBinaryFileSizeValue.referTo             (projectRoot, Ids::maxBinaryFileSize,        getUndoManager(), 10240 * 1024);
-    includeBinaryDataInJuceHeaderValue.referTo (projectRoot, Ids::includeBinaryInAppConfig, getUndoManager(), true);
+    includeBinaryDataInJuceHeaderValue.referTo (projectRoot, Ids::includeBinaryInJuceHeader, getUndoManager(), projectRoot.hasProperty(Ids::includeBinaryInAppConfig) ? projectRoot[Ids::includeBinaryInAppConfig] : true);
     binaryDataNamespaceValue.referTo           (projectRoot, Ids::binaryDataNamespace,      getUndoManager(), "BinaryData");
 }
 

--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -970,8 +970,8 @@ void Project::createPropertyEditors (PropertyListBuilder& props)
                    "(Note that individual resource files which are larger than this size cannot be split across multiple cpp files).");
     }
 
-    props.add (new ChoicePropertyComponent (includeBinaryDataInAppConfigValue, "Include BinaryData in AppConfig"),
-                                             "Include BinaryData.h in the AppConfig.h file");
+    props.add (new ChoicePropertyComponent (includeBinaryDataInAppConfigValue, "Include BinaryData in JuceHeader"),
+                                             "Include BinaryData.h in the JuceHeader.h file");
 
     props.add (new TextPropertyComponent (binaryDataNamespaceValue, "BinaryData Namespace", 256, false),
                                           "The namespace containing the binary assests.");

--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -219,7 +219,7 @@ void Project::initialiseProjectValues()
     userNotesValue.referTo                     (projectRoot, Ids::userNotes,  getUndoManager());
 
     maxBinaryFileSizeValue.referTo             (projectRoot, Ids::maxBinaryFileSize,        getUndoManager(), 10240 * 1024);
-    includeBinaryDataInAppConfigValue.referTo  (projectRoot, Ids::includeBinaryInAppConfig, getUndoManager(), true);
+    includeBinaryDataInJuceHeaderValue.referTo (projectRoot, Ids::includeBinaryInAppConfig, getUndoManager(), true);
     binaryDataNamespaceValue.referTo           (projectRoot, Ids::binaryDataNamespace,      getUndoManager(), "BinaryData");
 }
 
@@ -970,7 +970,7 @@ void Project::createPropertyEditors (PropertyListBuilder& props)
                    "(Note that individual resource files which are larger than this size cannot be split across multiple cpp files).");
     }
 
-    props.add (new ChoicePropertyComponent (includeBinaryDataInAppConfigValue, "Include BinaryData in JuceHeader"),
+    props.add (new ChoicePropertyComponent (includeBinaryDataInJuceHeaderValue, "Include BinaryData in JuceHeader"),
                                              "Include BinaryData.h in the JuceHeader.h file");
 
     props.add (new TextPropertyComponent (binaryDataNamespaceValue, "BinaryData Namespace", 256, false),

--- a/extras/Projucer/Source/Project/jucer_Project.h
+++ b/extras/Projucer/Source/Project/jucer_Project.h
@@ -116,7 +116,7 @@ public:
     StringPairArray getPreprocessorDefs() const          { return parsedPreprocessorDefs; }
 
     int getMaxBinaryFileSize() const                     { return maxBinaryFileSizeValue.get(); }
-    bool shouldIncludeBinaryInAppConfig() const          { return includeBinaryDataInAppConfigValue.get(); }
+    bool shouldIncludeBinaryInJuceHeader() const         { return includeBinaryDataInJuceHeaderValue.get(); }
     String getBinaryDataNamespaceString() const          { return binaryDataNamespaceValue.get(); }
 
     bool shouldDisplaySplashScreen() const               { return displaySplashScreenValue.get(); }
@@ -391,7 +391,7 @@ private:
 
     ValueWithDefault projectNameValue, projectUIDValue, projectTypeValue, versionValue, bundleIdentifierValue, companyNameValue, companyCopyrightValue,
                      companyWebsiteValue, companyEmailValue, displaySplashScreenValue, reportAppUsageValue, splashScreenColourValue, cppStandardValue,
-                     headerSearchPathsValue, preprocessorDefsValue, userNotesValue, maxBinaryFileSizeValue, includeBinaryDataInAppConfigValue, binaryDataNamespaceValue;
+                     headerSearchPathsValue, preprocessorDefsValue, userNotesValue, maxBinaryFileSizeValue, includeBinaryDataInJuceHeaderValue, binaryDataNamespaceValue;
 
     ValueWithDefault pluginFormatsValue, pluginNameValue, pluginDescriptionValue, pluginManufacturerValue, pluginManufacturerCodeValue,
                      pluginCodeValue, pluginChannelConfigsValue, pluginCharacteristicsValue, pluginAUExportPrefixValue, pluginAAXIdentifierValue,

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectSaver.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectSaver.h
@@ -543,7 +543,7 @@ private:
             out << newLine;
         }
 
-        if (hasBinaryData && project.shouldIncludeBinaryInAppConfig())
+        if (hasBinaryData && project.shouldIncludeBinaryInJuceHeader())
             out << CodeHelpers::createIncludeStatement (project.getBinaryDataHeaderFile(), appConfigFile) << newLine;
 
         out << newLine

--- a/extras/Projucer/Source/Utility/Helpers/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/Helpers/jucer_PresetIDs.h
@@ -243,6 +243,7 @@ namespace Ids
     DECLARE_ID (userNotes);
     DECLARE_ID (maxBinaryFileSize);
     DECLARE_ID (includeBinaryInAppConfig);
+    DECLARE_ID (includeBinaryInJuceHeader);
     DECLARE_ID (binaryDataNamespace);
     DECLARE_ID (characterSet);
     DECLARE_ID (JUCERPROJECT);


### PR DESCRIPTION
While working on supporting the "Include Binary"/"Include BinaryData in AppConfig" (the name changed [recently](https://github.com/WeAreROLI/JUCE/commit/b72a6265163a58cce999b09ac8c0060ab6d69d78#diff-eb8e7638808460f0f95688e30752f0ccL738)) project setting in [FRUT](https://github.com/McMartin/FRUT), I found out that it was mis-named and mis-documented since its introduction in 2013 (in ec524a437d0565fba51143fa254872af8da4b6e2): `BinaryData.h` is included in `JuceHeader.h`, not in `AppConfig.h`.

I made 3 commits, feel free to merge as many as you want:
- the first one only changes the caption and the tooltip that one sees in Projucer's UI
- the second one changes also the associated member variables and functions
- the third one goes one step further and renames the XML property, while not breaking any user-facing behavior by converting the value from the old property. 

@ed95 @julianstorer

