### PR TITLE
Make Range constructor constexpr

### DIFF
--- a/modules/juce_core/maths/juce_Range.h
+++ b/modules/juce_core/maths/juce_Range.h
@@ -44,7 +44,7 @@ public:
     Range() = default;
 
     /** Constructs a range with given start and end values. */
-    Range (const ValueType startValue, const ValueType endValue) noexcept
+    constexpr Range (const ValueType startValue, const ValueType endValue) noexcept
         : start (startValue), end (jmax (startValue, endValue))
     {
     }


### PR DESCRIPTION
I needed the two-argument constructor for `juce::Range` to be `constexpr`, so that I can create `static const` class members inline:

```cpp
class Notes {
public:
	static constexpr note_t minNote = 24; // C1
	static constexpr note_t maxNote = 95; // B6
	static constexpr juce::Range<note_t> validNoteRange{minNote, maxNote};
};
```