### PR TITLE
Added warning about overwriting files to zenity 

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_FileChooser.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_FileChooser.cpp
@@ -46,7 +46,8 @@ public:
         : owner (fileChooser),
           isDirectory         ((flags & FileBrowserComponent::canSelectDirectories)   != 0),
           isSave              ((flags & FileBrowserComponent::saveMode)               != 0),
-          selectMultipleFiles ((flags & FileBrowserComponent::canSelectMultipleItems) != 0)
+          selectMultipleFiles ((flags & FileBrowserComponent::canSelectMultipleItems) != 0),
+          warnAboutOverwrite  ((flags & FileBrowserComponent::warnAboutOverwriting)   != 0)
     {
         const File previousWorkingDirectory (File::getCurrentWorkingDirectory());
 
@@ -81,7 +82,7 @@ public:
 
 private:
     FileChooser& owner;
-    bool isDirectory, isSave, selectMultipleFiles;
+    bool isDirectory, isSave, selectMultipleFiles, warnAboutOverwrite;
 
     ChildProcess child;
     StringArray args;
@@ -193,6 +194,9 @@ private:
     {
         args.add ("zenity");
         args.add ("--file-selection");
+
+        if(warnAboutOverwrite)
+            args.add("--confirm-overwrite");
 
         if (owner.title.isNotEmpty())
             args.add ("--title=" + owner.title);


### PR DESCRIPTION
Zenity is used as the file chooser on Linux when KDE is not running. Previously, when an existing file was selected while saving a file the existing file would be overwritten with no warning. Now, there will be an appropriate warning message.