### PR TITLE
Fix graphics performance: Don't need displayScale value changed when CoreGraphicsRenderer used.

### DIFF
--- a/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
@@ -849,9 +849,12 @@ public:
         float displayScale = 1.0f;
 
        #if defined (MAC_OS_X_VERSION_10_7) && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7)
-        NSScreen* screen = [[view window] screen];
-        if ([screen respondsToSelector: @selector (backingScaleFactor)])
-            displayScale = (float) screen.backingScaleFactor;
+        if (!usingCoreGraphics)
+        {
+            NSScreen* screen = [[view window] screen];
+            if ([screen respondsToSelector: @selector (backingScaleFactor)])
+                displayScale = (float) screen.backingScaleFactor;
+        }
        #endif
 
        #if USE_COREGRAPHICS_RENDERING && JUCE_COREGRAPHICS_RENDER_WITH_MULTIPLE_PAINT_CALLS


### PR DESCRIPTION
Hello, Geniuses!
I found a code that is a performance bottleneck when running on Retina Display with CoreGraphicsRenderer.

Actually, since NSHighResolutionCapable is set to true in Info.plist on Retina compatible applications, CoreGraphics seems to automatically scale internal back buffers by scale factor (factor is x2).
However, as I have seen, I recognize that there is a problem that JUCE side is doing affine transformation (scale multiplication).
I think that this implementation is the cause of the following problems that have been posted by JUCE Forum.
https://forum.juce.com/t/drawing-images-on-mbp-retina-is-ultra-slow/9548

On the other hand, when using SoftwareRenderer, the above scaling processing is necessary.

Based on the above, I propose an implementation that does not change displayScale value when using CoreGraphicsRenderer.

Pleasse check.