### PR TITLE
juce_audio_formats module fails to build on i686 *nix

### DIFF
--- a/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c
+++ b/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c
@@ -244,7 +244,7 @@ void FLAC__cpu_info(FLAC__CPUInfo *info)
 		struct sigaction sigill_save;
 		struct sigaction sigill_sse;
 		sigill_sse.sa_sigaction = sigill_handler_sse_os;
-      #ifdef __ANDROID__
+      #if defined(__ANDROID__) || true
         sigemptyset (&sigill_sse.sa_mask);
       #else
 		__sigemptyset(&sigill_sse.sa_mask);


### PR DESCRIPTION
```
Compiling include_juce_audio_formats.cpp
In file included from ../../JuceLibraryCode/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp:141:0,
                 from ../../JuceLibraryCode/modules/juce_audio_formats/juce_audio_formats.cpp:66,
                 from ../../JuceLibraryCode/include_juce_audio_formats.cpp:9:
../../JuceLibraryCode/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c: In function 'void juce::FlacNamespace::FLAC__cpu_info(juce::FlacNamespace::FLAC__CPUInfo*)':
../../JuceLibraryCode/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c:250:3: error: '__sigemptyset' was not declared in this scope
   __sigemptyset(&sigill_sse.sa_mask);
   ^~~~~~~~~~~~~
../../JuceLibraryCode/modules/juce_audio_formats/codecs/flac/libFLAC/cpu.c:250:3: note: suggested alternative: 'sigemptyset'
   __sigemptyset(&sigill_sse.sa_mask);
   ^~~~~~~~~~~~~
   sigemptyset
make: *** [Makefile:119: build/intermediate/Debug/include_juce_audio_formats_15f82001.o] Error 1
```

i dont know what is the proper semantics of this switch; but this patch allows this to compile on my computer
