### PR TITLE
Make AudioTransportSource::stop() non-blocking

### DIFF
--- a/modules/juce_audio_devices/sources/juce_AudioTransportSource.cpp
+++ b/modules/juce_audio_devices/sources/juce_AudioTransportSource.cpp
@@ -129,12 +129,8 @@ void AudioTransportSource::stop()
             const ScopedLock sl (callbackLock);
             playing = false;
         }
-
-        int n = 500;
-        while (--n >= 0 && ! stopped)
-            Thread::sleep (2);
-
-        sendChangeMessage();
+        stopTimeOut = 500;
+        startTimer(0, 2);
     }
 }
 
@@ -282,5 +278,14 @@ void AudioTransportSource::getNextAudioBlock (const AudioSourceChannelInfo& info
 
     lastGain = gain;
 }
+    
+void AudioTransportSource::timerCallback(int timerID)
+{
+    if (stopped || stopTimeOut-- == 0)
+    {
+        sendChangeMessage();
+        stopTimer(0);
+    }
+};
 
 } // namespace juce

--- a/modules/juce_audio_devices/sources/juce_AudioTransportSource.h
+++ b/modules/juce_audio_devices/sources/juce_AudioTransportSource.h
@@ -39,7 +39,8 @@ namespace juce
     @tags{Audio}
 */
 class JUCE_API  AudioTransportSource  : public PositionableAudioSource,
-                                        public ChangeBroadcaster
+                                        public ChangeBroadcaster,
+                                        private MultiTimer
 {
 public:
     //==============================================================================
@@ -171,8 +172,10 @@ private:
     double sampleRate = 44100.0, sourceSampleRate = 0;
     int blockSize = 128, readAheadBufferSize = 0;
     bool isPrepared = false, inputStreamEOF = false;
+    int stopTimeOut = 500;
 
     void releaseMasterResources();
+    void timerCallback(int timerID) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioTransportSource)
 };


### PR DESCRIPTION
Previously AudioTransportSource::stop() would block the calling thread for up to 1 second waiting for the transport to stop.

This change removes the blocking behaviour and instead uses a timer to check for the transport stop and send change notification.