### PR TITLE
NetworkInterface class added

### DIFF
--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -148,6 +148,7 @@
 #include "misc/juce_ConsoleApplication.cpp"
 #include "network/juce_MACAddress.cpp"
 #include "network/juce_NamedPipe.cpp"
+#include "network/juce_NetworkInterface.cpp"
 #include "network/juce_Socket.cpp"
 #include "network/juce_IPAddress.cpp"
 #include "streams/juce_BufferedInputStream.cpp"

--- a/modules/juce_core/juce_core.h
+++ b/modules/juce_core/juce_core.h
@@ -326,6 +326,7 @@ namespace juce
 #include "network/juce_IPAddress.h"
 #include "network/juce_MACAddress.h"
 #include "network/juce_NamedPipe.h"
+#include "network/juce_NetworkInterface.h"
 #include "network/juce_Socket.h"
 #include "network/juce_URL.h"
 #include "network/juce_WebInputStream.h"

--- a/modules/juce_core/native/juce_BasicNativeHeaders.h
+++ b/modules/juce_core/native/juce_BasicNativeHeaders.h
@@ -91,6 +91,7 @@
  #include <dlfcn.h>
  #include <ifaddrs.h>
  #include <net/if_dl.h>
+ #include <net/if_media.h>
  #include <mach/mach_time.h>
  #include <mach-o/dyld.h>
  #include <objc/runtime.h>
@@ -211,6 +212,8 @@
  #include <errno.h>
  #include <fcntl.h>
  #include <fnmatch.h>
+ #include <linux/ethtool.h>
+ #include <linux/sockios.h>
  #include <net/if.h>
  #include <netdb.h>
  #include <netinet/in.h>

--- a/modules/juce_core/native/juce_android_Network.cpp
+++ b/modules/juce_core/native/juce_android_Network.cpp
@@ -57,6 +57,25 @@ void MACAddress::findAllAddresses (Array<MACAddress>& /*result*/)
     // TODO
 }
 
+bool MACAddress::getMacAddressForInterface(StringRef /*iname*/, MACAddress & /*result*/)
+{
+    // TODO
+    return false;
+}
+
+int getInterfaceMtuSize( StringRef /*iname*/ )
+{
+    // TODO
+    return -1;
+}
+
+int64 getInterfaceSpeed( StringRef /*iname*/ )
+{
+    // TODO
+    return -1;
+}
+
+
 
 JUCE_API bool JUCE_CALLTYPE Process::openEmailWithAttachments (const String& /*targetEmailAddress*/,
                                                                const String& /*emailSubject*/,

--- a/modules/juce_core/native/juce_linux_Network.cpp
+++ b/modules/juce_core/native/juce_linux_Network.cpp
@@ -54,6 +54,92 @@ void MACAddress::findAllAddresses (Array<MACAddress>& result)
     }
 }
 
