### PR TITLE
switch to value base color picker

### DIFF
--- a/modules/juce_gui_extra/misc/juce_ColourSelector.cpp
+++ b/modules/juce_gui_extra/misc/juce_ColourSelector.cpp
@@ -68,12 +68,12 @@ public:
 
             for (int y = 0; y < height; ++y)
             {
-                auto val = 1.0f - y / (float) height;
+                auto sat =  y / (float) height;
 
                 for (int x = 0; x < width; ++x)
                 {
-                    auto sat = x / (float) width;
-                    pixels.setPixelColour (x, y, Colour (h, sat, val, 1.0f));
+                    auto hue = x / (float) width;
+                    pixels.setPixelColour (x, y, Colour (hue, sat, v, 1.0f));
                 }
             }
         }
@@ -93,17 +93,17 @@ public:
 
     void mouseDrag (const MouseEvent& e) override
     {
-        auto sat =        (e.x - edge) / (float) (getWidth()  - edge * 2);
-        auto val = 1.0f - (e.y - edge) / (float) (getHeight() - edge * 2);
+        auto hue =        (e.x - edge) / (float) (getWidth()  - edge * 2);
+        auto sat = (e.y - edge) / (float) (getHeight() - edge * 2);
 
-        owner.setSV (sat, val);
+		owner.setSH(sat, hue);
     }
 
     void updateIfNeeded()
     {
-        if (lastHue != h)
+        if (lastValue != v)
         {
-            lastHue = h;
+            lastValue = v;
             colours = {};
             repaint();
         }
@@ -122,7 +122,7 @@ private:
     float& h;
     float& s;
     float& v;
-    float lastHue = 0;
+    float lastValue = 0;
     const int edge;
     Image colours;
 
@@ -150,7 +150,7 @@ private:
         auto area = getLocalBounds().reduced (edge);
 
         marker.setBounds (Rectangle<int> (markerSize, markerSize)
-                            .withCentre (area.getRelativePoint (s, 1.0f - v)));
+                            .withCentre (area.getRelativePoint (h, s)));
     }
 
     JUCE_DECLARE_NON_COPYABLE (ColourSpaceView)
@@ -241,6 +241,97 @@ private:
     HueSelectorMarker marker;
 
     JUCE_DECLARE_NON_COPYABLE (HueSelectorComp)
+};
+
+
+
+
+class ColourSelector::ValueSelectorComp : public Component
+{
+public:
+	ValueSelectorComp(ColourSelector& cs, float &hue, float &sat, float& value, int edgeSize)
+		: owner(cs),h(hue), s(sat), v(value), edge(edgeSize)
+	{
+		addAndMakeVisible(marker);
+	}
+
+	void paint(Graphics& g) override
+	{
+		ColourGradient cg;
+		cg.isRadial = false;
+		cg.point1.setXY(0.0f, (float)edge);
+		cg.point2.setXY(0.0f, (float)getHeight());
+
+		for (float i = 0.0f; i <= 1.0f; i += 0.02f)
+			cg.addColour(i, Colour(h, s, v, 1.0f));
+
+		g.setGradientFill(cg);
+		g.fillRect(getLocalBounds().reduced(edge));
+	}
+
+	void resized() override
+	{
+		auto markerSize = jmax(14, edge * 2);
+		auto area = getLocalBounds().reduced(edge);
+
+		marker.setBounds(Rectangle<int>(getWidth(), markerSize)
+			.withCentre(area.getRelativePoint(0.5f, 1-v)));
+	}
+
+	void mouseDown(const MouseEvent& e) override
+	{
+		mouseDrag(e);
+	}
+
+	void mouseDrag(const MouseEvent& e) override
+	{
+		owner.setValue(1-((e.y - edge) / (float)(getHeight() - edge * 2)));
+	}
+
+	void updateIfNeeded()
+	{
+		resized();
+	}
+
+private:
+	ColourSelector& owner;
+	float& v;
+	float& h;
+	float &s;
+	const int edge;
+
+	struct ValueSelectorMarker : public Component
+	{
+		ValueSelectorMarker()
+		{
+			setInterceptsMouseClicks(false, false);
+		}
+
+		void paint(Graphics& g) override
+		{
+			auto cw = (float)getWidth();
+			auto ch = (float)getHeight();
+
+			Path p;
+			p.addTriangle(1.0f, 1.0f,
+				cw * 0.3f, ch * 0.5f,
+				1.0f, ch - 1.0f);
+
+			p.addTriangle(cw - 1.0f, 1.0f,
+				cw * 0.7f, ch * 0.5f,
+				cw - 1.0f, ch - 1.0f);
+
+			g.setColour(Colours::white.withAlpha(0.75f));
+			g.fillPath(p);
+
+			g.setColour(Colours::black.withAlpha(0.75f));
+			g.strokePath(p, PathStrokeType(1.2f));
+		}
+	};
+
+	ValueSelectorMarker marker;
+
+	JUCE_DECLARE_NON_COPYABLE(ValueSelectorComp)
 };
 
 //==============================================================================
