### PR TITLE
PROJUCER: Added per-file compiler settings

### DIFF
--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -240,6 +240,8 @@ void Project::initialiseProjectValues()
         includeBinaryDataInJuceHeaderValue.referTo (projectRoot, Ids::includeBinaryInJuceHeader, getUndoManager(), true);
 
     binaryDataNamespaceValue.referTo           (projectRoot, Ids::binaryDataNamespace,       getUndoManager(), "BinaryData");
+    
+    compilerFlagsSettingsValue.referTo          (projectRoot, Ids::compilerFlagsSettings, getUndoManager(), StringArray("default"),",");
 }
 
 void Project::initialiseAudioPluginValues()
@@ -1186,6 +1188,8 @@ void Project::findAllImageItems (OwnedArray<Project::Item>& items)
 Project::Item::Item (Project& p, const ValueTree& s, bool isModuleCode)
     : project (p), state (s), belongsToModule (isModuleCode)
 {
+    if ( isFile() && !state.hasProperty (Ids::compilerFlagsSetting))
+        setCompilerFlagsSetting("default");
 }
 
 Project::Item::Item (const Item& other)
@@ -1272,6 +1276,14 @@ bool Project::Item::shouldBeAddedToXcodeResources() const   { return state [Ids:
 
 Value Project::Item::getShouldInhibitWarningsValue()        { return state.getPropertyAsValue (Ids::noWarnings, getUndoManager()); }
 bool Project::Item::shouldInhibitWarnings() const           { return state [Ids::noWarnings]; }
+
+Value Project::Item::getCompilerFlagsSettingValue()         { return state.getPropertyAsValue (Ids::compilerFlagsSetting, getUndoManager()); }
+String Project::Item::getCompilerFlagsSetting() const       { return state[Ids::compilerFlagsSetting]; }
+
+void Project::Item::setCompilerFlagsSetting(const String& Setting)
+{
+    state.getPropertyAsValue(Ids::compilerFlagsSetting, getUndoManager()).setValue(Setting);
+}
 
 bool Project::Item::isModuleCode() const                    { return belongsToModule; }
 

--- a/extras/Projucer/Source/Project/jucer_Project.h
+++ b/extras/Projucer/Source/Project/jucer_Project.h
@@ -123,6 +123,47 @@ public:
     bool shouldIncludeBinaryInJuceHeader() const         { return includeBinaryDataInJuceHeaderValue.get(); }
     String getBinaryDataNamespaceString() const          { return binaryDataNamespaceValue.get(); }
 
+    StringArray getCompilerFlagsSettings() const
+    {
+        const auto compilerFlagsSettings = compilerFlagsSettingsValue.get();
+        jassert(compilerFlagsSettings.isArray());
+        const Array<var>* settingsArray = compilerFlagsSettings.getArray();
+        StringArray result;
+        for ( auto& s : *settingsArray ) {
+            jassert(s.isString());
+            result.add(s.toString());
+        }
+        return result;
+    }
+    
+    void addCompilerFlagsSetting( const String& S )
+    {
+        const auto compilerFlagsSettings = compilerFlagsSettingsValue.get();
+        jassert(compilerFlagsSettings.isArray());
+        const Array<var>* settingsArray = compilerFlagsSettings.getArray();
+        StringArray newSettingsArray;
+        for( const auto& s : *settingsArray ) {
+            jassert(s.isString());
+            newSettingsArray.add(s.toString());
+        }
+        newSettingsArray.addIfNotAlreadyThere(S);
+        compilerFlagsSettingsValue.setValue(newSettingsArray, getUndoManagerFor(projectRoot));
+    }
+    
+    void removeCompilerFlagsSetting( const String& S )
+    {
+        const auto compilerFlagsSettings = compilerFlagsSettingsValue.get();
+        jassert(compilerFlagsSettings.isArray());
+        const Array<var>* settingsArray = compilerFlagsSettings.getArray();
+        StringArray newSettingsArray;
+        for( const auto& s : *settingsArray ) {
+            jassert(s.isString());
+            const auto T = s.toString();
+            if ( T != S ) newSettingsArray.add(T);
+        }
+        compilerFlagsSettingsValue.setValue(newSettingsArray, getUndoManagerFor(projectRoot));
+    }
+    
     bool shouldDisplaySplashScreen() const               { return displaySplashScreenValue.get(); }
     bool shouldReportAppUsage() const                    { return reportAppUsageValue.get(); }
     String getSplashScreenColourString() const           { return splashScreenColourValue.get(); }
@@ -277,6 +318,11 @@ public:
 
         Value getShouldInhibitWarningsValue();
         bool shouldInhibitWarnings() const;
+        
+        Value getCompilerFlagsSettingValue();
+        String getCompilerFlagsSetting() const;
+        
+        void setCompilerFlagsSetting( const String& Setting );
 
         bool isModuleCode() const;
 
@@ -413,7 +459,7 @@ private:
 
     ValueWithDefault projectNameValue, projectUIDValue, projectLineFeedValue, projectTypeValue, versionValue, bundleIdentifierValue, companyNameValue,
                      companyCopyrightValue, companyWebsiteValue, companyEmailValue, displaySplashScreenValue, reportAppUsageValue, splashScreenColourValue, cppStandardValue,
-                     headerSearchPathsValue, preprocessorDefsValue, userNotesValue, maxBinaryFileSizeValue, includeBinaryDataInJuceHeaderValue, binaryDataNamespaceValue;
+                     headerSearchPathsValue, preprocessorDefsValue, userNotesValue, maxBinaryFileSizeValue, includeBinaryDataInJuceHeaderValue, binaryDataNamespaceValue, compilerFlagsSettingsValue;
 
     ValueWithDefault pluginFormatsValue, pluginNameValue, pluginDescriptionValue, pluginManufacturerValue, pluginManufacturerCodeValue,
                      pluginCodeValue, pluginChannelConfigsValue, pluginCharacteristicsValue, pluginAUExportPrefixValue, pluginAAXIdentifierValue,

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
@@ -508,6 +508,9 @@ private:
         mo << newLine;
         addCompileUnits (mo, excludeFromBuild);
         mo << ")" << newLine << newLine;
+        
+        setCompileUnitFlags(mo);
+        mo << newLine;
 
         if (excludeFromBuild.size() > 0)
         {
@@ -1284,6 +1287,34 @@ private:
     {
         for (int i = 0; i < getAllGroups().size(); ++i)
             addCompileUnits (getAllGroups().getReference(i), mo, excludeFromBuild);
+    }
+    
+    void setCompileUnitFlags ( const Project::Item& projectItem, MemoryOutputStream& mo ) const
+    {
+        if (projectItem.isGroup())
+        {
+            for (int i = 0; i < projectItem.getNumChildren(); ++i)
+                setCompileUnitFlags (projectItem.getChild(i), mo);
+        }
+        else if (projectItem.shouldBeAddedToTargetProject())
+        {
+            RelativePath file (projectItem.getFile(), getTargetFolder().getChildFile ("app"), RelativePath::buildTargetFolder);
+            if( projectItem.shouldBeCompiled() ) {
+                const auto s = projectItem.getCompilerFlagsSetting();
+                if ( s != "default" ) {
+                    const auto compilerFlags = getCompilerFlagsConfigurationValues().at(s).get().toString();
+                    if ( compilerFlags.length()>0 ) {
+                        mo << "set_source_files_properties(\"" << file.toUnixStyle() << "\" PROPERTIES COMPILE_FLAGS " << compilerFlags << " )" << newLine;
+                    }
+                }
+            }
+        }
+    }
+    
+    void setCompileUnitFlags (MemoryOutputStream& mo ) const
+    {
+        for (int i = 0; i < getAllGroups().size(); ++i  )
+            setCompileUnitFlags ( getAllGroups().getReference(i), mo);
     }
 
     //==============================================================================

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CodeBlocks.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CodeBlocks.h
@@ -781,6 +781,17 @@ private:
             {
                 unit->createNewChildElement ("Option")->setAttribute ("compile", 0);
                 unit->createNewChildElement ("Option")->setAttribute ("link", 0);
+            } else {
+                const auto s = projectItem.getCompilerFlagsSetting();
+                if ( s != "default" ) {
+                    const auto compilerFlags = getCompilerFlagsConfigurationValues().at(s).get().toString();
+                    if( compilerFlags.length() > 0 ) {
+                        auto Option = unit->createNewChildElement ("Option");
+                        Option->setAttribute("compiler", "gcc");
+                        Option->setAttribute("use", 1 );
+                        Option->setAttribute("buildCommand", "$compiler $options " + compilerFlags + " $includes -c $file  -o $object" );
+                    }
+                }
             }
         }
     }

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
@@ -769,6 +769,11 @@ public:
 
                         if (! projectItem.shouldBeCompiled())
                             e->createNewChildElement ("ExcludedFromBuild")->addTextElement ("true");
+                        
+                        const auto S = projectItem.getCompilerFlagsSetting();
+                        if ( S != "default" )
+                            e->createNewChildElement ("AdditionalOptions")
+                             ->addTextElement (owner.getCompilerFlagsConfigurationValues().at(S).get().toString() + " %(AdditionalOptions)" );
                     }
                 }
                 else if (path.hasFileExtension (headerFileExtensions))

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
@@ -257,10 +257,22 @@ ProjectExporter::ProjectExporter (Project& p, const ValueTree& state)
       smallIconValue          (settings, Ids::smallIcon,           getUndoManager()),
       extraPPDefsValue        (settings, Ids::extraDefs,           getUndoManager())
 {
+    updateCompilerFlagsConfigurations();
 }
 
 ProjectExporter::~ProjectExporter()
 {
+}
+
+void ProjectExporter::updateCompilerFlagsConfigurations()
+{
+    compilerFlagsConfigurationValues.clear();
+    auto compilerFlagsConfigurationTree = settings.getOrCreateChildWithName (Ids::compilerFlagsConfigurations, getUndoManager());
+    const auto compilerFlagsSettings = project.getCompilerFlagsSettings();
+    for ( const auto& S : compilerFlagsSettings ) {
+        if ( S != "default" )
+            compilerFlagsConfigurationValues[S] = ValueWithDefault(compilerFlagsConfigurationTree, S, getUndoManager());
+    }
 }
 
 void ProjectExporter::updateDeprecatedProjectSettingsInteractively() {}
