### PR TITLE
Fix compiling juce_Unity_Wrapper.cpp for Win32

### DIFF
--- a/modules/juce_audio_plugin_client/Unity/juce_Unity_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/Unity/juce_Unity_Wrapper.cpp
@@ -655,7 +655,7 @@ static void declareEffect (UnityAudioEffectDefinition& definition)
 
 } // namespace juce
 
-UNITY_INTERFACE_EXPORT int UnityGetAudioEffectDefinitions (UnityAudioEffectDefinition*** definitionsPtr)
+UNITY_INTERFACE_EXPORT int UNITY_INTERFACE_API UnityGetAudioEffectDefinitions (UnityAudioEffectDefinition*** definitionsPtr)
 {
     if (juce::getWrapperMap().size() == 0)
         juce::initialiseJuce_GUI();
@@ -724,7 +724,7 @@ UNITY_INTERFACE_EXPORT renderCallback UNITY_INTERFACE_API getRenderCallback()
     return onRenderEvent;
 }
 
-UNITY_INTERFACE_EXPORT void unityInitialiseTexture (int id, void* data, int w, int h)
+UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API unityInitialiseTexture (int id, void* data, int w, int h)
 {
     getWrapperChecked (id)->getEditorPeer().setPixelDataHandle (reinterpret_cast<juce::uint8*> (data), w, h);
 }


### PR DESCRIPTION
Otherwise we get the following compiler errors:

```
  juce\modules\juce_audio_plugin_client\unity\juce_unity_wrapper.cpp(658): error C2373: 'UnityGetAudioEffectDefinitions': redefinition; different type modifiers
  juce\modules\juce_audio_plugin_client\unity\juce_unityplugininterface.h(178): note: see declaration of 'UnityGetAudioEffectDefinitions'
  juce\modules\juce_audio_plugin_client\unity\juce_unity_wrapper.cpp(727): error C2373: 'unityInitialiseTexture': redefinition; different type modifiers
  juce\modules\juce_audio_plugin_client\unity\juce_unityplugininterface.h(183): note: see declaration of 'unityInitialiseTexture'
```

For whatever reason, compiling for x64 doesn't fail.

@ed95 I stumbled across this compiler errors when working on adding the Unity plugin format to FRUT. I guess you don't have any CI for Win32 using Visual Studio 2017.