@@ -336,10 +427,10 @@ ColourSelector::ColourSelector (int sectionsToShow, int edge, int gapAroundColou
     if ((flags & showColourspace) != 0)
     {
         colourSpace.reset (new ColourSpaceView (*this, h, s, v, gapAroundColourSpaceComponent));
-        hueSelector.reset (new HueSelectorComp (*this, h, gapAroundColourSpaceComponent));
+        valueSelector.reset (new ValueSelectorComp (*this, h, s, v, gapAroundColourSpaceComponent));
 
         addAndMakeVisible (colourSpace.get());
-        addAndMakeVisible (hueSelector.get());
+        addAndMakeVisible (valueSelector.get());
     }
 
     update (dontSendNotification);
@@ -380,15 +471,42 @@ void ColourSelector::setHue (float newH)
     }
 }
 
-void ColourSelector::setSV (float newS, float newV)
+void ColourSelector::setValue(float newV)
+{
+	newV = jlimit(0.0f, 1.0f, newV);
+
+	if (v != newV)
+	{
+		v = newV;
+		colour = Colour(h, s, v, colour.getFloatAlpha());
+		update(sendNotification);
+	}
+}
+
+
+void ColourSelector::setSV(float newS, float newV)
+{
+	newS = jlimit(0.0f, 1.0f, newS);
+	newV = jlimit(0.0f, 1.0f, newV);
+
+	if (s != newS || v != newV)
+	{
+		s = newS;
+		v = newV;
+		colour = Colour(h, s, v, colour.getFloatAlpha());
+		update(sendNotification);
+	}
+}
+
+void ColourSelector::setSH (float newS, float newH)
 {
     newS = jlimit (0.0f, 1.0f, newS);
-    newV = jlimit (0.0f, 1.0f, newV);
+    newH = jlimit (0.0f, 1.0f, newH);
 
-    if (s != newS || v != newV)
+    if (s != newS || h != newH)
     {
         s = newS;
-        v = newV;
+        h = newH;
         colour = Colour (h, s, v, colour.getFloatAlpha());
         update (sendNotification);
     }
@@ -413,7 +531,7 @@ void ColourSelector::update (NotificationType notification)
     if (colourSpace != nullptr)
     {
         colourSpace->updateIfNeeded();
-        hueSelector->updateIfNeeded();
+        valueSelector->updateIfNeeded();
     }
 
     if ((flags & showColourAtTop) != 0)
@@ -485,7 +603,7 @@ void ColourSelector::resized()
                                 getWidth() - hueWidth - edgeGap - 4,
                                 getHeight() - topSpace - sliderSpace - swatchSpace - edgeGap);
 
-        hueSelector->setBounds (colourSpace->getRight() + 4, y,
+        valueSelector->setBounds (colourSpace->getRight() + 4, y,
                                 getWidth() - edgeGap - (colourSpace->getRight() + 4),
                                 colourSpace->getHeight());
 

--- a/modules/juce_gui_extra/misc/juce_ColourSelector.h
+++ b/modules/juce_gui_extra/misc/juce_ColourSelector.h
@@ -136,7 +136,8 @@ public:
     //==============================================================================
     // These need to be public otherwise the Projucer's live-build engine will complain
     class ColourSpaceView;
-    class HueSelectorComp;
+	class HueSelectorComp;
+	class ValueSelectorComp;
 
 private:
     //==============================================================================
@@ -146,14 +147,17 @@ private:
     float h, s, v;
     std::unique_ptr<Slider> sliders[4];
     std::unique_ptr<ColourSpaceView> colourSpace;
-    std::unique_ptr<HueSelectorComp> hueSelector;
-    OwnedArray<SwatchComponent> swatchComponents;
+    //std::unique_ptr<HueSelectorComp> hueSelector;
+	std::unique_ptr<ValueSelectorComp> valueSelector; 
+	OwnedArray<SwatchComponent> swatchComponents;
     const int flags;
     int edgeGap;
     Rectangle<int> previewArea;
 
-    void setHue (float newH);
-    void setSV (float newS, float newV);
+	void setHue(float newH);
+	void setValue (float newV);
+	void setSV(float newS, float newV);
+	void setSH (float newS, float newH);
     void updateHSV();
     void update (NotificationType);
     void changeColour();


### PR DESCRIPTION
This is a proposal to switch to value based color picker.
Hue and saturation are in the ColourSpace view and value is the right slider.
It makes more sense for most cases, and it seems more user-friendly for end users to have control over brightness on a separate slider instead of hue.