+int getInterfaceMtuSize( StringRef iname )
+{
+	struct ifreq ifinfo;
+	int sd;
+	int ret;
+	const char *ifc = static_cast<const char*> (String(iname).toUTF8());
+
+	if (strlen(ifc) >= IFNAMSIZ)
+	{
+		return -1;
+	}
+
+	strcpy(ifinfo.ifr_name, ifc);
+	sd = socket(AF_INET, SOCK_DGRAM, 0);
+	ret = ioctl(sd, SIOCGIFMTU, &ifinfo);
+	close(sd);
+
+	if ((ret == 0) && (ifinfo.ifr_mtu>0))
+	{
+		return ifinfo.ifr_mtu;
+	}
+	else
+	{
+		return -1;
+	}
+}
+
+int64 getInterfaceSpeed( StringRef iname )
+{
+	struct ifreq ifinfo;
+	struct ethtool_cmd edata;
+	int ret;
+	int sd;
+	const char *ifc = static_cast<const char*> (String(iname).toUTF8());
+
+	if (strlen(ifc) >= IFNAMSIZ)
+	{
+		return -1;
+	}
+
+	strcpy(ifinfo.ifr_name, ifc);
+	sd = socket(AF_INET, SOCK_DGRAM, 0);
+	ifinfo.ifr_data = (char *)&edata;
+	edata.cmd = ETHTOOL_GSET;
+	ret = ioctl(sd, SIOCETHTOOL, &ifinfo);
+	close(sd);
+
+	if (ret == 0)
+	{
+		return ethtool_cmd_speed( &edata ) * 1000000;
+	}
+	else
+	{
+		return -1;
+	}
+}
+
+
+bool MACAddress::getMacAddressForInterface(StringRef iname, MACAddress &result)
+{
+	struct ifreq ifinfo;
+	int sd;
+	int ret;
+	const char *ifc = static_cast<const char*> (String(iname).toUTF8());
+
+	if (strlen(ifc) >= IFNAMSIZ)
+	{
+		return false;
+	}
+
+	strcpy(ifinfo.ifr_name, ifc);
+	sd = socket(AF_INET, SOCK_DGRAM, 0);
+	ret = ioctl(sd, SIOCGIFHWADDR, &ifinfo);
+	close(sd);
+
+	if ((ret == 0) && (ifinfo.ifr_hwaddr.sa_family == 1))
+	{
+		result = MACAddress((const uint8*)ifinfo.ifr_hwaddr.sa_data);
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
 
 bool JUCE_CALLTYPE Process::openEmailWithAttachments (const String& /* targetEmailAddress */,
                                                       const String& /* emailSubject */,

--- a/modules/juce_core/native/juce_mac_Network.mm
+++ b/modules/juce_core/native/juce_mac_Network.mm
@@ -57,6 +57,144 @@ void MACAddress::findAllAddresses (Array<MACAddress>& result)
     }
 }
 
+
+bool MACAddress::getMacAddressForInterface (StringRef iname, MACAddress &result)
+{
+    ifaddrs* addrs = nullptr;
+	bool ret = false;
+    String ifc = iname;
+
+    if (getifaddrs (&addrs) == 0)
+    {
+        for (const ifaddrs* cursor = addrs; cursor != nullptr; cursor = cursor->ifa_next)
+        {
+            // Required to avoid misaligned pointer access
+            sockaddr sto;
+            std::memcpy (&sto, cursor->ifa_addr, sizeof (sockaddr));
+
+            if (sto.sa_family == AF_LINK)
+            {
+                auto sadd = (const sockaddr_dl*) cursor->ifa_addr;
+
+               #ifndef IFT_ETHER
+                enum { IFT_ETHER = 6 };
+               #endif
+
+                if (sadd->sdl_type == IFT_ETHER)
+                {
+					String devicename = String(cursor->ifa_name);
+//                    printf( "dev: %s -- %s\n", static_cast<const char*> (devicename.toUTF8()), static_cast<const char*> (ifc.toUTF8()));
+                    if( devicename == ifc ) {
+						MACAddress ma = MACAddress (((const uint8*) sadd->sdl_data) + sadd->sdl_nlen);
+//                        printf( "mac: %s\n", static_cast<const char*> (ma.toString().toUTF8()));
+						result = ma;
+						ret = true;
+						break;
+					}
+               }
+            }
+        }
+
+        freeifaddrs (addrs);
+    }
+	return ret;
+}
+
+
+int getInterfaceMtuSize( StringRef iname ) {
+	struct ifreq ifinfo;
+	int sd;
+	int ret;
+	const char *ifc = static_cast<const char*> (String(iname).toUTF8());
+
+	if (strlen(ifc) >= IFNAMSIZ) {
+		return -1;
+	}
+
+	strcpy(ifinfo.ifr_name, ifc);
+	sd = socket(AF_INET, SOCK_DGRAM, 0);
+	ret = ioctl(sd, SIOCGIFMTU, &ifinfo);
+	close(sd);
+
+	if ((ret == 0) && (ifinfo.ifr_mtu>0)) {
+		return ifinfo.ifr_mtu;
+	}
+	else {
+		return -1;
+	}
+}
+
+
+static int64 speedFromMediaWord( int mediaWord )
+{
+	if( (mediaWord & IFM_NMASK ) != IFM_ETHER )
+	{
+		return -1;
+	}
+	switch( mediaWord & IFM_TMASK )
+	{
+        case IFM_HPNA_1:
+            return 1 * 1000000;
+        case IFM_10_T:
+		case IFM_10_2:
+		case IFM_10_5:
+		case IFM_10_STP:
+		case IFM_10_FL:
+			return 10 * 1000000;
+		case IFM_100_TX:
+		case IFM_100_FX:
+		case IFM_100_T4:
+		case IFM_100_VG:
+		case IFM_100_T2:
+			return 100 * 1000000;
+		case IFM_1000_SX:
+		case IFM_1000_LX:
+		case IFM_1000_CX:
+		case IFM_1000_T:
+			return 1000 * 1000000;
+        case IFM_2500_T:
+            return 2500 * 1000000LL;
+        case IFM_5000_T:
+            return 5000 * 1000000LL;
+        case IFM_10G_T:
+        case IFM_10G_SR:
+        case IFM_10G_LR:
+        case IFM_10G_CX4:
+            return 10000 * 1000000LL;
+	}
+	return -1;
+}
+
+
+int64 getInterfaceSpeed( StringRef iname )
+{
+	struct ifmediareq ifmr;
+	int sd;
+	int ret;
+	const char *ifc = static_cast<const char*> (String(iname).toUTF8());
+
+	if (strlen(ifc) >= IFNAMSIZ)
+	{
+		return -1;
+	}
+
+    memset( &ifmr, 0, sizeof(ifmr));
+	strcpy(ifmr.ifm_name, ifc);
+	sd = socket(AF_INET, SOCK_DGRAM, 0);
+	ret = ioctl(sd, SIOCGIFMEDIA, &ifmr);
+	close(sd);
+
+	if (ret == 0)
+	{
+		return speedFromMediaWord( ifmr.ifm_active );
+	}
+	else
+	{
+		return -1;
+	}
+}
+
+
 //==============================================================================
 bool JUCE_CALLTYPE Process::openEmailWithAttachments (const String& targetEmailAddress,
                                                       const String& emailSubject,

--- a/modules/juce_core/native/juce_posix_IPAddress.h
+++ b/modules/juce_core/native/juce_posix_IPAddress.h
@@ -130,4 +130,129 @@ IPAddress IPAddress::getInterfaceBroadcastAddress (const IPAddress& interfaceAdd
     return {};
 }
 
+int getInterfaceMtuSize( StringRef iname );
+int64 getInterfaceSpeed( StringRef iname );
+
+static bool findIndex( int idx, Array<NetworkInterface>& ifcs )
+{
+	if( idx < 1 )
+	{
+		return false;
+	}
+	for( int i =0; i < ifcs.size();i++ )
+	{
+		if( ifcs[i].getInterfaceIndex() == idx )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+
+void NetworkInterface::findAllInterfaces(Array<NetworkInterface>& result)
+{
+	const int s = socket(AF_INET, SOCK_DGRAM, 0);
+	if (s != -1)
+	{
+		struct ifaddrs* addrs = nullptr;
+
+		if (getifaddrs(&addrs) != -1)
+		{
+			for (struct ifaddrs* ifa = addrs; ifa != nullptr; ifa = ifa->ifa_next)
+			{
+				InterfaceInfo i;
+				bool found = false;
+				struct ifreq ifr;
+				strcpy(ifr.ifr_name, ifa->ifa_name);
+				ifr.ifr_addr.sa_family = AF_INET;
+				String devName(ifa->ifa_name);
+				populateInterfaceInfo(ifa, i);
+
+				if (i.interfaceAddress.isNull())
+				{
+					continue;
+				}
+
+				for (int index = 0; index < result.size(); index++)
+				{
+					NetworkInterface ni = result[index];
+					if (ni.getDeviceName() == devName)
+					{
+						ni.addIPAddress(i.interfaceAddress);
+						result.set(index, ni);
+						found = true;
+						break;
+					}
+				}
+
+				if (!found)
+				{
+					NetworkInterface ni(devName, devName, if_nametoindex(ifa->ifa_name));
+					ni.addIPAddress(i.interfaceAddress);
+
+					MACAddress ma;
+					if( MACAddress::getMacAddressForInterface( devName, ma ) )
+					{
+						ni.setMACAddress(ma);
+					}
+
+					if (ifa->ifa_flags & IFF_UP )
+					{
+#if	JUCE_LINUX
+						if (ifa->ifa_flags & IFF_RUNNING)
+						{
+#endif
+							ni.setInterfaceUp(true);
+#if	JUCE_LINUX
+						}
+#endif
+					}
+
+					int64 speed = getInterfaceSpeed( devName );
+					if( speed >= 0 )
+					{
+						ni.setRxSpeed( speed );
+						ni.setTxSpeed( speed );
+					}	
+					int mtu = getInterfaceMtuSize( devName );
+					if( mtu >= 0 )
+					{
+						ni.setMtuSize( mtu );
+					}
+
+					result.add(ni);
+				}
+			}
+
+			freeifaddrs(addrs);
+		}
+
+		::close(s);
+	}
+
+	/* add all non-operative interfaces */
+	for (unsigned int i = 1; i; i++)
+	{
+		char ifname[IF_NAMESIZE + 1];
+		
+		if( findIndex( i, result ) )
+		{
+			continue;
+		}
+		char *name = if_indextoname(i, ifname);
+		if (name)
+		{
+			String devName(name);
+			NetworkInterface ni(devName, devName, i);
+			result.add(ni);
+		}
+		else
+		{
+			break;
+		}	
+	}
+}
+
+
 } // namespace juce

--- a/modules/juce_core/native/juce_win32_Network.cpp
+++ b/modules/juce_core/native/juce_win32_Network.cpp
@@ -573,6 +573,60 @@ void IPAddress::findAllAddresses (Array<IPAddress>& result, bool includeIPv6)
     }
 }
 
+bool MACAddress::getMacAddressForInterface(StringRef iname, MACAddress &result)
+{
+	GetAdaptersAddressesHelper addressesHelper;
+
+	if (addressesHelper.callGetAdaptersAddresses())
+	{
+		for (PIP_ADAPTER_ADDRESSES adapter = addressesHelper.adaptersAddresses; adapter != nullptr; adapter = adapter->Next)
+		{
+			String deviceName(adapter->AdapterName);
+			if (deviceName == iname)
+			{
+				MACAddress mac = MACAddress(adapter->PhysicalAddress);
+				result = mac;
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+
+void NetworkInterface::findAllInterfaces(Array<NetworkInterface>& result)
+{
+	GetAdaptersAddressesHelper addressesHelper;
+
+	if (addressesHelper.callGetAdaptersAddresses())
+	{
+		for (PIP_ADAPTER_ADDRESSES adapter = addressesHelper.adaptersAddresses; adapter != nullptr; adapter = adapter->Next)
+		{
+			Array<IPAddress> addrs;
+			MACAddressHelpers::findAddresses(addrs, true, adapter->FirstUnicastAddress);
+
+			MACAddressHelpers::findAddresses(addrs, false, adapter->FirstUnicastAddress);
+
+			MACAddress mac = MACAddress(adapter->PhysicalAddress);
+
+			String deviceName(adapter->AdapterName);
+			String friendlyName(adapter->FriendlyName);
+
+			NetworkInterface ni(deviceName, friendlyName, adapter->IfIndex);
+			ni.setMACAddress(mac);
+			ni.addIPAddresses(addrs);
+			ni.setRxSpeed(adapter->ReceiveLinkSpeed);
+			ni.setTxSpeed(adapter->TransmitLinkSpeed);
+			ni.setMtuSize(adapter->Mtu);
+			ni.setInterfaceUp(adapter->OperStatus == IfOperStatusUp);
+
+			result.addIfNotAlreadyThere( ni );
+		}
+	}
+}
+
+
+
 IPAddress IPAddress::getInterfaceBroadcastAddress (const IPAddress&)
 {
     // TODO

--- a/modules/juce_core/network/juce_MACAddress.h
+++ b/modules/juce_core/network/juce_MACAddress.h
@@ -39,6 +39,8 @@ public:
     /** Populates a list of the MAC addresses of all the available network cards. */
     static void findAllAddresses (Array<MACAddress>& results);
 
+	static bool getMacAddressForInterface(StringRef iname, MACAddress &result);
+
     //==============================================================================
     /** Creates a null address (00-00-00-00-00-00). */
     MACAddress() noexcept;

--- a/modules/juce_core/network/juce_NetworkInterface.cpp
+++ b/modules/juce_core/network/juce_NetworkInterface.cpp
@@ -1,0 +1,168 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE library.
+   Copyright (c) 2017 - ROLI Ltd.
+
+   JUCE is an open source library subject to commercial or open-source
+   licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   To use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+	NetworkInterface::NetworkInterface(const NetworkInterface& other) noexcept
+	{
+		this->deviceName = other.deviceName;
+		this->friendlyName = other.friendlyName;
+		this->index = other.index;
+		this->macAddress = other.macAddress;
+		this->allIpAddresses = other.allIpAddresses;
+		this->ipv4Addresses = other.ipv4Addresses;
+		this->mtuSize = other.mtuSize;
+		this->rxSpeed = other.rxSpeed;
+		this->txSpeed = other.txSpeed;
+		this->interfaceUp = other.interfaceUp;
+	}
+
+	NetworkInterface& NetworkInterface::operator= (const NetworkInterface& other) noexcept
+	{
+		this->deviceName = other.deviceName;
+		this->friendlyName = other.friendlyName;
+		this->index = other.index;
+		this->macAddress = other.macAddress;
+		this->allIpAddresses = other.allIpAddresses;
+		this->ipv4Addresses = other.ipv4Addresses;
+		this->mtuSize = other.mtuSize;
+		this->rxSpeed = other.rxSpeed;
+		this->txSpeed = other.txSpeed;
+		this->interfaceUp = other.interfaceUp;
+		return *this;
+	}
+
+
+	NetworkInterface::NetworkInterface(StringRef device, StringRef friendly, int interfaceIndex) noexcept : deviceName(device), friendlyName( friendly ), index(interfaceIndex)  {
+		this->mtuSize = -1;
+		this->interfaceUp = false;
+		this->rxSpeed = -1;
+		this->txSpeed = -1;
+	}
+
+	NetworkInterface::NetworkInterface() noexcept {
+		this->mtuSize = -1;
+		this->interfaceUp = false;
+		this->rxSpeed = -1;
+		this->txSpeed = -1;
+	}
+
+
+	NetworkInterface::~NetworkInterface() {
+
+	}
+
+	bool NetworkInterface::operator== (const NetworkInterface& other) const noexcept { return other.deviceName == deviceName; }
+	bool NetworkInterface::operator!= (const NetworkInterface& other) const noexcept { return !operator== (other); }
+
+	String NetworkInterface::toString() const {
+		if (deviceName == friendlyName)
+			return deviceName;
+		else
+			return friendlyName + " (" + deviceName + ")";
+	}
+
+	// getters
+	String NetworkInterface::getFriendlyName() const {
+		return friendlyName;
+	}
+
+	String NetworkInterface::getDeviceName() const {
+		return deviceName;
+
+	}
+
+	MACAddress NetworkInterface::getMACAddress() const {
+		return macAddress;
+	}
+
+	int NetworkInterface::getInterfaceIndex() {
+		return index;
+	}
+
+	int NetworkInterface::getMtuSize() {
+		return mtuSize;
+	}
+
+	bool NetworkInterface::isUp() {
+		return interfaceUp;
+	}
+
+	int64 NetworkInterface::getRxSpeed() {
+		return rxSpeed;
+	}
+
+	int64 NetworkInterface::getTxSpeed() {
+		return txSpeed;
+	}
+
+	Array<IPAddress> NetworkInterface::getIPAddresses(bool includeIPv6) const {
+		if (includeIPv6)
+			return allIpAddresses;
+		else
+			return ipv4Addresses;
+	}
+
+	// setters
+	void NetworkInterface::setMACAddress(MACAddress &mac) {
+		macAddress = mac;
+	}
+
+	void NetworkInterface::setMtuSize(int mtu) {
+		mtuSize = mtu;
+	}
+
+	void NetworkInterface::setInterfaceUp(bool isUp) {
+		interfaceUp = isUp;
+	}
+
+	void NetworkInterface::setRxSpeed(int64 bps) {
+		rxSpeed = bps;
+	}
+
+	void NetworkInterface::setTxSpeed(int64 bps) {
+		txSpeed = bps;
+	}
+
+	void NetworkInterface::addIPAddress(IPAddress &addr) {
+		if (!addr.isIPv6) {
+			ipv4Addresses.addIfNotAlreadyThere(addr);
+		}
+		allIpAddresses.addIfNotAlreadyThere(addr);
+	}
+
+	void NetworkInterface::addIPAddresses(Array<IPAddress> &addrs) {
+		for (int i = 0; i < addrs.size(); i++) {
+			IPAddress adr = addrs[i];
+			addIPAddress( adr );
+		}
+	}
+
+	Array<NetworkInterface> NetworkInterface::getAllInterfaces()
+	{
+		Array<NetworkInterface> interfaces;
+		findAllInterfaces(interfaces);
+		return interfaces;
+	}
+
+} // namespace juce

--- a/modules/juce_core/network/juce_NetworkInterface.h
+++ b/modules/juce_core/network/juce_NetworkInterface.h
@@ -1,0 +1,111 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE library.
+   Copyright (c) 2017 - ROLI Ltd.
+
+   JUCE is an open source library subject to commercial or open-source
+   licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   To use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+//==============================================================================
+/**
+    Represents a Network Interface.
+
+    @tags{Core}
+*/
+class JUCE_API  NetworkInterface  final
+{
+public:
+
+	NetworkInterface() noexcept;
+	NetworkInterface(StringRef device, StringRef friendly, int interfaceIndex) noexcept;
+	~NetworkInterface();
+
+	/** Creates a copy of another interface. */
+	NetworkInterface(const NetworkInterface&) noexcept;
+
+	/** Creates a copy of another interface. */
+	NetworkInterface& operator= (const NetworkInterface&) noexcept;
+
+	bool operator== (const NetworkInterface&) const noexcept;
+	bool operator!= (const NetworkInterface&) const noexcept;
+
+
+	String toString() const;
+
+	/** Retrieves the "friendly" name of the network-interface.  Only on Windows the friendly-name differs from the device-name */
+	String getFriendlyName() const;
+
+	/** Retrieves the technical name of the network interface */
+	String getDeviceName() const;
+
+	/** Retrieves the EUI-48 address for this interface.  If none is available, this will return a "null"-MAC */
+	MACAddress getMACAddress() const;
+
+	/** Retrieves the index of the interface as being used by Bonjour for example. If less than 1 no index could be retrieved */
+	int getInterfaceIndex();
+
+	/** Retrieves the maximum transmission unit in bytes this interface supports */
+	int getMtuSize();
+
+	/** Retrieves the operating-state of this interfaces */
+	bool isUp();
+
+	/** Retrieves the receive-speed this interface is working with.  -1 if this information could not be retrieved */
+	int64 getRxSpeed();
+
+	/** Retrieves the transmit-speed this interface is working with.  -1 if this information could not be retrieved */
+	int64 getTxSpeed();
+
+	/** Retrieve the IPDAdresses used on this interface 
+
+		@param includeIPv6    if this is specified as true, both IPv4 & IPv6 addresses will be returned
+	*/
+	Array<IPAddress> getIPAddresses(bool includeIPv6 = false) const;
+
+	// setters
+	void setMACAddress(MACAddress &mac);
+	void addIPAddress(IPAddress &addr);
+	void addIPAddresses(Array<IPAddress> &addrs);
+	void setMtuSize( int mtu );
+	void setInterfaceUp( bool isUp );
+	void setRxSpeed(int64 bps);
+	void setTxSpeed(int64 bps);
+
+    //==============================================================================
+    /** Populates a list of all the Network interface that this machine is using. */
+    static void findAllInterfaces (Array<NetworkInterface>& results );
+
+    /** Populates a list of all the Network interaces that this machine is using. */
+    static Array<NetworkInterface> getAllInterfaces ();
+
+private:
+	String deviceName;
+	String friendlyName;
+	Array<IPAddress> allIpAddresses;
+	Array<IPAddress> ipv4Addresses;
+	MACAddress macAddress;
+	int index;
+	int64 rxSpeed;
+	int64 txSpeed;
+	int mtuSize;
+	bool interfaceUp;
+};
+
+} // namespace juce


### PR DESCRIPTION
Can retrieve various information about the available network-interface on the System.
Includes static enumerators findAllInterfaces/getAllInterfaces with support for Windows, Linux & macOS