### PR TITLE
add parse() method to JSON javascript object

### DIFF
--- a/modules/juce_core/javascript/juce_Javascript.cpp
+++ b/modules/juce_core/javascript/juce_Javascript.cpp
@@ -1760,9 +1760,10 @@ struct JavascriptEngine::RootObject   : public DynamicObject
     //==============================================================================
     struct JSONClass  : public DynamicObject
     {
-        JSONClass()                        { setMethod ("stringify", stringify); }
+		JSONClass() { setMethod("stringify", stringify); setMethod("parse", parse);  }
         static Identifier getClassName()   { static const Identifier i ("JSON"); return i; }
-        static var stringify (Args a)      { return JSON::toString (get (a, 0)); }
+		static var stringify(Args a) { return JSON::toString(get(a, 0)); }
+		static var parse (Args a)     { return JSON::fromString (get (a, 0).toString()); }
     };
 
     //==============================================================================


### PR DESCRIPTION
To allow conversion in both direction, very useful when you want get data from an http request and have custom scripts that can parse the response