### PR TITLE
Cleanup: Remove assigned to but unused variables

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ResourceFile.cpp
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ResourceFile.cpp
@@ -114,8 +114,6 @@ Result ResourceFile::writeHeader (MemoryOutputStream& header)
            << "namespace " << className << newLine
            << "{" << newLine;
 
-    bool containsAnyImages = false;
-
     for (int i = 0; i < files.size(); ++i)
     {
         auto& file = files.getReference(i);
@@ -131,9 +129,6 @@ Result ResourceFile::writeHeader (MemoryOutputStream& header)
 
         if (fileStream.openedOk())
         {
-            containsAnyImages = containsAnyImages
-                                 || (ImageFileFormat::findImageFormatForStream (fileStream) != nullptr);
-
             header << "    extern const char*   " << variableName << ";" << newLine;
             header << "    const int            " << variableName << "Size = " << (int) dataSize << ";" << newLine << newLine;
         }
@@ -169,8 +164,6 @@ Result ResourceFile::writeCpp (MemoryOutputStream& cpp, const File& headerFile, 
     cpp << "namespace " << className << newLine
         << "{" << newLine;
 
-    bool containsAnyImages = false;
-
     while (i < files.size())
     {
         auto& file = files.getReference(i);
@@ -180,9 +173,6 @@ Result ResourceFile::writeCpp (MemoryOutputStream& cpp, const File& headerFile, 
 
         if (fileStream.openedOk())
         {
-            containsAnyImages = containsAnyImages
-                                 || (ImageFileFormat::findImageFormatForStream (fileStream) != nullptr);
-
             auto tempVariable = "temp_binary_data_" + String (i);
 
             cpp  << newLine << "//================== " << file.getFileName() << " ==================" << newLine


### PR DESCRIPTION
A small cleanup that I found when looking at removing dependencies on `juce_graphics`, `juce_gui_basics` and `juce_gui_extra` from the `ResourceFile` class of Projucer.

@ed95, @julianstorer, @tpoole: merge at will, thanks!