### PR TITLE
Passes the function parameter 'areaToFitWithin' of the method constra…

### DIFF
--- a/modules/juce_graphics/geometry/juce_Rectangle.h
+++ b/modules/juce_graphics/geometry/juce_Rectangle.h
@@ -767,7 +767,7 @@ public:
         is larger than the target rectangle in either dimension, then that dimension
         will be reduced to fit within the target.
     */
-    Rectangle constrainedWithin (Rectangle areaToFitWithin) const noexcept
+    Rectangle constrainedWithin (const Rectangle& areaToFitWithin) const noexcept
     {
         auto newW = jmin (w, areaToFitWithin.getWidth());
         auto newH = jmin (h, areaToFitWithin.getHeight());


### PR DESCRIPTION
…inedWithin by const reference.

Hi JUCE developpers,

I've create this pull request to help improving JUCE performance by avoiding a copy of `juce::Rectangle` in the method `constrainedWithin` in `juce_Rectangle.h` file.
The parameter was passed by value, so a copy of the parameter was made, but only `const` method are called on this object in this method. So passing the object by `const` reference will avoid this copy while assuring that the object is not modified.

If you have any recommendation, or suggestion to improve this PR, don't hesitate to ask.

Thanks for your work good work on JUCE.
Hope to ear about you soon,

Xavier Jouvenot

