### PR TITLE
Add ability to edit slider value on double-click

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_Slider.cpp
+++ b/modules/juce_gui_basics/widgets/juce_Slider.cpp
@@ -511,9 +511,10 @@ public:
         }
     }
 
-    void setTextBoxIsEditable (bool shouldBeEditable)
+    void setTextBoxIsEditable (bool shouldBeEditable, bool editOnDoubleClick)
     {
         editableText = shouldBeEditable;
+        doubleClickToEditText = editOnDoubleClick;
         updateTextBoxEnablement();
     }
 
@@ -552,7 +553,8 @@ public:
             bool shouldBeEditable = editableText && owner.isEnabled();
 
             if (valueBox->isEditable() != shouldBeEditable) // (to avoid changing the single/double click flags unless we need to)
-                valueBox->setEditable (shouldBeEditable);
+                valueBox->setEditable (shouldBeEditable && !doubleClickToEditText,
+                                       shouldBeEditable && doubleClickToEditText);
         }
     }
 
@@ -1261,6 +1263,7 @@ public:
     ModifierKeys::Flags modifierToSwapModes = ModifierKeys::ctrlAltCommandModifiers;
 
     bool editableText = true;
+    bool doubleClickToEditText = false;
     bool doubleClickToValue = false;
     bool isVelocityBased = false;
     bool userKeyOverridesVelocity = true;
@@ -1480,7 +1483,10 @@ void Slider::setTextBoxStyle (TextEntryBoxPosition newPosition, bool isReadOnly,
 }
 
 bool Slider::isTextBoxEditable() const noexcept                     { return pimpl->editableText; }
-void Slider::setTextBoxIsEditable (const bool shouldBeEditable)     { pimpl->setTextBoxIsEditable (shouldBeEditable); }
+void Slider::setTextBoxIsEditable (const bool shouldBeEditable, bool editOnDoubleClick)
+{
+    pimpl->setTextBoxIsEditable (shouldBeEditable, editOnDoubleClick);
+}
 void Slider::showTextBox()                                          { pimpl->showTextBox(); }
 void Slider::hideTextBox (bool discardCurrentEditorContents)        { pimpl->hideTextBox (discardCurrentEditorContents); }
 

--- a/modules/juce_gui_basics/widgets/juce_Slider.h
+++ b/modules/juce_gui_basics/widgets/juce_Slider.h
@@ -345,9 +345,14 @@ public:
         By default this is true, and the user can enter values into the textbox,
         but it can be turned off if that's not suitable.
 
+        @param shouldBeEditable         determines if the text box is editable
+        @param editOnDoubleClick        if true the text box will be editable on double-click
+                                        otherwise it will be editable on single-click. This
+                                        argument has no effect if shouldBeEditable is false
+     
         @see setTextBoxStyle, getValueFromText, getTextFromValue
     */
-    void setTextBoxIsEditable (bool shouldBeEditable);
+    void setTextBoxIsEditable (bool shouldBeEditable, bool editOnDoubleClick = false);
 
     /** Returns true if the text-box is read-only.
         @see setTextBoxStyle


### PR DESCRIPTION
Previously a slider text box was only editable on single-click

However a common UI idiom is for slider values to be editable on double click. This non-breaking commit enables slider text boxes to optionally be set to editable on double click. 