### PR TITLE
Allow ComponentEditor to edit source files other than .cpp

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/jucer_JucerDocument.cpp
+++ b/extras/Projucer/Source/ComponentEditor/jucer_JucerDocument.cpp
@@ -645,7 +645,7 @@ XmlElement* JucerDocument::pullMetaDataFromCppFile (const String& cpp)
 
 bool JucerDocument::isValidJucerCppFile (const File& f)
 {
-    if (f.hasFileExtension (".cpp"))
+    if (f.hasFileExtension (cppFileExtensions))
         if (ScopedPointer<XmlElement> xml = pullMetaDataFromCppFile (f.loadFileAsString()))
             return xml->hasTagName (jucerCompXmlTag);
 


### PR DESCRIPTION
It is not permitted to edit GUI components unless the files are named .cpp.
I permit the other C++ file extensions.