### PR TITLE
fix typo in modules/juce_events/messages/juce_ApplicationBase.h

### DIFF
--- a/modules/juce_events/messages/juce_ApplicationBase.h
+++ b/modules/juce_events/messages/juce_ApplicationBase.h
@@ -107,9 +107,10 @@ public:
         If your application class returns true for this, more than one instance is
         permitted to run (except on the Mac where this isn't possible).
 
-        If it's false, the second instance won't start, but it you will still get a
-        callback to anotherInstanceStarted() to tell you about this - which
-        gives you a chance to react to what the user was trying to do.
+        If it's false, the second instance won't start, but the first instance
+        will still get a callback to anotherInstanceStarted();
+        which gives you a chance to react to what the user was trying to do.
+        @see anotherInstanceStarted
     */
     virtual bool moreThanOneInstanceAllowed() = 0;
 
@@ -151,6 +152,8 @@ public:
     /** Indicates that the user has tried to start up another instance of the app.
 
         This will get called even if moreThanOneInstanceAllowed() is false.
+        Note, that this is implemented only for windows and mac.
+        @see moreThanOneInstanceAllowed
     */
     virtual void anotherInstanceStarted (const String& commandLine) = 0;
 


### PR DESCRIPTION
the typo is just the "but it you will" bit; but these could use the extra details and clarification that it is the running instance that gets the callback, and only on some platforms
