### PR TITLE
Implement BluetoothMidiDevicePairingDialogue for Mac OS X

### DIFF
--- a/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
+++ b/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
@@ -24,22 +24,122 @@
   ==============================================================================
 */
 
+#include <CoreAudioKit/CABTLEMIDIWindowController.h>
+
+// This is a very basic wrapper class that can open a Bluetooth MIDI pairing dialogue
+// on Mac OS X and notify it's owner when the window is being closed.
+@interface OSXBluetoothMidiDialogueWrapper : NSObject {
+    CABTLEMIDIWindowController* controller;
+    std::function<void(void)> onWindowClose;
+}
+
+- (void) show;
+
+@end
+
+@implementation OSXBluetoothMidiDialogueWrapper
+- (instancetype) init:(std::function<void(void)>) onWindowClose_ {
+    self = [super init];
+    
+    if (self) {
+        // This will increment the refcount on the controller.
+        // We need to free the memory later.
+        controller = [[CABTLEMIDIWindowController alloc] init];
+        
+        onWindowClose = onWindowClose_;
+    }
+    
+    return self;
+}
+
+- (void) dealloc {
+    // This will decrement the refcount on the controller. If everything is operating
+    // normally, the refcount will be zero and the memory is freed.
+    [controller release];
+    
+    [super dealloc];
+}
+
+- (void) show {
+    [controller showWindow:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(receiveNotification:)
+                                                 name:@"NSWindowWillCloseNotification"
+                                               object:[controller window]];
+}
+
+- (void) receiveNotification:(NSNotification *) notification
+{
+    if ([[notification name] isEqualToString:@"NSWindowWillCloseNotification"]) {
+        onWindowClose();
+    }
+}
+
+@end
+
 namespace juce
 {
-
-bool BluetoothMidiDevicePairingDialogue::open (ModalComponentManager::Callback* exitCallback,
-                                               Rectangle<int>*)
-{
-    std::unique_ptr<ModalComponentManager::Callback> cb (exitCallback);
-    // Do not call this on OSX. Instead, you should pair Bluetooth MIDI devices
-    // using the "Audio MIDI Setup" app (located in /Applications/Utilities).
-    jassertfalse;
-    return false;
-}
-
-bool BluetoothMidiDevicePairingDialogue::isAvailable()
-{
-    return false;
-}
-
+    
+    //==============================================================================
+    class BluetoothMidiSelectorOverlay  : public Component
+    {
+    public:
+        BluetoothMidiSelectorOverlay (ModalComponentManager::Callback* exitCallbackToUse, const Rectangle<int>&) :
+            exitCallback (exitCallbackToUse)
+        {
+            const auto windowCloseCallback = [&]
+            {
+                exitCallback->modalStateFinished(0);
+                
+                // TODO: This is only called when the BLE MIDI pairing window is closed.
+                //       Since the pairing window is not modal, the parent window can be closed first,
+                //       and trigger the leak detector. Need to somehow make sure that can't happen.
+                
+                // To prevent leaking of this BluetoothMidiSelectorOverlay instance,
+                // we need to trigger async deletion (that will happen some time after the modal callback)
+                WeakReference<Component> target (this);
+                MessageManager::callAsync ([=]
+                    {
+                       if (auto* c = target.get())
+                           delete c;
+                    });
+            };
+            
+            nativeDialogue = [[OSXBluetoothMidiDialogueWrapper alloc] init:windowCloseCallback];
+            [nativeDialogue show];
+        }
+        
+        ~BluetoothMidiSelectorOverlay()
+        {
+            [nativeDialogue release];
+        }
+        
+    private:
+        OSXBluetoothMidiDialogueWrapper* nativeDialogue;
+        std::unique_ptr<ModalComponentManager::Callback> exitCallback;
+        
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BluetoothMidiSelectorOverlay)
+    };
+    
+    bool BluetoothMidiDevicePairingDialogue::open (ModalComponentManager::Callback* exitCallback,
+                                                   Rectangle<int>* btBounds)
+    {
+        std::unique_ptr<ModalComponentManager::Callback> cb (exitCallback);
+        auto boundsToUse = (btBounds != nullptr ? *btBounds : Rectangle<int> {});
+        
+        if (isAvailable())
+        {
+            new BluetoothMidiSelectorOverlay (cb.release(), boundsToUse);
+            return true;
+        }
+        
+        return false;
+    }
+    
+    bool BluetoothMidiDevicePairingDialogue::isAvailable()
+    {
+        return NSClassFromString ([NSString stringWithUTF8String: "CABTLEMIDIWindowController"]) != nil;
+    }
+    
 } // namespace juce

--- a/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
+++ b/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
@@ -90,7 +90,9 @@ namespace juce
         {
             const auto windowCloseCallback = [&]
             {
-                exitCallback->modalStateFinished(0);
+                if (exitCallback) {
+                    exitCallback->modalStateFinished(0);
+                }
                 
                 // TODO: This is only called when the BLE MIDI pairing window is closed.
                 //       Since the pairing window is not modal, the parent window can be closed first,


### PR DESCRIPTION
This PR utilizes the [CABTLEMIDIWindowController](https://developer.apple.com/documentation/coreaudiokit/cabtlemidiwindowcontroller?language=objc) class from CoreAudioKit to implement [BluetoothMidiDevicePairingDialogue](https://docs.juce.com/master/classBluetoothMidiDevicePairingDialogue.html) for Mac OS X systems (SDK 10.11+).

This can be tested by building the Audio Plugin Host from the extras folder. The "Audio Settings" window will contain a button that opens this dialogue.

There are  a few things to note:
* My Objective C experience is limited, and there may be room for improvements there. Just let me know if you spot anything obvious.
* Since the CABTLEMIDIWindowController class simply spawns a new window, this isn't really a "modal" component, but I made it follow the same API as the iOS version, taking a modal callback object that is called when the window is closed.
* I'm a little concerned about the `BluetoothMidiDevicePairingDialogue::open` function. It simply calls `new BluetoothMidiSelectorOverlay (cb.release(), boundsToUse);` and exits. Where is this instance deleted? Is this done automatically when the "modal" state is exited? I had to go around this by using `MessageManager::callAsync` to trigger deletion of the object to avoid memory leaks.