### PR TITLE
added Interpolation support to ColourPoint and corresponding method

### DIFF
--- a/modules/juce_graphics/colour/juce_ColourGradient.cpp
+++ b/modules/juce_graphics/colour/juce_ColourGradient.cpp
@@ -111,7 +111,7 @@ void ColourGradient::clearColours()
     colours.clear();
 }
 
-int ColourGradient::addColour (const double proportionAlongGradient, Colour colour)
+int ColourGradient::addColour (const double proportionAlongGradient, Colour colour, Interpolation interpolation)
 {
     // must be within the two end-points
     jassert (proportionAlongGradient >= 0 && proportionAlongGradient <= 1.0);
@@ -129,7 +129,7 @@ int ColourGradient::addColour (const double proportionAlongGradient, Colour colo
         if (colours.getReference(i).position > pos)
             break;
 
-    colours.insert (i, { pos, colour });
+    colours.insert (i, { pos, colour, interpolation });
     return i;
 }
 
@@ -167,11 +167,30 @@ Colour ColourGradient::getColour (int index) const noexcept
     return {};
 }
 
+
 void ColourGradient::setColour (int index, Colour newColour) noexcept
 {
     if (isPositiveAndBelow (index, colours.size()))
         colours.getReference (index).colour = newColour;
 }
+
+
+
+ColourGradient::Interpolation ColourGradient::getInterpolation(int index) const noexcept
+{
+	if (isPositiveAndBelow(index, colours.size()))
+		return colours.getReference(index).interpolation;
+
+	return {};
+}
+
+
+void ColourGradient::setInterpolation(int index, Interpolation newInterpolation) noexcept
+{
+	if (isPositiveAndBelow(index, colours.size()))
+		colours.getReference(index).interpolation = newInterpolation;
+}
+
 
 Colour ColourGradient::getColourAtPosition (double position) const noexcept
 {
@@ -189,9 +208,12 @@ Colour ColourGradient::getColourAtPosition (double position) const noexcept
     if (i >= colours.size() - 1)
         return p1.colour;
 
+	if (p1.interpolation == NONE)
+		return p1.colour;
+
     auto& p2 = colours.getReference (i + 1);
 
-    return p1.colour.interpolatedWith (p2.colour, (float) ((position - p1.position) / (p2.position - p1.position)));
+	return p1.colour.interpolatedWith(p2.colour, (float)((position - p1.position) / (p2.position - p1.position)));
 }
 
 //==============================================================================
@@ -215,8 +237,15 @@ void ColourGradient::createLookupTable (PixelARGB* const lookupTable, const int 
         {
             jassert (index >= 0 && index < numEntries);
 
-            lookupTable[index] = pix1;
-            lookupTable[index].tween (pix2, (uint32) ((i << 8) / numToDo));
+			if (p.interpolation == LINEAR)
+			{
+				lookupTable[index] = pix1;
+				lookupTable[index].tween(pix2, (uint32)((i << 8) / numToDo));
+			} else
+			{
+				lookupTable[index] = pix2;
+			}
+            
             ++index;
         }
 

--- a/modules/juce_graphics/colour/juce_ColourGradient.h
+++ b/modules/juce_graphics/colour/juce_ColourGradient.h
@@ -50,6 +50,8 @@ public:
     ColourGradient& operator= (const ColourGradient&);
     ColourGradient& operator= (ColourGradient&&) noexcept;
 
+	enum Interpolation { LINEAR, NONE };
+
     //==============================================================================
     /** Creates a gradient object.
 
@@ -138,7 +140,7 @@ public:
         @param colour                       the colour that should be used at this point
         @returns the index at which the new point was added
     */
-    int addColour (double proportionAlongGradient, Colour colour);
+    int addColour (double proportionAlongGradient, Colour colour, Interpolation interpolation = Interpolation::LINEAR);
 
     /** Removes one of the colours from the gradient. */
     void removeColour (int index);
@@ -165,6 +167,17 @@ public:
         The index is from 0 to getNumColours() - 1.
     */
     void setColour (int index, Colour newColour) noexcept;
+
+	/** Returns the interpolation that was added with a given index.
+		The index is from 0 to getNumColours() - 1.
+	*/
+	Interpolation getInterpolation(int index) const noexcept;
+
+	/** Changes the interpolation at a given index.
+	   The index is from 0 to getNumColours() - 1.
+   */
+	void setInterpolation(int index, Interpolation newInterpolation) noexcept;
+
 
     /** Returns the an interpolated colour at any position along the gradient.
         @param position     the position along the gradient, between 0 and 1
@@ -215,6 +228,7 @@ private:
 
         double position;
         Colour colour;
+		Interpolation interpolation;
     };
 
     Array<ColourPoint> colours;


### PR DESCRIPTION
This is a proposition to add interpolation support to ColourGradient.
It adds an enum ColourGradient::Interpolation (only LINEAR and and NONE for now, LINEAR being the current interpolation method, there could be SMOOTH (Ease in-out))

The only thing I can't work out is the rendering of fillGradient, because it seems to rely on lowlevel graphics methods that I don't know at all.

Hope it helps !