### PR TITLE
Plug memory leak calling setStateInformation() on hosted VST3

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -2289,7 +2289,7 @@ public:
 
         if (head != nullptr)
         {
-            ComSmartPtr<Steinberg::MemoryStream> componentStream (createMemoryStreamForState (*head, "IComponent"));
+            ComSmartPtr<Steinberg::MemoryStream> componentStream (createMemoryStreamForState (*head, "IComponent"), false);
 
             if (componentStream != nullptr && holder->component != nullptr)
                 holder->component->setState (componentStream);


### PR DESCRIPTION
See my JUCE Forum post https://forum.juce.com/t/memory-leak-calling-setstateinformation-on-hosted-vst3-plugin/31660, and test/demo project https://github.com/getdunne/juce-wrapper. I think the leak is caused by the `ComSmartPtr<Steinberg::MemoryStream>` object getting initialized with a reference count of 2 here, when it should be just 1.