### PR TITLE
Fixed the build on gcc 4.9 not implementing std::is_trivially_copyable

### DIFF
--- a/modules/juce_core/containers/juce_ArrayBase.cpp
+++ b/modules/juce_core/containers/juce_ArrayBase.cpp
@@ -111,9 +111,9 @@ public:
 
     void runTest() override
     {
-        static_assert (std::is_trivially_copyable<CopyableType>::value,
+        static_assert (IsTriviallyCopyable<CopyableType>::value,
                        "Test TriviallyCopyableType is not trivially copyable");
-        static_assert (! std::is_trivially_copyable<NoncopyableType>::value,
+        static_assert (! IsTriviallyCopyable<NoncopyableType>::value,
                        "Test NonTriviallyCopyableType is trivially copyable");
 
         beginTest ("grow capacity");

--- a/modules/juce_core/containers/juce_ArrayBase.h
+++ b/modules/juce_core/containers/juce_ArrayBase.h
@@ -329,11 +329,19 @@ public:
 
 private:
     //==============================================================================
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
     template <typename T>
-    using TriviallyCopyableVoid = typename std::enable_if<std::is_trivially_copyable<T>::value, void>::type;
+    struct IsTriviallyCopyable : std::integral_constant<bool, false> {};
+#else
+    template <typename T>
+    using IsTriviallyCopyable = std::is_trivially_copyable<T>;
+#endif
 
     template <typename T>
-    using NonTriviallyCopyableVoid = typename std::enable_if<! std::is_trivially_copyable<T>::value, void>::type;
+    using TriviallyCopyableVoid = typename std::enable_if<IsTriviallyCopyable<T>::value, void>::type;
+
+    template <typename T>
+    using NonTriviallyCopyableVoid = typename std::enable_if<! IsTriviallyCopyable<T>::value, void>::type;
 
     //==============================================================================
     template <typename T = ElementType>


### PR DESCRIPTION
Gcc 4.9 does not have a complete c++11 implementation which includes `std::is_trivially_copyable`.
If I detect a gcc compiler version < 5, I disable the copy optimization which prevents the build on this older compiler.