### PR TITLE
Projucer exporter for Android: Fix path for Extra resources

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Android.h
@@ -1107,7 +1107,7 @@ private:
                 if (remoteNotifsConfigFilePath.isEmpty())
                     remoteNotifsConfigFilePath = androidRemoteNotificationsConfigFile.get().toString();
 
-                File file (getProject().getFile().getChildFile (remoteNotifsConfigFilePath));
+                File file (getProject().getFile().getParentDirectory().getChildFile (remoteNotifsConfigFilePath));
                 // Settings file must be present for remote notifications to work and it must be called google-services.json.
                 jassert (file.existsAsFile() && file.getFileName() == "google-services.json");
 
@@ -1126,7 +1126,7 @@ private:
 
         for (auto& path : resourcePaths)
         {
-            auto file = getProject().getFile().getChildFile (path);
+            auto file = getProject().getFile().getParentDirectory().getChildFile (path);
 
             jassert (file.exists());
 


### PR DESCRIPTION
Path was constructed from the project file itself instead of its parent directory.