@@ -335,6 +347,12 @@ void ProjectExporter::createPropertyEditors (PropertyListBuilder& props)
         props.add (new TextPropertyComponent (extraCompilerFlagsValue, "Extra Compiler Flags", 8192, true),
                    "Extra command-line flags to be passed to the compiler. This string can contain references to preprocessor definitions in the "
                    "form ${NAME_OF_DEFINITION}, which will be replaced with their values.");
+        
+        updateCompilerFlagsConfigurations();
+        for ( auto& c : compilerFlagsConfigurationValues ) {
+            props.add (new TextPropertyComponent (c.second, String("Extra Compiler Flags for ") + c.first, 1024, false),
+                       String("Specific additional compiler flag configuration for the setting ") + c.first );
+        }
 
         props.add (new TextPropertyComponent (extraLinkerFlagsValue, "Extra Linker Flags", 8192, true),
                    "Extra command-line flags to be passed to the linker. You might want to use this for adding additional libraries. "

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.h
@@ -29,6 +29,8 @@
 #include "../Project/jucer_Project.h"
 #include "../Utility/UI/PropertyComponents/jucer_PropertyComponentsWithEnablement.h"
 
+#include <map>
+
 class ProjectSaver;
 
 //==============================================================================
@@ -362,6 +364,11 @@ public:
         gccOfast  = 6
     };
 
