### PR TITLE
Remove some warnings from clang-tidy with the flag modernize-use-equa…

### DIFF
--- a/extras/AudioPerformanceTest/Source/Main.cpp
+++ b/extras/AudioPerformanceTest/Source/Main.cpp
@@ -34,7 +34,7 @@ class AudioPerformanceTestApplication  : public JUCEApplication
 {
 public:
     //==============================================================================
-    AudioPerformanceTestApplication() {}
+    AudioPerformanceTestApplication() = default;
 
     const String getApplicationName() override       { return ProjectInfo::projectName; }
     const String getApplicationVersion() override    { return ProjectInfo::versionString; }

--- a/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
+++ b/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
@@ -39,10 +39,10 @@ class JUCE_API  AudioPlayHead
 {
 protected:
     //==============================================================================
-    AudioPlayHead() {}
+    AudioPlayHead() = default;
 
 public:
-    virtual ~AudioPlayHead() {}
+    virtual ~AudioPlayHead() = default;
 
     //==============================================================================
     /** Frame rate types. */

--- a/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
+++ b/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
@@ -49,7 +49,7 @@ public:
     /** Creates an empty channel set.
         You can call addChannel to add channels to the set.
     */
-    AudioChannelSet() noexcept  {}
+    AudioChannelSet() noexcept = default;
 
     /** Creates a zero-channel set which can be used to indicate that a
         bus is disabled. */

--- a/modules/juce_audio_basics/buffers/juce_AudioDataConverters.h
+++ b/modules/juce_audio_basics/buffers/juce_AudioDataConverters.h
@@ -277,8 +277,8 @@ public:
     class NonInterleaved
     {
     public:
-        inline NonInterleaved() noexcept {}
-        inline NonInterleaved (const NonInterleaved&) noexcept {}
+        inline NonInterleaved() noexcept = default;
+        inline NonInterleaved (const NonInterleaved&) noexcept = default;
         inline NonInterleaved (const int) noexcept {}
         inline void copyFrom (const NonInterleaved&) noexcept {}
         template <class SampleFormatType> inline void advanceData (SampleFormatType& s) noexcept                    { s.advance(); }
@@ -293,7 +293,7 @@ public:
     {
     public:
         inline Interleaved() noexcept : numInterleavedChannels (1) {}
-        inline Interleaved (const Interleaved& other) noexcept : numInterleavedChannels (other.numInterleavedChannels) {}
+        inline Interleaved (const Interleaved& other) noexcept = default;
         inline Interleaved (const int numInterleavedChans) noexcept : numInterleavedChannels (numInterleavedChans) {}
         inline void copyFrom (const Interleaved& other) noexcept { numInterleavedChannels = other.numInterleavedChannels; }
         template <class SampleFormatType> inline void advanceData (SampleFormatType& s) noexcept                    { s.skip (numInterleavedChannels); }
@@ -587,7 +587,7 @@ public:
     class Converter
     {
     public:
-        virtual ~Converter() {}
+        virtual ~Converter() = default;
 
         /** Converts a sequence of samples from the converter's source format into the dest format. */
         virtual void convertSamples (void* destSamples, const void* sourceSamples, int numSamples) const = 0;

--- a/modules/juce_audio_basics/midi/juce_MidiKeyboardState.h
+++ b/modules/juce_audio_basics/midi/juce_MidiKeyboardState.h
@@ -38,8 +38,8 @@ class JUCE_API  MidiKeyboardStateListener
 {
 public:
     //==============================================================================
-    MidiKeyboardStateListener() noexcept        {}
-    virtual ~MidiKeyboardStateListener()        {}
+    MidiKeyboardStateListener() noexcept = default;
+    virtual ~MidiKeyboardStateListener() = default;
 
     //==============================================================================
     /** Called when one of the MidiKeyboardState's keys is pressed.

--- a/modules/juce_audio_basics/mpe/juce_MPEInstrument.h
+++ b/modules/juce_audio_basics/mpe/juce_MPEInstrument.h
@@ -241,7 +241,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Implement this callback to be informed whenever a new expressive MIDI
             note is triggered.

--- a/modules/juce_audio_basics/mpe/juce_MPEZoneLayout.h
+++ b/modules/juce_audio_basics/mpe/juce_MPEZoneLayout.h
@@ -80,13 +80,7 @@ public:
     */
     struct Zone
     {
-        Zone (const Zone& other) noexcept
-            : numMemberChannels (other.numMemberChannels),
-              perNotePitchbendRange (other.perNotePitchbendRange),
-              masterPitchbendRange (other.masterPitchbendRange),
-              lowerZone (other.lowerZone)
-        {
-        }
+        Zone (const Zone& other) noexcept = default;
 
         bool isLowerZone() const noexcept             { return lowerZone; }
         bool isUpperZone() const noexcept             { return ! lowerZone; }
@@ -185,7 +179,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Implement this callback to be notified about any changes to this
             MPEZoneLayout. Will be called whenever a zone is added, zones are

--- a/modules/juce_audio_basics/sources/juce_AudioSource.h
+++ b/modules/juce_audio_basics/sources/juce_AudioSource.h
@@ -32,9 +32,7 @@ namespace juce
 struct JUCE_API  AudioSourceChannelInfo
 {
     /** Creates an uninitialised AudioSourceChannelInfo. */
-    AudioSourceChannelInfo() noexcept
-    {
-    }
+    AudioSourceChannelInfo() noexcept = default;
 
     /** Creates an AudioSourceChannelInfo. */
     AudioSourceChannelInfo (AudioBuffer<float>* bufferToUse,
@@ -113,11 +111,11 @@ class JUCE_API  AudioSource
 protected:
     //==============================================================================
     /** Creates an AudioSource. */
-    AudioSource() noexcept      {}
+    AudioSource() noexcept = default;
 
 public:
     /** Destructor. */
-    virtual ~AudioSource()      {}
+    virtual ~AudioSource() = default;
 
     //==============================================================================
     /** Tells the source to prepare for playing.

--- a/modules/juce_audio_basics/sources/juce_PositionableAudioSource.h
+++ b/modules/juce_audio_basics/sources/juce_PositionableAudioSource.h
@@ -40,11 +40,11 @@ class JUCE_API  PositionableAudioSource  : public AudioSource
 protected:
     //==============================================================================
     /** Creates the PositionableAudioSource. */
-    PositionableAudioSource() noexcept  {}
+    PositionableAudioSource() noexcept = default;
 
 public:
     /** Destructor */
-    ~PositionableAudioSource()          {}
+    ~PositionableAudioSource() = default;
 
     //==============================================================================
     /** Tells the stream to move to a new position.

--- a/modules/juce_audio_basics/utilities/juce_LinearSmoothedValue.h
+++ b/modules/juce_audio_basics/utilities/juce_LinearSmoothedValue.h
@@ -35,9 +35,7 @@ class LinearSmoothedValue
 {
 public:
     /** Constructor. */
-    LinearSmoothedValue() noexcept
-    {
-    }
+    LinearSmoothedValue() noexcept = default;
 
     /** Constructor. */
     LinearSmoothedValue (FloatType initialValue) noexcept

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODevice.h
@@ -43,7 +43,7 @@ class JUCE_API  AudioIODeviceCallback
 {
 public:
     /** Destructor. */
-    virtual ~AudioIODeviceCallback()  {}
+    virtual ~AudioIODeviceCallback() = default;
 
     /** Processes a block of incoming and outgoing audio data.
 

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.h
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.h
@@ -126,7 +126,7 @@ public:
     class Listener
     {
     public:
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when the list of available audio devices changes. */
         virtual void audioDeviceListChanged() = 0;

--- a/modules/juce_audio_devices/midi_io/juce_MidiInput.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiInput.h
@@ -41,7 +41,7 @@ class JUCE_API  MidiInputCallback
 {
 public:
     /** Destructor. */
-    virtual ~MidiInputCallback()  {}
+    virtual ~MidiInputCallback() = default;
 
 
     /** Receives an incoming message.

--- a/modules/juce_audio_formats/format/juce_AudioFormatWriter.h
+++ b/modules/juce_audio_formats/format/juce_AudioFormatWriter.h
@@ -216,8 +216,8 @@ public:
         class JUCE_API  IncomingDataReceiver
         {
         public:
-            IncomingDataReceiver() {}
-            virtual ~IncomingDataReceiver() {}
+            IncomingDataReceiver() = default;
+            virtual ~IncomingDataReceiver() = default;
 
             virtual void reset (int numChannels, double sampleRate, int64 totalSamplesInSource) = 0;
             virtual void addBlock (int64 sampleNumberInSource, const AudioBuffer<float>& newData,

--- a/modules/juce_audio_processors/format/juce_AudioPluginFormat.h
+++ b/modules/juce_audio_processors/format/juce_AudioPluginFormat.h
@@ -42,7 +42,7 @@ public:
     /** Structure used for callbacks when instantiation is completed. */
     struct JUCE_API  InstantiationCompletionCallback
     {
-        virtual ~InstantiationCompletionCallback() {}
+        virtual ~InstantiationCompletionCallback() = default;
         virtual void completionCallback (AudioPluginInstance* instance, const String& error) = 0;
 
         JUCE_LEAK_DETECTOR (InstantiationCompletionCallback)

--- a/modules/juce_audio_processors/processors/juce_AudioPluginInstance.h
+++ b/modules/juce_audio_processors/processors/juce_AudioPluginInstance.h
@@ -59,7 +59,7 @@ public:
         Make sure that you delete any UI components that belong to this plugin before
         deleting the plugin.
     */
-    ~AudioPluginInstance() override {}
+    ~AudioPluginInstance() override = default;
 
     //==============================================================================
     /** Fills-in the appropriate parts of this plugin description object. */
@@ -118,7 +118,7 @@ protected:
         StringArray onStrings, offStrings;
     };
 
-    AudioPluginInstance() {}
+    AudioPluginInstance() = default;
     AudioPluginInstance (const BusesProperties& ioLayouts) : AudioProcessor (ioLayouts) {}
     template <int numLayouts>
     AudioPluginInstance (const short channelLayoutList[numLayouts][2]) : AudioProcessor (channelLayoutList) {}

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
@@ -60,7 +60,7 @@ public:
     /** Each node in the graph has a UID of this type. */
     struct NodeID
     {
-        NodeID() {}
+        NodeID() = default;
         explicit NodeID (uint32 i) : uid (i) {}
 
         uint32 uid = 0;

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorListener.h
@@ -42,7 +42,7 @@ class JUCE_API  AudioProcessorListener
 public:
     //==============================================================================
     /** Destructor. */
-    virtual ~AudioProcessorListener() {}
+    virtual ~AudioProcessorListener() = default;
 
     //==============================================================================
     /** Receives a callback when a parameter is changed.

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
@@ -238,7 +238,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener()  {}
+        virtual ~Listener() = default;
 
         /** Receives a callback when a parameter has been changed.
 

--- a/modules/juce_audio_utils/gui/juce_AudioThumbnailBase.h
+++ b/modules/juce_audio_utils/gui/juce_AudioThumbnailBase.h
@@ -46,8 +46,8 @@ class JUCE_API  AudioThumbnailBase    : public ChangeBroadcaster,
 {
 public:
     //==============================================================================
-    AudioThumbnailBase() {}
-    virtual ~AudioThumbnailBase() {}
+    AudioThumbnailBase() = default;
+    virtual ~AudioThumbnailBase() = default;
 
     //==============================================================================
     /** Clears and resets the thumbnail. */

--- a/modules/juce_core/files/juce_File.h
+++ b/modules/juce_core/files/juce_File.h
@@ -48,7 +48,7 @@ public:
 
         You can use its operator= method to point it at a proper file.
     */
-    File() noexcept  {}
+    File() noexcept = default;
 
     /** Creates a file from an absolute path.
 
@@ -66,7 +66,7 @@ public:
     File (const File&);
 
     /** Destructor. */
-    ~File() noexcept  {}
+    ~File() noexcept = default;
 
     /** Sets the file based on an absolute pathname.
 

--- a/modules/juce_core/maths/juce_Expression.h
+++ b/modules/juce_core/maths/juce_Expression.h
@@ -136,7 +136,7 @@ public:
         class Visitor
         {
         public:
-            virtual ~Visitor() {}
+            virtual ~Visitor() = default;
             virtual void visit (const Scope&) = 0;
         };
 

--- a/modules/juce_core/memory/juce_HeapBlock.h
+++ b/modules/juce_core/memory/juce_HeapBlock.h
@@ -97,9 +97,7 @@ public:
         After creation, you can resize the array using the malloc(), calloc(),
         or realloc() methods.
     */
-    HeapBlock() noexcept
-    {
-    }
+    HeapBlock() noexcept = default;
 
     /** Creates a HeapBlock containing a number of elements.
 

--- a/modules/juce_core/memory/juce_LeakedObjectDetector.h
+++ b/modules/juce_core/memory/juce_LeakedObjectDetector.h
@@ -72,7 +72,7 @@ private:
     class LeakCounter
     {
     public:
-        LeakCounter() noexcept {}
+        LeakCounter() noexcept = default;
 
         ~LeakCounter()
         {

--- a/modules/juce_core/memory/juce_ReferenceCountedObject.h
+++ b/modules/juce_core/memory/juce_ReferenceCountedObject.h
@@ -99,7 +99,7 @@ public:
 protected:
     //==============================================================================
     /** Creates the reference-counted object (with an initial ref count of zero). */
-    ReferenceCountedObject() {}
+    ReferenceCountedObject() = default;
 
     /** Copying from another object does not affect this one's reference-count. */
     ReferenceCountedObject (const ReferenceCountedObject&) noexcept {}
@@ -187,7 +187,7 @@ public:
 protected:
     //==============================================================================
     /** Creates the reference-counted object (with an initial ref count of zero). */
-    SingleThreadedReferenceCountedObject() {}
+    SingleThreadedReferenceCountedObject() = default;
 
     /** Copying from another object does not affect this one's reference-count. */
     SingleThreadedReferenceCountedObject (const SingleThreadedReferenceCountedObject&) {}
@@ -246,7 +246,7 @@ public:
 
     //==============================================================================
     /** Creates a pointer to a null object. */
-    ReferenceCountedObjectPtr() noexcept {}
+    ReferenceCountedObjectPtr() noexcept = default;
 
     /** Creates a pointer to a null object. */
     ReferenceCountedObjectPtr (decltype (nullptr)) noexcept {}

--- a/modules/juce_core/memory/juce_WeakReference.h
+++ b/modules/juce_core/memory/juce_WeakReference.h
@@ -152,7 +152,7 @@ public:
     class Master
     {
     public:
-        Master() noexcept {}
+	 Master() noexcept = default;
 
         ~Master() noexcept
         {

--- a/modules/juce_core/network/juce_WebInputStream.h
+++ b/modules/juce_core/network/juce_WebInputStream.h
@@ -36,7 +36,7 @@ class JUCE_API WebInputStream : public InputStream
     class JUCE_API Listener
     {
     public:
-        virtual ~Listener() {}
+	 virtual ~Listener() = default;
 
         virtual bool postDataSendProgress (WebInputStream& /*request*/, int /*bytesSent*/, int /*totalBytes*/)    { return true; }
     };

--- a/modules/juce_core/streams/juce_InputSource.h
+++ b/modules/juce_core/streams/juce_InputSource.h
@@ -38,10 +38,10 @@ class JUCE_API  InputSource
 {
 public:
     //==============================================================================
-    InputSource() noexcept      {}
+    InputSource() noexcept = default;
 
     /** Destructor. */
-    virtual ~InputSource()      {}
+    virtual ~InputSource() = default;
 
     //==============================================================================
     /** Returns a new InputStream to read this item.

--- a/modules/juce_core/streams/juce_InputStream.h
+++ b/modules/juce_core/streams/juce_InputStream.h
@@ -37,7 +37,7 @@ class JUCE_API  InputStream
 {
 public:
     /** Destructor. */
-    virtual ~InputStream()  {}
+    virtual ~InputStream() = default;
 
     //==============================================================================
     /** Returns the total number of bytes available for reading in this stream.
@@ -253,7 +253,7 @@ public:
 
 protected:
     //==============================================================================
-    InputStream() noexcept {}
+    InputStream() noexcept = default;
 
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (InputStream)

--- a/modules/juce_core/text/juce_CharPointer_ASCII.h
+++ b/modules/juce_core/text/juce_CharPointer_ASCII.h
@@ -44,10 +44,7 @@ public:
     {
     }
 
-    inline CharPointer_ASCII (const CharPointer_ASCII& other) noexcept
-        : data (other.data)
-    {
-    }
+    inline CharPointer_ASCII (const CharPointer_ASCII& other) noexcept = default;
 
     inline CharPointer_ASCII operator= (const CharPointer_ASCII other) noexcept
     {

--- a/modules/juce_core/text/juce_CharPointer_UTF16.h
+++ b/modules/juce_core/text/juce_CharPointer_UTF16.h
@@ -45,10 +45,7 @@ public:
     {
     }
 
-    inline CharPointer_UTF16 (const CharPointer_UTF16& other) noexcept
-        : data (other.data)
-    {
-    }
+    inline CharPointer_UTF16 (const CharPointer_UTF16& other) noexcept = default;
 
     inline CharPointer_UTF16 operator= (CharPointer_UTF16 other) noexcept
     {

--- a/modules/juce_core/text/juce_CharPointer_UTF32.h
+++ b/modules/juce_core/text/juce_CharPointer_UTF32.h
@@ -41,10 +41,7 @@ public:
     {
     }
 
-    inline CharPointer_UTF32 (const CharPointer_UTF32& other) noexcept
-        : data (other.data)
-    {
-    }
+    inline CharPointer_UTF32 (const CharPointer_UTF32& other) noexcept = default;
 
     inline CharPointer_UTF32 operator= (CharPointer_UTF32 other) noexcept
     {

--- a/modules/juce_core/text/juce_CharPointer_UTF8.h
+++ b/modules/juce_core/text/juce_CharPointer_UTF8.h
@@ -41,10 +41,7 @@ public:
     {
     }
 
-    inline CharPointer_UTF8 (const CharPointer_UTF8& other) noexcept
-        : data (other.data)
-    {
-    }
+    inline CharPointer_UTF8 (const CharPointer_UTF8& other) noexcept = default;
 
     inline CharPointer_UTF8 operator= (CharPointer_UTF8 other) noexcept
     {

--- a/modules/juce_core/threads/juce_CriticalSection.h
+++ b/modules/juce_core/threads/juce_CriticalSection.h
@@ -133,8 +133,8 @@ private:
 class JUCE_API  DummyCriticalSection
 {
 public:
-    inline DummyCriticalSection() noexcept      {}
-    inline ~DummyCriticalSection() noexcept     {}
+    inline DummyCriticalSection() noexcept = default;
+    inline ~DummyCriticalSection() noexcept = default;
 
     inline void enter() const noexcept          {}
     inline bool tryEnter() const noexcept       { return true; }

--- a/modules/juce_core/threads/juce_DynamicLibrary.h
+++ b/modules/juce_core/threads/juce_DynamicLibrary.h
@@ -38,7 +38,7 @@ public:
     /** Creates an unopened DynamicLibrary object.
         Call open() to actually open one.
     */
-    DynamicLibrary() noexcept {}
+    DynamicLibrary() noexcept = default;
 
     /**
     */

--- a/modules/juce_core/threads/juce_SpinLock.h
+++ b/modules/juce_core/threads/juce_SpinLock.h
@@ -41,8 +41,8 @@ namespace juce
 class JUCE_API  SpinLock
 {
 public:
-    inline SpinLock() noexcept {}
-    inline ~SpinLock() noexcept {}
+    inline SpinLock() noexcept = default;
+    inline ~SpinLock() noexcept = default;
 
     /** Acquires the lock.
         This will block until the lock has been successfully acquired by this thread.

--- a/modules/juce_core/threads/juce_Thread.h
+++ b/modules/juce_core/threads/juce_Thread.h
@@ -180,7 +180,7 @@ public:
     class JUCE_API Listener
     {
     public:
-        virtual ~Listener() {}
+	 virtual ~Listener() = default;
 
         /** Called if Thread::signalThreadShouldExit was called.
             @see Thread::threadShouldExit, Thread::addListener, Thread::removeListener

--- a/modules/juce_core/threads/juce_ThreadPool.h
+++ b/modules/juce_core/threads/juce_ThreadPool.h
@@ -191,7 +191,7 @@ public:
     class JUCE_API  JobSelector
     {
     public:
-        virtual ~JobSelector() {}
+	 virtual ~JobSelector() = default;
 
         /** Should return true if the specified thread matches your criteria for whatever
             operation that this object is being used for.

--- a/modules/juce_core/threads/juce_TimeSliceThread.h
+++ b/modules/juce_core/threads/juce_TimeSliceThread.h
@@ -44,7 +44,7 @@ class JUCE_API  TimeSliceClient
 {
 public:
     /** Destructor. */
-    virtual ~TimeSliceClient()   {}
+    virtual ~TimeSliceClient() = default;
 
     /** Called back by a TimeSliceThread.
 

--- a/modules/juce_core/zip/juce_ZipFile.h
+++ b/modules/juce_core/zip/juce_ZipFile.h
@@ -243,7 +243,7 @@ private:
    #if JUCE_DEBUG
     struct OpenStreamCounter
     {
-        OpenStreamCounter() {}
+	 OpenStreamCounter() = default;
         ~OpenStreamCounter();
 
         int numOpenStreams = 0;

--- a/modules/juce_data_structures/undomanager/juce_UndoableAction.h
+++ b/modules/juce_data_structures/undomanager/juce_UndoableAction.h
@@ -40,11 +40,11 @@ class JUCE_API  UndoableAction
 {
 protected:
     /** Creates an action. */
-    UndoableAction() noexcept   {}
+    UndoableAction() noexcept = default;
 
 public:
     /** Destructor. */
-    virtual ~UndoableAction()   {}
+    virtual ~UndoableAction() = default;
 
     //==============================================================================
     /** Overridden by a subclass to perform the action.

--- a/modules/juce_data_structures/values/juce_Value.h
+++ b/modules/juce_data_structures/values/juce_Value.h
@@ -138,8 +138,8 @@ public:
     class JUCE_API  Listener
     {
     public:
-        Listener()          {}
-        virtual ~Listener() {}
+        Listener() = default;
+        virtual ~Listener() = default;
 
         /** Called when a Value object is changed.
 

--- a/modules/juce_data_structures/values/juce_ValueTree.h
+++ b/modules/juce_data_structures/values/juce_ValueTree.h
@@ -475,7 +475,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** This method is called when a property of this tree (or of one of its sub-trees) is changed.
             Note that when you register a listener to a tree, it will receive this callback for

--- a/modules/juce_data_structures/values/juce_ValueWithDefault.h
+++ b/modules/juce_data_structures/values/juce_ValueWithDefault.h
@@ -41,7 +41,7 @@ class ValueWithDefault
 public:
     //==============================================================================
     /** Creates an unitialised ValueWithDefault. Initialise it using one of the referTo() methods. */
-    ValueWithDefault() {}
+    ValueWithDefault() = default;
 
     /** Creates an ValueWithDefault object. The default value will be an empty var. */
     ValueWithDefault (ValueTree& tree, const Identifier& propertyID, UndoManager* um)

--- a/modules/juce_events/broadcasters/juce_ActionListener.h
+++ b/modules/juce_events/broadcasters/juce_ActionListener.h
@@ -35,7 +35,7 @@ class JUCE_API  ActionListener
 {
 public:
     /** Destructor. */
-    virtual ~ActionListener()  {}
+    virtual ~ActionListener() = default;
 
     /** Overridden by your subclass to receive the callback.
 

--- a/modules/juce_events/broadcasters/juce_ChangeListener.h
+++ b/modules/juce_events/broadcasters/juce_ChangeListener.h
@@ -45,7 +45,7 @@ class JUCE_API  ChangeListener
 {
 public:
     /** Destructor. */
-    virtual ~ChangeListener()  {}
+    virtual ~ChangeListener() = default;
 
     /** Your subclass should implement this method to receive the callback.
         @param source the ChangeBroadcaster that triggered the callback.

--- a/modules/juce_events/messages/juce_CallbackMessage.h
+++ b/modules/juce_events/messages/juce_CallbackMessage.h
@@ -49,10 +49,10 @@ class JUCE_API  CallbackMessage   : public MessageManager::MessageBase
 {
 public:
     //==============================================================================
-    CallbackMessage() noexcept {}
+    CallbackMessage() noexcept = default;
 
     /** Destructor. */
-    ~CallbackMessage() {}
+    ~CallbackMessage() = default;
 
     //==============================================================================
     /** Called when the message is delivered.

--- a/modules/juce_events/messages/juce_MessageManager.h
+++ b/modules/juce_events/messages/juce_MessageManager.h
@@ -186,8 +186,8 @@ public:
     class JUCE_API  MessageBase  : public ReferenceCountedObject
     {
     public:
-        MessageBase() noexcept {}
-        virtual ~MessageBase() {}
+        MessageBase() noexcept = default;
+        virtual ~MessageBase() = default;
 
         virtual void messageCallback() = 0;
         bool post();

--- a/modules/juce_graphics/effects/juce_ImageEffectFilter.h
+++ b/modules/juce_graphics/effects/juce_ImageEffectFilter.h
@@ -65,7 +65,7 @@ public:
                               float alpha) = 0;
 
     /** Destructor. */
-    virtual ~ImageEffectFilter() {}
+    virtual ~ImageEffectFilter() = default;
 
 };
 

--- a/modules/juce_graphics/geometry/juce_RectangleList.h
+++ b/modules/juce_graphics/geometry/juce_RectangleList.h
@@ -47,7 +47,7 @@ public:
 
     //==============================================================================
     /** Creates an empty RectangleList */
-    RectangleList() noexcept {}
+    RectangleList() noexcept = default;
 
     /** Creates a copy of another list */
     RectangleList (const RectangleList& other)  : rects (other.rects)

--- a/modules/juce_graphics/images/juce_Image.h
+++ b/modules/juce_graphics/images/juce_Image.h
@@ -360,9 +360,9 @@ public:
         class BitmapDataReleaser
         {
         protected:
-            BitmapDataReleaser() {}
+            BitmapDataReleaser() = default;
         public:
-            virtual ~BitmapDataReleaser() {}
+            virtual ~BitmapDataReleaser() = default;
         };
 
         std::unique_ptr<BitmapDataReleaser> dataReleaser;
@@ -475,7 +475,7 @@ public:
     /** Used to receive callbacks for image data changes */
     struct Listener
     {
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         virtual void imageDataChanged (ImagePixelData*) = 0;
         virtual void imageDataBeingDeleted (ImagePixelData*) = 0;

--- a/modules/juce_graphics/images/juce_ImageFileFormat.h
+++ b/modules/juce_graphics/images/juce_ImageFileFormat.h
@@ -44,11 +44,11 @@ class JUCE_API  ImageFileFormat
 protected:
     //==============================================================================
     /** Creates an ImageFormat. */
-    ImageFileFormat()                   {}
+    ImageFileFormat() = default;
 
 public:
     /** Destructor. */
-    virtual ~ImageFileFormat()          {}
+    virtual ~ImageFileFormat() = default;
 
     //==============================================================================
     /** Returns a description of this file format.

--- a/modules/juce_graphics/native/juce_RenderingHelpers.h
+++ b/modules/juce_graphics/native/juce_RenderingHelpers.h
@@ -43,15 +43,10 @@ namespace RenderingHelpers
 class TranslationOrTransform
 {
 public:
-    TranslationOrTransform() noexcept {}
+    TranslationOrTransform() noexcept = default;
     TranslationOrTransform (Point<int> origin) noexcept  : offset (origin) {}
 
-    TranslationOrTransform (const TranslationOrTransform& other) noexcept
-        : complexTransform (other.complexTransform), offset (other.offset),
-          isOnlyTranslated (other.isOnlyTranslated), isRotated (other.isRotated)
-    {
-    }
-
+    TranslationOrTransform (const TranslationOrTransform& other) noexcept = default;
     AffineTransform getTransform() const noexcept
     {
         return isOnlyTranslated ? AffineTransform::translation (offset)
@@ -283,7 +278,7 @@ template <class RendererType>
 class CachedGlyphEdgeTable  : public ReferenceCountedObject
 {
 public:
-    CachedGlyphEdgeTable() {}
+    CachedGlyphEdgeTable() = default;
 
     void draw (RendererType& state, Point<float> pos) const
     {
@@ -1397,7 +1392,7 @@ namespace EdgeTableFillers
         private:
             struct BresenhamInterpolator
             {
-                BresenhamInterpolator() noexcept {}
+                BresenhamInterpolator() noexcept = default;
 
                 void set (int n1, int n2, int steps, int offsetInt) noexcept
                 {
@@ -1628,8 +1623,8 @@ struct ClipRegions
 {
     struct Base  : public SingleThreadedReferenceCountedObject
     {
-        Base() {}
-        virtual ~Base() {}
+        Base() = default;
+        virtual ~Base() = default;
 
         using Ptr = ReferenceCountedObjectPtr<Base>;
 
@@ -2528,10 +2523,7 @@ public:
     {
     }
 
-    SoftwareRendererSavedState (const SoftwareRendererSavedState& other)
-        : BaseClass (other), image (other.image), font (other.font)
-    {
-    }
+    SoftwareRendererSavedState (const SoftwareRendererSavedState& other) = default;
 
     SoftwareRendererSavedState* beginTransparencyLayer (float opacity)
     {

--- a/modules/juce_gui_basics/buttons/juce_Button.h
+++ b/modules/juce_gui_basics/buttons/juce_Button.h
@@ -166,7 +166,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener()  {}
+        virtual ~Listener() = default;
 
         /** Called when the button is clicked. */
         virtual void buttonClicked (Button*) = 0;
@@ -367,7 +367,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawButtonBackground (Graphics&, Button&, const Colour& backgroundColour,
                                            bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) = 0;

--- a/modules/juce_gui_basics/buttons/juce_ImageButton.h
+++ b/modules/juce_gui_basics/buttons/juce_ImageButton.h
@@ -131,7 +131,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawImageButton (Graphics&, Image*,
                                       int imageX, int imageY, int imageW, int imageH,

--- a/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.h
+++ b/modules/juce_gui_basics/commands/juce_ApplicationCommandManager.h
@@ -338,7 +338,7 @@ class JUCE_API  ApplicationCommandManagerListener
 public:
     //==============================================================================
     /** Destructor. */
-    virtual ~ApplicationCommandManagerListener()  {}
+    virtual ~ApplicationCommandManagerListener() = default;
 
     /** Called when an app command is about to be invoked. */
     virtual void applicationCommandInvoked (const ApplicationCommandTarget::InvocationInfo&) = 0;

--- a/modules/juce_gui_basics/components/juce_CachedComponentImage.h
+++ b/modules/juce_gui_basics/components/juce_CachedComponentImage.h
@@ -42,8 +42,8 @@ namespace juce
 class JUCE_API  CachedComponentImage
 {
 public:
-    CachedComponentImage() noexcept {}
-    virtual ~CachedComponentImage() {}
+    CachedComponentImage() noexcept = default;
+    virtual ~CachedComponentImage() = default;
 
     //==============================================================================
     /** Called as part of the parent component's paint method, this must draw

--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -2205,7 +2205,7 @@ public:
         /** Creates a Positioner which can control the specified component. */
         explicit Positioner (Component& component) noexcept;
         /** Destructor. */
-        virtual ~Positioner() {}
+        virtual ~Positioner() = default;
 
         /** Returns the component that this positioner controls. */
         Component& getComponent() const noexcept    { return component; }

--- a/modules/juce_gui_basics/components/juce_ComponentListener.h
+++ b/modules/juce_gui_basics/components/juce_ComponentListener.h
@@ -44,7 +44,7 @@ class JUCE_API  ComponentListener
 {
 public:
     /** Destructor. */
-    virtual ~ComponentListener()  {}
+    virtual ~ComponentListener() = default;
 
     /** Called when the component's position or size changes.
 

--- a/modules/juce_gui_basics/components/juce_ModalComponentManager.h
+++ b/modules/juce_gui_basics/components/juce_ModalComponentManager.h
@@ -57,10 +57,10 @@ public:
     {
     public:
         /** */
-        Callback() {}
+        Callback() = default;
 
         /** Destructor. */
-        virtual ~Callback() {}
+        virtual ~Callback() = default;
 
         /** Called to indicate that a modal component has been dismissed.
 

--- a/modules/juce_gui_basics/desktop/juce_Desktop.h
+++ b/modules/juce_gui_basics/desktop/juce_Desktop.h
@@ -40,7 +40,7 @@ class JUCE_API  FocusChangeListener
 {
 public:
     /** Destructor. */
-    virtual ~FocusChangeListener()  {}
+    virtual ~FocusChangeListener() = default;
 
     /** Callback to indicate that the currently focused component has changed. */
     virtual void globalFocusChanged (Component* focusedComponent) = 0;

--- a/modules/juce_gui_basics/desktop/juce_Displays.h
+++ b/modules/juce_gui_basics/desktop/juce_Displays.h
@@ -127,7 +127,7 @@ public:
     /** @internal */
     void refresh();
     /** @internal */
-    ~Displays() {}
+    ~Displays() = default;
     // This method has been deprecated - use the findDisplayForPoint() or findDisplayForRect() methods instead
     // as they can deal with converting between logical and physical pixels
     JUCE_DEPRECATED (const Display& getDisplayContaining (Point<int> position) const noexcept);

--- a/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h
+++ b/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.h
@@ -183,7 +183,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         // These return a pointer to an internally cached drawable - make sure you don't keep
         // a copy of this pointer anywhere, as it may become invalid in the future.

--- a/modules/juce_gui_basics/filebrowser/juce_FileChooser.h
+++ b/modules/juce_gui_basics/filebrowser/juce_FileChooser.h
@@ -318,7 +318,7 @@ private:
     //==============================================================================
     struct Pimpl
     {
-        virtual ~Pimpl() {}
+        virtual ~Pimpl() = default;
 
         virtual void launch()     = 0;
         virtual void runModally() = 0;

--- a/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.h
+++ b/modules/juce_gui_basics/filebrowser/juce_FilenameComponent.h
@@ -42,7 +42,7 @@ class JUCE_API  FilenameComponentListener
 {
 public:
     /** Destructor. */
-    virtual ~FilenameComponentListener() {}
+    virtual ~FilenameComponentListener() = default;
 
     /** This method is called after the FilenameComponent's file has been changed. */
     virtual void filenameComponentChanged (FilenameComponent* fileComponentThatHasChanged) = 0;
@@ -191,7 +191,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual Button* createFilenameComponentBrowseButton (const String& text) = 0;
         virtual void layoutFilenameComponent (FilenameComponent&, ComboBox* filenameBox, Button* browseButton) =  0;

--- a/modules/juce_gui_basics/keyboard/juce_KeyListener.h
+++ b/modules/juce_gui_basics/keyboard/juce_KeyListener.h
@@ -42,7 +42,7 @@ class JUCE_API  KeyListener
 {
 public:
     /** Destructor. */
-    virtual ~KeyListener()  {}
+    virtual ~KeyListener() = default;
 
     //==============================================================================
     /** Called to indicate that a key has been pressed.

--- a/modules/juce_gui_basics/keyboard/juce_TextInputTarget.h
+++ b/modules/juce_gui_basics/keyboard/juce_TextInputTarget.h
@@ -43,10 +43,10 @@ class JUCE_API  TextInputTarget
 public:
     //==============================================================================
     /** */
-    TextInputTarget() {}
+    TextInputTarget() = default;
 
     /** Destructor. */
-    virtual ~TextInputTarget() {}
+    virtual ~TextInputTarget() = default;
 
     /** Returns true if this input target is currently accepting input.
         For example, a text editor might return false if it's in read-only mode.

--- a/modules/juce_gui_basics/layout/juce_AnimatedPositionBehaviours.h
+++ b/modules/juce_gui_basics/layout/juce_AnimatedPositionBehaviours.h
@@ -46,9 +46,7 @@ namespace AnimatedPositionBehaviours
     */
     struct ContinuousWithMomentum
     {
-        ContinuousWithMomentum() noexcept
-        {
-        }
+        ContinuousWithMomentum() noexcept = default;
 
         /** Sets the friction that damps the movement of the value.
             A typical value is 0.08; higher values indicate more friction.

--- a/modules/juce_gui_basics/layout/juce_ComponentBuilder.h
+++ b/modules/juce_gui_basics/layout/juce_ComponentBuilder.h
@@ -186,8 +186,8 @@ public:
     class JUCE_API  ImageProvider
     {
     public:
-        ImageProvider() {}
-        virtual ~ImageProvider() {}
+        ImageProvider() = default;
+        virtual ~ImageProvider() = default;
 
         /** Retrieves the image associated with this identifier, which could be any
             kind of string, number, filename, etc.

--- a/modules/juce_gui_basics/layout/juce_ConcertinaPanel.h
+++ b/modules/juce_gui_basics/layout/juce_ConcertinaPanel.h
@@ -113,7 +113,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawConcertinaPanelHeader (Graphics&, const Rectangle<int>& area,
                                                 bool isMouseOver, bool isMouseDown,

--- a/modules/juce_gui_basics/layout/juce_GroupComponent.h
+++ b/modules/juce_gui_basics/layout/juce_GroupComponent.h
@@ -89,7 +89,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawGroupComponentOutline (Graphics&, int w, int h, const String& text,
                                                 const Justification&, GroupComponent&) = 0;

--- a/modules/juce_gui_basics/layout/juce_ScrollBar.h
+++ b/modules/juce_gui_basics/layout/juce_ScrollBar.h
@@ -305,7 +305,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when a ScrollBar is moved.
 
@@ -328,7 +328,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual bool areScrollbarButtonsVisible() = 0;
 

--- a/modules/juce_gui_basics/layout/juce_SidePanel.h
+++ b/modules/juce_gui_basics/layout/juce_SidePanel.h
@@ -161,7 +161,7 @@ public:
      */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual Font getSidePanelTitleFont (SidePanel&) = 0;
         virtual Justification getSidePanelTitleJustification (SidePanel&) = 0;

--- a/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.h
+++ b/modules/juce_gui_basics/layout/juce_StretchableLayoutResizerBar.h
@@ -79,7 +79,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawStretchableLayoutResizerBar (Graphics&, int w, int h,
                                                       bool isVerticalBar, bool isMouseOver, bool isMouseDragging) = 0;

--- a/modules/juce_gui_basics/layout/juce_TabbedButtonBar.h
+++ b/modules/juce_gui_basics/layout/juce_TabbedButtonBar.h
@@ -308,7 +308,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual int getTabButtonSpaceAroundImage() = 0;
         virtual int getTabButtonOverlap (int tabDepth) = 0;

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
@@ -40,7 +40,7 @@ struct JUCE_API  ExtraLookAndFeelBaseClasses
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LassoComponentMethods
     {
-        virtual ~LassoComponentMethods() {}
+        virtual ~LassoComponentMethods() = default;
 
         virtual void drawLasso (Graphics&, Component& lassoComp) = 0;
     };
@@ -49,7 +49,7 @@ struct JUCE_API  ExtraLookAndFeelBaseClasses
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  KeyMappingEditorComponentMethods
     {
-        virtual ~KeyMappingEditorComponentMethods() {}
+        virtual ~KeyMappingEditorComponentMethods() = default;
 
         virtual void drawKeymapChangeButton (Graphics&, int width, int height, Button&, const String& keyDescription) = 0;
     };
@@ -58,7 +58,7 @@ struct JUCE_API  ExtraLookAndFeelBaseClasses
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  AudioDeviceSelectorComponentMethods
     {
-        virtual ~AudioDeviceSelectorComponentMethods() {}
+        virtual ~AudioDeviceSelectorComponentMethods() = default;
 
         virtual void drawLevelMeter (Graphics&, int width, int height, float level) = 0;
     };

--- a/modules/juce_gui_basics/menus/juce_MenuBarModel.h
+++ b/modules/juce_gui_basics/menus/juce_MenuBarModel.h
@@ -80,7 +80,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         //==============================================================================
         /** This callback is made when items are changed in the menu bar model. */

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.h
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.h
@@ -684,7 +684,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         /** Fills the background of a popup menu component. */
         virtual void drawPopupMenuBackground (Graphics&, int width, int height) = 0;

--- a/modules/juce_gui_basics/misc/juce_BubbleComponent.h
+++ b/modules/juce_gui_basics/misc/juce_BubbleComponent.h
@@ -150,7 +150,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawBubble (Graphics&, BubbleComponent&,
                                  const Point<float>& positionOfTip,

--- a/modules/juce_gui_basics/mouse/juce_DragAndDropTarget.h
+++ b/modules/juce_gui_basics/mouse/juce_DragAndDropTarget.h
@@ -47,7 +47,7 @@ class JUCE_API  DragAndDropTarget
 {
 public:
     /** Destructor. */
-    virtual ~DragAndDropTarget()  {}
+    virtual ~DragAndDropTarget() = default;
 
     //==============================================================================
     /** Contains details about the source of a drag-and-drop operation. */

--- a/modules/juce_gui_basics/mouse/juce_FileDragAndDropTarget.h
+++ b/modules/juce_gui_basics/mouse/juce_FileDragAndDropTarget.h
@@ -38,7 +38,7 @@ class JUCE_API  FileDragAndDropTarget
 {
 public:
     /** Destructor. */
-    virtual ~FileDragAndDropTarget()  {}
+    virtual ~FileDragAndDropTarget() = default;
 
     /** Callback to check whether this target is interested in the set of files being offered.
 

--- a/modules/juce_gui_basics/mouse/juce_MouseInactivityDetector.h
+++ b/modules/juce_gui_basics/mouse/juce_MouseInactivityDetector.h
@@ -71,7 +71,7 @@ public:
     class Listener
     {
     public:
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when the mouse is moved or clicked for the first time
             after a period of inactivity. */

--- a/modules/juce_gui_basics/mouse/juce_MouseListener.h
+++ b/modules/juce_gui_basics/mouse/juce_MouseListener.h
@@ -40,7 +40,7 @@ class JUCE_API  MouseListener
 {
 public:
     /** Destructor. */
-    virtual ~MouseListener()  {}
+    virtual ~MouseListener() = default;
 
     /** Called when the mouse moves inside a component.
 

--- a/modules/juce_gui_basics/mouse/juce_TextDragAndDropTarget.h
+++ b/modules/juce_gui_basics/mouse/juce_TextDragAndDropTarget.h
@@ -39,7 +39,7 @@ class JUCE_API  TextDragAndDropTarget
 {
 public:
     /** Destructor. */
-    virtual ~TextDragAndDropTarget()  {}
+    virtual ~TextDragAndDropTarget() = default;
 
     /** Callback to check whether this target is interested in the set of text being offered.
 

--- a/modules/juce_gui_basics/mouse/juce_TooltipClient.h
+++ b/modules/juce_gui_basics/mouse/juce_TooltipClient.h
@@ -43,7 +43,7 @@ class JUCE_API  TooltipClient
 {
 public:
     /** Destructor. */
-    virtual ~TooltipClient()  {}
+    virtual ~TooltipClient() = default;
 
     /** Returns the string that this object wants to show as its tooltip. */
     virtual String getTooltip() = 0;
@@ -70,7 +70,7 @@ class JUCE_API  SettableTooltipClient   : public TooltipClient
 public:
     //==============================================================================
     /** Destructor. */
-    ~SettableTooltipClient() override {}
+    ~SettableTooltipClient() override = default;
 
     //==============================================================================
     /** Assigns a new tooltip to this object. */
@@ -80,7 +80,7 @@ public:
     String getTooltip() override                                    { return tooltipString; }
 
 protected:
-    SettableTooltipClient() {}
+    SettableTooltipClient() = default;
 
 private:
     String tooltipString;

--- a/modules/juce_gui_basics/positioning/juce_MarkerList.h
+++ b/modules/juce_gui_basics/positioning/juce_MarkerList.h
@@ -130,7 +130,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when something in the given marker list changes. */
         virtual void markersChanged (MarkerList* markerList) = 0;
@@ -152,7 +152,7 @@ public:
     /** A base class for objects that want to provide a MarkerList. */
     struct MarkerListHolder
     {
-        virtual ~MarkerListHolder() {}
+        virtual ~MarkerListHolder() = default;
 
         /** Objects can implement this method to provide a MarkerList. */
         virtual MarkerList* getMarkers (bool xAxis) = 0;

--- a/modules/juce_gui_basics/positioning/juce_RelativePointPath.h
+++ b/modules/juce_gui_basics/positioning/juce_RelativePointPath.h
@@ -81,7 +81,7 @@ public:
     {
     public:
         ElementBase (ElementType type);
-        virtual ~ElementBase() {}
+        virtual ~ElementBase() = default;
         virtual void addToPath (Path& path, Expression::Scope*) const = 0;
         virtual RelativePoint* getControlPoints (int& numPoints) = 0;
         virtual ElementBase* clone() const = 0;

--- a/modules/juce_gui_basics/properties/juce_PropertyComponent.h
+++ b/modules/juce_gui_basics/properties/juce_PropertyComponent.h
@@ -123,7 +123,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawPropertyPanelSectionHeader (Graphics&, const String& name, bool isOpen, int width, int height) = 0;
         virtual void drawPropertyComponentBackground (Graphics&, int width, int height, PropertyComponent&) = 0;

--- a/modules/juce_gui_basics/properties/juce_TextPropertyComponent.h
+++ b/modules/juce_gui_basics/properties/juce_TextPropertyComponent.h
@@ -133,7 +133,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when text has finished being entered (i.e. not per keypress) has changed. */
         virtual void textPropertyComponentChanged (TextPropertyComponent*) = 0;

--- a/modules/juce_gui_basics/widgets/juce_ComboBox.h
+++ b/modules/juce_gui_basics/widgets/juce_ComboBox.h
@@ -288,7 +288,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when a ComboBox has its selected item changed. */
         virtual void comboBoxChanged (ComboBox* comboBoxThatHasChanged) = 0;
@@ -365,7 +365,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawComboBox (Graphics&, int width, int height, bool isButtonDown,
                                    int buttonX, int buttonY, int buttonW, int buttonH,

--- a/modules/juce_gui_basics/widgets/juce_Label.h
+++ b/modules/juce_gui_basics/widgets/juce_Label.h
@@ -184,7 +184,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** Called when a Label's text has changed. */
         virtual void labelTextChanged (Label* labelThatHasChanged) = 0;
@@ -276,7 +276,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawLabel (Graphics&, Label&) = 0;
         virtual Font getLabelFont (Label&) = 0;

--- a/modules/juce_gui_basics/widgets/juce_ListBox.h
+++ b/modules/juce_gui_basics/widgets/juce_ListBox.h
@@ -40,7 +40,7 @@ class JUCE_API  ListBoxModel
 public:
     //==============================================================================
     /** Destructor. */
-    virtual ~ListBoxModel()  {}
+    virtual ~ListBoxModel() = default;
 
     //==============================================================================
     /** This has to return the number of items in the list.

--- a/modules/juce_gui_basics/widgets/juce_ProgressBar.h
+++ b/modules/juce_gui_basics/widgets/juce_ProgressBar.h
@@ -102,7 +102,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         /** Draws a progress bar.
 

--- a/modules/juce_gui_basics/widgets/juce_Slider.h
+++ b/modules/juce_gui_basics/widgets/juce_Slider.h
@@ -558,7 +558,7 @@ public:
     public:
         //==============================================================================
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         //==============================================================================
         /** Called when the slider's value is changed.
@@ -890,7 +890,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         //==============================================================================
         virtual void drawLinearSlider (Graphics&,

--- a/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h
+++ b/modules/juce_gui_basics/widgets/juce_TableHeaderComponent.h
@@ -306,10 +306,10 @@ public:
     {
     public:
         //==============================================================================
-        Listener() {}
+        Listener() = default;
 
         /** Destructor. */
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         //==============================================================================
         /** This is called when some of the table's columns are added, removed, hidden,
@@ -390,7 +390,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawTableHeaderBackground (Graphics&, TableHeaderComponent&) = 0;
 

--- a/modules/juce_gui_basics/widgets/juce_TableListBox.h
+++ b/modules/juce_gui_basics/widgets/juce_TableListBox.h
@@ -42,10 +42,10 @@ class JUCE_API  TableListBoxModel
 {
 public:
     //==============================================================================
-    TableListBoxModel()  {}
+    TableListBoxModel() = default;
 
     /** Destructor. */
-    virtual ~TableListBoxModel()  {}
+    virtual ~TableListBoxModel() = default;
 
     //==============================================================================
     /** This must return the number of rows currently in the table.

--- a/modules/juce_gui_basics/widgets/juce_TextEditor.h
+++ b/modules/juce_gui_basics/widgets/juce_TextEditor.h
@@ -295,7 +295,7 @@ public:
     {
     public:
         /** Destructor. */
-        virtual ~Listener()  {}
+        virtual ~Listener() = default;
 
         /** Called when the user changes the text in some way. */
         virtual void textEditorTextChanged (TextEditor&) {}
@@ -569,8 +569,8 @@ public:
     class JUCE_API  InputFilter
     {
     public:
-        InputFilter() {}
-        virtual ~InputFilter() {}
+        InputFilter() = default;
+        virtual ~InputFilter() = default;
 
         /** This method is called whenever text is entered into the editor.
             An implementation of this class should should check the input string,
@@ -632,7 +632,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void fillTextEditorBackground (Graphics&, int width, int height, TextEditor&) = 0;
         virtual void drawTextEditorOutline (Graphics&, int width, int height, TextEditor&) = 0;

--- a/modules/juce_gui_basics/widgets/juce_Toolbar.h
+++ b/modules/juce_gui_basics/widgets/juce_Toolbar.h
@@ -274,7 +274,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void paintToolbarBackground (Graphics&, int width, int height, Toolbar&) = 0;
 

--- a/modules/juce_gui_basics/widgets/juce_TreeView.h
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.h
@@ -858,7 +858,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawTreeviewPlusMinusBox (Graphics&, const Rectangle<float>& area,
                                                Colour backgroundColour, bool isItemOpen, bool isMouseOver) = 0;

--- a/modules/juce_gui_basics/windows/juce_AlertWindow.h
+++ b/modules/juce_gui_basics/windows/juce_AlertWindow.h
@@ -423,7 +423,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual AlertWindow* createAlertWindow (const String& title, const String& message,
                                                 const String& button1,

--- a/modules/juce_gui_basics/windows/juce_CallOutBox.h
+++ b/modules/juce_gui_basics/windows/juce_CallOutBox.h
@@ -141,7 +141,7 @@ public:
     /** This abstract base class is implemented by LookAndFeel classes. */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawCallOutBoxBackground (CallOutBox&, Graphics&, const Path&, Image&) = 0;
         virtual int getCallOutBoxBorderSize (const CallOutBox&) = 0;

--- a/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+++ b/modules/juce_gui_basics/windows/juce_ComponentPeer.h
@@ -387,7 +387,7 @@ public:
     struct JUCE_API  ScaleFactorListener
     {
         /** Destructor. */
-        virtual ~ScaleFactorListener() {}
+        virtual ~ScaleFactorListener() = default;
 
         /** Called when the scale factor changes. */
         virtual void nativeScaleFactorChanged (double newScaleFactor) = 0;

--- a/modules/juce_gui_basics/windows/juce_DocumentWindow.h
+++ b/modules/juce_gui_basics/windows/juce_DocumentWindow.h
@@ -232,7 +232,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         virtual void drawDocumentWindowTitleBar (DocumentWindow&,
                                                  Graphics&, int w, int h,

--- a/modules/juce_gui_basics/windows/juce_ResizableWindow.h
+++ b/modules/juce_gui_basics/windows/juce_ResizableWindow.h
@@ -326,7 +326,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         //==============================================================================
         virtual void drawCornerResizer (Graphics&, int w, int h, bool isMouseOver, bool isMouseDragging) = 0;

--- a/modules/juce_gui_basics/windows/juce_TooltipWindow.h
+++ b/modules/juce_gui_basics/windows/juce_TooltipWindow.h
@@ -117,7 +117,7 @@ public:
     */
     struct JUCE_API  LookAndFeelMethods
     {
-        virtual ~LookAndFeelMethods() {}
+        virtual ~LookAndFeelMethods() = default;
 
         /** returns the bounds for a tooltip at the given screen coordinate, constrained within the given desktop area. */
         virtual Rectangle<int> getTooltipBounds (const String& tipText, Point<int> screenPos, Rectangle<int> parentArea) = 0;

--- a/modules/juce_gui_extra/code_editor/juce_CodeDocument.h
+++ b/modules/juce_gui_extra/code_editor/juce_CodeDocument.h
@@ -326,8 +326,8 @@ public:
     class JUCE_API  Listener
     {
     public:
-        Listener() {}
-        virtual ~Listener() {}
+        Listener() = default;
+        virtual ~Listener() = default;
 
         /** Called by a CodeDocument when text is added. */
         virtual void codeDocumentTextInserted (const String& newText, int insertIndex) = 0;

--- a/modules/juce_gui_extra/code_editor/juce_CodeTokeniser.h
+++ b/modules/juce_gui_extra/code_editor/juce_CodeTokeniser.h
@@ -39,8 +39,8 @@ namespace juce
 class JUCE_API  CodeTokeniser
 {
 public:
-    CodeTokeniser()                 {}
-    virtual ~CodeTokeniser()        {}
+    CodeTokeniser() = default;
+    virtual ~CodeTokeniser() = default;
 
     //==============================================================================
     /** Reads the next token from the source and returns its token type.

--- a/modules/juce_gui_extra/misc/juce_PushNotifications.h
+++ b/modules/juce_gui_extra/misc/juce_PushNotifications.h
@@ -593,7 +593,7 @@ public:
     */
     struct Listener
     {
-        virtual ~Listener() {}
+        virtual ~Listener() = default;
 
         /** This callback will be called after you call requestSettingsUsed() or
             requestPermissionsWithSettings().


### PR DESCRIPTION
Remove some warnings from clang-tidy with the flag modernize-use-equals-default