### PR TITLE
add option in JUCE to allow forbidden characters in OSC addresses.

### DIFF
--- a/modules/juce_osc/juce_osc.h
+++ b/modules/juce_osc/juce_osc.h
@@ -54,6 +54,14 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 
+/** Config: JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS
+	Enables the use of characters in adress that are not allowed by the OSC specifications (like spaces), but that are used
+	by some applications anyway (e.g. /my spaced/address)
+*/
+#ifndef JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS
+#define JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 0
+#endif
+
 //==============================================================================
 #include "osc/juce_OSCTypes.h"
 #include "osc/juce_OSCTimeTag.h"

--- a/modules/juce_osc/osc/juce_OSCAddress.cpp
+++ b/modules/juce_osc/osc/juce_OSCAddress.cpp
@@ -274,10 +274,17 @@ namespace
             return c >= ' ' && c <= '~';
         }
 
+#pragma warning(push)
+#pragma warning(disable: 4100)
         static bool isDisallowedChar (juce_wchar c) noexcept
         {
+#if JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS
+			return false;
+#else
             return CharPointer_ASCII (Traits::getDisallowedChars()).indexOf (c, false) >= 0;
+#endif
         }
+#pragma warning(pop)
 
         static bool containsOnlyAllowedPrintableASCIIChars (const String& string) noexcept
         {


### PR DESCRIPTION
I've been struggling with a lot of people and software designers who decided to prioritize "user-friendly" osc addresses (e.g. with spaces : /my super/address) against OSC specification compliance. Those are famous software in digital art, like MadMapper or Millumin.
The way OSC is handled in JUCE right now doesn't allow programmers to decide whether they want to allow those addresses, and it can be a blocker if you really need to be able to communicate with those not standard softwares.

The proposal is to add a module option (disabled by default), that bypasses the special chars check when enabled