### PR TITLE
AAX:  Call setVisible (false) on the editor content component before …

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -458,6 +458,7 @@ namespace AAXClasses
                     if (auto* modReceiver = dynamic_cast<ModifierKeyReceiver*> (component->getPeer()))
                         modReceiver->removeModifierKeyProvider();
 
+                    component->setVisible (false);
                     component->removeFromDesktop();
                     component = nullptr;
                 }


### PR DESCRIPTION
…removing it from the desktop to avoid an OpenGLTexture leak