### PR TITLE
Add OSC Color support

### DIFF
--- a/modules/juce_osc/osc/juce_OSCArgument.cpp
+++ b/modules/juce_osc/osc/juce_OSCArgument.cpp
@@ -27,11 +27,9 @@
 namespace juce
 {
 
-OSCArgument::OSCArgument (int32 value, bool asColor) noexcept
-    : type (asColor?OSCTypes::color:OSCTypes::int32)
+OSCArgument::OSCArgument (int32 value) noexcept
+    : type (OSCTypes::int32), intValue(value)
 {
-	if (asColor) colorValue = value;
-	else intValue = value;
 }
 
 OSCArgument::OSCArgument (float value) noexcept
@@ -41,6 +39,11 @@ OSCArgument::OSCArgument (float value) noexcept
 
 OSCArgument::OSCArgument (const String& value) noexcept
     : type (OSCTypes::string), stringValue (value)
+{
+}
+
+OSCArgument::OSCArgument(const OSCColor& value) noexcept
+	: type(OSCTypes::color), colorValue(value)
 {
 }
 
@@ -87,13 +90,13 @@ const MemoryBlock& OSCArgument::getBlob() const noexcept
 }
 
 
-uint32 OSCArgument::getColor() const noexcept
+OSCColor OSCArgument::getColor() const noexcept
 {
-	if (isColor())
+	if(isColor())
 		return colorValue;
 
 	jassertfalse; // you must check the type of an argument before attempting to get its value!
-	return 0;
+	return OSCColor(0,0,0,0);
 }
 
 

--- a/modules/juce_osc/osc/juce_OSCArgument.cpp
+++ b/modules/juce_osc/osc/juce_OSCArgument.cpp
@@ -27,9 +27,11 @@
 namespace juce
 {
 
-OSCArgument::OSCArgument (int32 value) noexcept
-    : type (OSCTypes::int32), intValue (value)
+OSCArgument::OSCArgument (int32 value, bool asColor) noexcept
+    : type (asColor?OSCTypes::color:OSCTypes::int32)
 {
+	if (asColor) colorValue = value;
+	else intValue = value;
 }
 
 OSCArgument::OSCArgument (float value) noexcept
@@ -46,6 +48,7 @@ OSCArgument::OSCArgument (const MemoryBlock& b)
     : type (OSCTypes::blob), blob (b)
 {
 }
+
 
 //==============================================================================
 String OSCArgument::getString() const noexcept
@@ -82,6 +85,17 @@ const MemoryBlock& OSCArgument::getBlob() const noexcept
 
     return blob;
 }
+
+
+uint32 OSCArgument::getColor() const noexcept
+{
+	if (isColor())
+		return colorValue;
+
+	jassertfalse; // you must check the type of an argument before attempting to get its value!
+	return 0;
+}
+
 
 
 //==============================================================================

--- a/modules/juce_osc/osc/juce_OSCArgument.h
+++ b/modules/juce_osc/osc/juce_OSCArgument.h
@@ -30,6 +30,24 @@ namespace juce
 
 //==============================================================================
 /**
+	A small struct holding the r, g, b, a values of an OSC Color argument
+	@tags{OSC}
+*/
+struct OSCColor
+{
+	OSCColor(uint8 _r, uint8 _g, uint8 _b, uint8 _a) :
+		r(_r), g(_g), b(_b), a(_a)
+	{
+	}
+
+	uint8 r;
+	uint8 g;
+	uint8 b;
+	uint8 a;
+};
+
+//==============================================================================
+/**
     An OSC argument.
 
     An OSC argument is a value of one of the following types: int32, float32, string,
@@ -42,14 +60,18 @@ namespace juce
 class JUCE_API  OSCArgument
 {
 public:
+	
     /** Constructs an OSCArgument with type int32 and a given value. */
-    OSCArgument (int32 value, bool asColor = false) noexcept;
+    OSCArgument (int32 value) noexcept;
 
     /** Constructs an OSCArgument with type float32 and a given value. */
     OSCArgument (float value) noexcept;
 
     /** Constructs an OSCArgument with type string and a given value */
     OSCArgument (const String& value) noexcept;
+
+	/** Constructs an OSCArgument with type string and a given value */
+	OSCArgument(const OSCColor& value) noexcept;
 
     /** Constructs an OSCArgument with type blob and copies dataSize bytes
         from the memory pointed to by data into the blob.
@@ -107,7 +129,7 @@ public:
 	/** Returns the value of the OSCArgument as a colour.
 	If the type of the OSCArgument is not a color, the behaviour is undefined.
 	*/
-	uint32 getColor() const noexcept;
+	OSCColor getColor() const noexcept;
 
 
 private:
@@ -118,8 +140,9 @@ private:
     {
         int32 intValue;
         float floatValue;
-		uint32 colorValue;
+		OSCColor colorValue;
     };
