### PR TITLE
Viewport floating scrollbars

### DIFF
--- a/modules/juce_gui_basics/layout/juce_Viewport.cpp
+++ b/modules/juce_gui_basics/layout/juce_Viewport.cpp
@@ -320,6 +320,20 @@ bool Viewport::isCurrentlyScrollingOnDrag() const noexcept
 {
     return dragToScrollListener != nullptr && dragToScrollListener->isDragging;
 }
+    
+void Viewport::setFloatingScrollbarEnabled(bool floating)
+{
+    if (floatingScrollbars != floating)
+    {
+        floatingScrollbars = floating;
+        updateVisibleArea();
+    }
+}
+    
+bool Viewport::isFloatingScrollbarEnabled() const noexcept
+{
+    return floatingScrollbars;
+}
 
 //==============================================================================
 void Viewport::lookAndFeelChanged()
@@ -382,12 +396,12 @@ void Viewport::updateVisibleArea()
 
         if (contentComp == nullptr)
         {
-            contentHolder.setBounds (contentArea);
+            contentHolder.setBounds (floatingScrollbars ? getLocalBounds() : contentArea);
             break;
         }
 
         auto oldContentBounds = contentComp->getBounds();
-        contentHolder.setBounds (contentArea);
+        contentHolder.setBounds (floatingScrollbars ? getLocalBounds() : contentArea);
 
         // If the content has changed its size, that might affect our scrollbars, so go round again and re-caclulate..
         if (oldContentBounds == contentComp->getBounds())

--- a/modules/juce_gui_basics/layout/juce_Viewport.h
+++ b/modules/juce_gui_basics/layout/juce_Viewport.h
@@ -287,6 +287,17 @@ public:
         @see setScrollOnDragEnabled
     */
     bool isCurrentlyScrollingOnDrag() const noexcept;
+    
+    /** When enabled scrollbars will be drawn on top of the viewed component,
+        allowing it to draw behind them.
+        Otherwise, scrollbars will be placed side by side with the viewed component.
+     */
+    void setFloatingScrollbarEnabled (bool floating);
+    
+    /** Returns true if floating scrollbars are enabled
+        @see setFloatingScrollbars
+     */
+    bool isFloatingScrollbarEnabled() const noexcept;
 
     //==============================================================================
     /** @internal */
@@ -325,7 +336,8 @@ private:
     bool customScrollBarThickness = false;
     bool allowScrollingWithoutScrollbarV = false, allowScrollingWithoutScrollbarH = false;
     bool vScrollbarRight = true, hScrollbarBottom = true;
-
+    bool floatingScrollbars = false;
+    
     struct DragToScrollListener;
     std::unique_ptr<DragToScrollListener> dragToScrollListener;
 


### PR DESCRIPTION
Added option to have "floating" scrollbars on viewports (standard behaviour on macOS).
Floating scrollbars are drawn on top of the viewed component, instead of side by side.

When using this option:
- The viewed component can draw behind scrollbars, allowing them to be transparent
- The viewed component keeps the same size whether scrollbars are visible or not.

The option is false by default, preserving backwards compatibility.