### PR TITLE
Added shift as sustain behaviour for MidiKeyboardComponent

### DIFF
--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
@@ -708,6 +708,18 @@ void MidiKeyboardComponent::updateNoteUnderMouse (const MouseEvent& e, bool isDo
 
 void MidiKeyboardComponent::updateNoteUnderMouse (Point<float> pos, bool isDown, int fingerNum)
 {
+    if (sustainPressed)
+    {
+        for (int i=0; i < mouseDownNotes.size(); ++i)
+        {
+            if (mouseDownNotes.getUnchecked (i) < 0)
+            {
+                fingerNum = i;
+                break;
+            }
+        }
+    }
+
     float mousePositionVelocity = 0.0f;
     auto newNote = xyToNote (pos, mousePositionVelocity);
     auto oldNote = mouseOverNotes.getUnchecked (fingerNum);
@@ -725,7 +737,7 @@ void MidiKeyboardComponent::updateNoteUnderMouse (Point<float> pos, bool isDown,
     {
         if (newNote != oldNoteDown)
         {
-            if (oldNoteDown >= 0)
+            if (oldNoteDown >= 0 && sustainPressed == false)
             {
                 mouseDownNotes.set (fingerNum, -1);
 
@@ -740,7 +752,7 @@ void MidiKeyboardComponent::updateNoteUnderMouse (Point<float> pos, bool isDown,
             }
         }
     }
-    else if (oldNoteDown >= 0)
+    else if (oldNoteDown >= 0 && sustainPressed == false)
     {
         mouseDownNotes.set (fingerNum, -1);
 
@@ -784,6 +796,9 @@ void MidiKeyboardComponent::mouseDown (const MouseEvent& e)
 
 void MidiKeyboardComponent::mouseUp (const MouseEvent& e)
 {
+    if (sustainPressed)
+        return;
+
     updateNoteUnderMouse (e, false);
     shouldCheckMousePos = false;
 
@@ -815,6 +830,16 @@ void MidiKeyboardComponent::mouseWheelMove (const MouseEvent&, const MouseWheelD
 
 void MidiKeyboardComponent::timerCallback()
 {
+    if (ModifierKeys::getCurrentModifiers().isShiftDown())
+    {
+        sustainPressed = true;
+    }
+    else if (sustainPressed)
+    {
+        sustainPressed = false;
+        resetAnyKeysInUse();
+    }
+
     if (shouldCheckState)
     {
         shouldCheckState = false;

--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.h
@@ -410,6 +410,7 @@ private:
 
     Array<int> mouseOverNotes, mouseDownNotes;
     BigInteger keysPressed, keysCurrentlyDrawnDown;
+    bool sustainPressed = false;
     bool shouldCheckState = false;
 
     int rangeStart = 0, rangeEnd = 127;


### PR DESCRIPTION
This PR adds the shift key as sustain, when using the mouse.
This allows the user to enter chords with the mouse. 
Note that if shift is held, the mouse source id is ignored, otherwise only one key could be down at a time.
This doesn't affect multi touch, since there usually shift is not needed, same as playing on keyboard.