+
 
     String stringValue;
     MemoryBlock blob;

--- a/modules/juce_osc/osc/juce_OSCArgument.h
+++ b/modules/juce_osc/osc/juce_OSCArgument.h
@@ -24,6 +24,7 @@
   ==============================================================================
 */
 
+
 namespace juce
 {
 
@@ -42,7 +43,7 @@ class JUCE_API  OSCArgument
 {
 public:
     /** Constructs an OSCArgument with type int32 and a given value. */
-    OSCArgument (int32 value) noexcept;
+    OSCArgument (int32 value, bool asColor = false) noexcept;
 
     /** Constructs an OSCArgument with type float32 and a given value. */
     OSCArgument (float value) noexcept;
@@ -58,6 +59,9 @@ public:
     */
     OSCArgument (const MemoryBlock& blob);
 
+
+
+
     /** Returns the type of the OSCArgument as an OSCType.
         OSCType is a char type, and its value will be the OSC type tag of the type.
     */
@@ -66,14 +70,17 @@ public:
     /** Returns whether the type of the OSCArgument is int32. */
     bool isInt32() const noexcept           { return type == OSCTypes::int32; }
 
-    /** Returns whether the type of the OSCArgument is int32. */
+    /** Returns whether the type of the OSCArgument is float. */
     bool isFloat32() const noexcept         { return type == OSCTypes::float32; }
 
-    /** Returns whether the type of the OSCArgument is int32. */
+    /** Returns whether the type of the OSCArgument is string. */
     bool isString() const noexcept          { return type == OSCTypes::string; }
 
-    /** Returns whether the type of the OSCArgument is int32. */
+    /** Returns whether the type of the OSCArgument is blob. */
     bool isBlob() const noexcept            { return type == OSCTypes::blob; }
+
+	/** Returns whether the type of the OSCArgument is color. */
+	bool isColor() const noexcept			{ return type == OSCTypes::color; }
 
     /** Returns the value of the OSCArgument as an int32.
         If the type of the OSCArgument is not int32, the behaviour is undefined.
@@ -97,6 +104,11 @@ public:
      */
     const MemoryBlock& getBlob() const noexcept;
 
+	/** Returns the value of the OSCArgument as a colour.
+	If the type of the OSCArgument is not a color, the behaviour is undefined.
+	*/
+	uint32 getColor() const noexcept;
+
 
 private:
     //==============================================================================
@@ -106,6 +118,7 @@ private:
     {
         int32 intValue;
         float floatValue;
+		uint32 colorValue;
     };
 
     String stringValue;

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -83,6 +83,8 @@ void OSCMessage::addInt32 (int32 value)             { arguments.add (OSCArgument
 void OSCMessage::addFloat32 (float value)           { arguments.add (OSCArgument (value)); }
 void OSCMessage::addString (const String& value)    { arguments.add (OSCArgument (value)); }
 void OSCMessage::addBlob (const MemoryBlock& blob)  { arguments.add (OSCArgument (blob)); }
+void OSCMessage::addColor(const uint32 value)		{ arguments.add (OSCArgument(value, true)); }
+
 void OSCMessage::addArgument (OSCArgument arg)      { arguments.add (arg); }
 
 //==============================================================================

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -83,7 +83,7 @@ void OSCMessage::addInt32 (int32 value)             { arguments.add (OSCArgument
 void OSCMessage::addFloat32 (float value)           { arguments.add (OSCArgument (value)); }
 void OSCMessage::addString (const String& value)    { arguments.add (OSCArgument (value)); }
 void OSCMessage::addBlob (const MemoryBlock& blob)  { arguments.add (OSCArgument (blob)); }
-void OSCMessage::addColor(const uint32 value)		{ arguments.add (OSCArgument(value, true)); }
+void OSCMessage::addColor(const OSCColor &color)	{ arguments.add (OSCArgument(color)); }
 
 void OSCMessage::addArgument (OSCArgument arg)      { arguments.add (arg); }
 

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -132,6 +132,13 @@ public:
     */
     void addBlob (const MemoryBlock& blob);
 
+	/** Creates a new OSCArgument of type color with a given value
+	and adds it to the OSCMessage object.
+
+		Note : the value must be in the format RGBA (not ARGB).
+	*/
+	void addColor(uint32 value);
+
     /** Adds the OSCArgument argument to the OSCMessage object.
 
         Note: This method will result in a copy of the OSCArgument object if it is passed

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -137,7 +137,7 @@ public:
 
 		Note : the value must be in the format RGBA (not ARGB).
 	*/
-	void addColor(uint32 value);
+	void addColor(const OSCColor &value);
 
     /** Adds the OSCArgument argument to the OSCMessage object.
 

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -114,6 +114,14 @@ namespace
             return s;
         }
 
+		uint32 readColor()
+		{
+			if (input.getNumBytesRemaining() < 4)
+				throw OSCFormatError("OSC input stream exhausted while reading color");
+
+			return (uint32)input.readIntBigEndian();
+		}
+
         MemoryBlock readBlob()
         {
             if (input.getNumBytesRemaining() < 4)
@@ -191,7 +199,8 @@ namespace
                 case OSCTypes::int32:       return OSCArgument (readInt32());
                 case OSCTypes::float32:     return OSCArgument (readFloat32());
                 case OSCTypes::string:      return OSCArgument (readString());
-                case OSCTypes::blob:        return OSCArgument (readBlob());
+				case OSCTypes::blob:        return OSCArgument(readBlob());
+				case OSCTypes::color:        return OSCArgument (readColor(), true);
 
                 default:
                     // You supplied an invalid OSCType when calling readArgument! This should never happen.

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -114,12 +114,13 @@ namespace
             return s;
         }
 
-		uint32 readColor()
+		OSCColor readColor()
 		{
 			if (input.getNumBytesRemaining() < 4)
 				throw OSCFormatError("OSC input stream exhausted while reading color");
 
-			return (uint32)input.readIntBigEndian();
+			int c = input.readIntBigEndian();
+			return OSCColor(c >> 24 & 0xFF, c >> 16 & 0xFF, c >> 8 & 0xFF, c & 0xFF);
 		}
 
         MemoryBlock readBlob()
@@ -200,7 +201,7 @@ namespace
                 case OSCTypes::float32:     return OSCArgument (readFloat32());
                 case OSCTypes::string:      return OSCArgument (readString());
 				case OSCTypes::blob:        return OSCArgument(readBlob());
-				case OSCTypes::color:        return OSCArgument (readColor(), true);
+				case OSCTypes::color:       return OSCArgument (readColor());
 
                 default:
                     // You supplied an invalid OSCType when calling readArgument! This should never happen.

--- a/modules/juce_osc/osc/juce_OSCSender.cpp
+++ b/modules/juce_osc/osc/juce_OSCSender.cpp
@@ -74,6 +74,11 @@ namespace
             return output.writeRepeatedByte ('\0', numPaddingZeros);
         }
 
+		bool writeColor(uint32 value)
+		{
+			return output.writeIntBigEndian(value);
+		}
+
         bool writeBlob (const MemoryBlock& blob)
         {
             if (! (output.writeIntBigEndian ((int) blob.getSize())
@@ -123,7 +128,7 @@ namespace
                 case OSCTypes::float32:     return writeFloat32 (arg.getFloat32());
                 case OSCTypes::string:      return writeString (arg.getString());
                 case OSCTypes::blob:        return writeBlob (arg.getBlob());
-
+				case OSCTypes::color:		return writeColor(arg.getColor());
                 default:
                     // In this very unlikely case you supplied an invalid OSCType!
                     jassertfalse;

--- a/modules/juce_osc/osc/juce_OSCSender.cpp
+++ b/modules/juce_osc/osc/juce_OSCSender.cpp
@@ -74,9 +74,9 @@ namespace
             return output.writeRepeatedByte ('\0', numPaddingZeros);
         }
 
-		bool writeColor(uint32 value)
+		bool writeColor(const OSCColor &value)
 		{
-			return output.writeIntBigEndian(value);
+			return output.writeIntBigEndian(value.r << 24 | value.g << 16 | value.b << 8 | value.a);
 		}
 
         bool writeBlob (const MemoryBlock& blob)

--- a/modules/juce_osc/osc/juce_OSCTypes.cpp
+++ b/modules/juce_osc/osc/juce_OSCTypes.cpp
@@ -29,5 +29,6 @@ namespace juce
     const OSCType OSCTypes::int32   = 'i';
     const OSCType OSCTypes::float32 = 'f';
     const OSCType OSCTypes::string  = 's';
-    const OSCType OSCTypes::blob    = 'b';
+	const OSCType OSCTypes::blob	= 'b';
+	const OSCType OSCTypes::color   = 'r';
 }

--- a/modules/juce_osc/osc/juce_OSCTypes.h
+++ b/modules/juce_osc/osc/juce_OSCTypes.h
@@ -52,14 +52,16 @@ public:
     static const OSCType int32;
     static const OSCType float32;
     static const OSCType string;
-    static const OSCType blob;
+	static const OSCType blob;
+	static const OSCType color;
 
     static bool isSupportedType (OSCType type) noexcept
     {
         return type == OSCTypes::int32
             || type == OSCTypes::float32
             || type == OSCTypes::string
-            || type == OSCTypes::blob;
+			|| type == OSCTypes::blob
+			|| type == OSCTypes::color;
     }
 };
 


### PR DESCRIPTION
because int32 and uint32 are recognized as the same type, i had to add a bool flag to the OSCArgument(int32) constructor to choose whether its a color or an int