+    const std::map<String,ValueWithDefault>& getCompilerFlagsConfigurationValues() const
+    {
+        return compilerFlagsConfigurationValues;
+    }
+    
 protected:
     //==============================================================================
     String name;
@@ -406,6 +413,8 @@ protected:
     ValueWithDefault targetLocationValue, extraCompilerFlagsValue, extraLinkerFlagsValue, externalLibrariesValue,
                      userNotesValue, gnuExtensionsValue, bigIconValue, smallIconValue, extraPPDefsValue;
 
+    std::map<String, ValueWithDefault> compilerFlagsConfigurationValues;
+    
     mutable Array<Project::Item> itemGroups;
     void initItemGroups() const;
     Project::Item* modulesGroup = nullptr;
@@ -475,6 +484,9 @@ private:
     RelativePath getInternalVST3SDKPath();
     void addVST3FolderToPath();
     void addAAXFoldersToPath();
+    
+    void updateCompilerFlagsConfigurations();
+
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ProjectExporter)
 };

--- a/extras/Projucer/Source/Utility/Helpers/jucer_PresetIDs.h
+++ b/extras/Projucer/Source/Utility/Helpers/jucer_PresetIDs.h
@@ -159,6 +159,9 @@ namespace Ids
     DECLARE_ID (aaxIdentifier);
     DECLARE_ID (aaxFolder);
     DECLARE_ID (compile);
+    DECLARE_ID (compilerFlagsSetting);
+    DECLARE_ID (compilerFlagsSettings);
+    DECLARE_ID (compilerFlagsConfigurations);
     DECLARE_ID (noWarnings);
     DECLARE_ID (resource);
     DECLARE_ID (xcodeResource);

--- a/extras/Projucer/Source/Utility/PIPs/jucer_PIPGenerator.cpp
+++ b/extras/Projucer/Source/Utility/PIPs/jucer_PIPGenerator.cpp
@@ -173,6 +173,7 @@ void PIPGenerator::addFileToTree (ValueTree& groupTree, const String& name, bool
     file.setProperty (Ids::ID, createAlphaNumericUID(), nullptr);
     file.setProperty (Ids::name, name, nullptr);
     file.setProperty (Ids::compile, compile, nullptr);
+    file.setProperty (Ids::compilerFlagsSetting, "default", nullptr );
     file.setProperty (Ids::resource, 0, nullptr);
     file.setProperty (Ids::file, path, nullptr);
 


### PR DESCRIPTION
As discussed recently on the JUCE forum, this is an implementation of individual compiler settings for code files in Projucer. All exporters are supported, with exception of the incomplete CLion exporter.

Code files receive a new property called a compiler flag setting. New settings can be created and assigned in the file browser. The actual flag configurations belonging to each setting are then set in the exporter properties.
