### PR TITLE
X11: Added reliable detection of autorepeat for Xkb

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_X11.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_X11.cpp
@@ -171,6 +171,10 @@ void XWindowSystem::initialiseXDisplay() noexcept
         Process::terminate();
     }
 
+    Bool detectableAutoRepeat = True;
+    XkbSetDetectableAutoRepeat (display, detectableAutoRepeat, &detectableAutoRepeat);
+    this->detectableAutoRepeat = detectableAutoRepeat == True;
+
     // Create a context to store user data associated with Windows we create
     windowHandleXContext = XUniqueContext();
 

--- a/modules/juce_gui_basics/native/juce_linux_X11.h
+++ b/modules/juce_gui_basics/native/juce_linux_X11.h
@@ -42,11 +42,17 @@ public:
     XDisplay displayRef() noexcept;
     XDisplay displayUnref() noexcept;
 
+    bool hasDetectableAutoRepeat() const noexcept
+    {
+        return detectableAutoRepeat;
+    }
+
     JUCE_DECLARE_SINGLETON (XWindowSystem, false)
 
 private:
     XDisplay display = {};
     Atomic<int> displayCount;
+    bool detectableAutoRepeat = false;
 
     XWindowSystem() noexcept;
     ~XWindowSystem() noexcept;


### PR DESCRIPTION
This is a proposal for a reliable detection of repeated keys for Linux.
It is not based on peeking a future event and its timestamp.

**Method**

Use of libX11 API [XkbSetDetectableAutoRepeat](https://linux.die.net/man/3/xkbsetdetectableautorepeat).

Since the server-side may not necessarily support the request, it's good to keep the basic method as a fallback.

The purpose is to disable the reception of release events for repeated keys.
Then, if there is a press on a key already marked as down in the key state, it is identifiable as a repetition.

So unlike the basic method which filters out the release events, this filters the key press.

**Description of problem**

It solves a problem where repetitions are not detected in all cases.
A notable symptom is the `MidiKeyboardComponent` playing its notes in rapid fire, while keeping pressed one or more of the keys.

**Additional information**

By the currently used method, the repetitions are detected by timestamp on the press event which follows a release.

A problem is that there is a race for the reception of the press event.
The call `XPending` of `isKeyReleasePartOfAutoRepeat` can be observed returning false when the second event is not available in time.

This is a custom trace which shows the event sequence and the information around autorepeat.
[trace.diff.gz](https://github.com/WeAreROLI/JUCE/files/2237997/trace.diff.gz)

```
KeyPress code=42 time=195687039
KeyRelease code=42 time=195687051
- AutoRepeat: pending event KeyPress
- isKeyReleasePartOfAutoRepeat: true
KeyPress code=42 time=195687051
KeyRelease code=42 time=195687064
- AutoRepeat: pending event <none>
- isKeyReleasePartOfAutoRepeat: false
KeyPress code=42 time=195687064
KeyRelease code=42 time=195687077
- AutoRepeat: pending event KeyPress
- isKeyReleasePartOfAutoRepeat: true
KeyPress code=42 time=195687077
```

**Environment of test**

I am running this software: current Arch Linux, X.Org 1.20.0, MATE Desktop 1.20.3.
`Linux quad 4.16.18-rt9-1-rt #1 SMP PREEMPT RT Fri Jul 13 21:57:24 CEST 2018 x86_64 GNU/Linux`
