### PR TITLE
Windows: Fixed double delete crash in WebBrowserComponent::goToURL() when invoked with POST data

### DIFF
--- a/modules/juce_gui_extra/native/juce_win32_WebBrowserComponent.cpp
+++ b/modules/juce_gui_extra/native/juce_win32_WebBrowserComponent.cpp
@@ -87,8 +87,6 @@ public:
     {
         if (browser != nullptr)
         {
-            LPSAFEARRAY sa = nullptr;
-
             VARIANT headerFlags, frame, postDataVar, headersVar;  // (_variant_t isn't available in all compilers)
             VariantInit (&headerFlags);
             VariantInit (&frame);
@@ -103,6 +101,7 @@ public:
 
             if (postData != nullptr && postData->getSize() > 0)
             {
+                LPSAFEARRAY sa = nullptr;
                 sa = SafeArrayCreateVector (VT_UI1, 0, (ULONG) postData->getSize());
 
                 if (sa != nullptr)
@@ -121,7 +120,12 @@ public:
                         V_VT (&postDataVar2) = VT_ARRAY | VT_UI1;
                         V_ARRAY (&postDataVar2) = sa;
 
+                        sa = nullptr;
                         postDataVar = postDataVar2;
+                    }
+                    else // SafeArrayAccessData failed
+                    {
+                        SafeArrayDestroy (sa);
                     }
                 }
             }
@@ -129,9 +133,6 @@ public:
             auto urlBSTR = SysAllocString ((const OLECHAR*) url.toWideCharPointer());
             browser->Navigate (urlBSTR, &headerFlags, &frame, &postDataVar, &headersVar);
             SysFreeString (urlBSTR);
-
-            if (sa != nullptr)
-                SafeArrayDestroy (sa);
 
             VariantClear (&headerFlags);
             VariantClear (&frame);


### PR DESCRIPTION
Calling both `VariantClear (&postDataVar)` and `SafeArrayDestroy (sa)` at the end of win version of `WebBrowserComponent::goToURL()` causes crash after double deleting.

Can be easily reproduced by calling `WebBrowserComponent::goToURL()` with some POST data.