### PR TITLE
mention findItemFromIdentifierString() in TreeView::getUniqueName() doc

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TreeView.h
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.h
@@ -238,13 +238,14 @@ public:
 
     /** Returns a string to uniquely identify this item.
 
-        If you're planning on using the TreeView::getOpennessState() method, then
-        these strings will be used to identify which nodes are open. The string
-        should be unique amongst the item's sibling items, but it's ok for there
-        to be duplicates at other levels of the tree.
+        If you're planning on using the TreeView::getOpennessState() or
+        TreeView::getItemIdentifierString() methods, then these strings will be used
+        to identify which nodes are open. The string should be unique amongst the item's
+        sibling items, but it's ok for there to be duplicates at other levels of the tree.
 
-        If you're not going to store the state, then it's ok not to bother implementing
-        this method.
+        If you're not going to store the openness state nor search for TreeViewItems with
+        the TreeView::findItemFromIdentifierString() method, then it's ok not to bother
+        implementing this method.
     */
     virtual String getUniqueName() const;
 


### PR DESCRIPTION
the doc for TreeView::getUniqueName() indicates that it need be implemented only for the purpose of TreeView::getOpennessState(); but the doc for TreeView::getItemIdentifierString() states that it relies on getUniqueName() to be implemented also (and on all parent items up to the root)
