### PR TITLE
support 0 frames per second AnimatedAppComponent (allows stopping of the timer)

### DIFF
--- a/modules/juce_gui_extra/misc/juce_AnimatedAppComponent.cpp
+++ b/modules/juce_gui_extra/misc/juce_AnimatedAppComponent.cpp
@@ -35,8 +35,12 @@ AnimatedAppComponent::AnimatedAppComponent()
 
 void AnimatedAppComponent::setFramesPerSecond (int framesPerSecond)
 {
-    jassert (framesPerSecond > 0 && framesPerSecond < 1000);
-    startTimerHz (framesPerSecond);
+    if (framesPerSecond > 0) {
+        jassert (framesPerSecond < 1000);
+        startTimerHz (framesPerSecond);
+    } else {
+        stopTimer();
+    }
 }
 
 int AnimatedAppComponent::getMillisecondsSinceLastUpdate() const noexcept


### PR DESCRIPTION
A small tweak to AnimatedAppComponent::setFramesPerSecond() which allows 0 to be a signal to stop the timer which allows us to idle the CPU when not mid an animation.