### PR TITLE
Optimization of VST3 shell plug-ins instantiation

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -1104,9 +1104,9 @@ private:
     Result findName(IPluginFactory* factory, const PluginDescription& description)
     {
         if (factory == nullptr)
-            return Result::fail(L"Invalid Parameter");
+            return Result::fail("Invalid Parameter");
 
-        Result result(Result::fail(L"not found"));
+        Result result(Result::fail("not found"));
         auto numClasses = factory->countClasses();
 
         for (Steinberg::int32 i = 0; i < numClasses; ++i)

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -1090,7 +1090,7 @@ private:
         {
             ComSmartPtr<VST3HostContext> host (new VST3HostContext());
 
-            auto result = findName(pluginFactory, description);
+            auto result = findMatch(pluginFactory, description);
             if (result.wasOk())
             {
                 name = description.name;
@@ -1101,7 +1101,7 @@ private:
         return false;
     }
 
-    Result findName(IPluginFactory* factory, const PluginDescription& description)
+    Result findMatch(IPluginFactory* factory, const PluginDescription& description)
     {
         if (factory == nullptr)
             return Result::fail("Invalid Parameter");
@@ -1119,7 +1119,7 @@ private:
 
             const String infoName(toString(info.name).trim());
 
-            if (infoName == description.name)
+            if (infoName == description.name && getHashForTUID(info.cid) == description.uid)
                 return Result::ok();
         }
         return result;


### PR DESCRIPTION
Instantiating a VST3 shell plug-in can be overkill. For example, if using Waves complete suite of plug-ins (more than 400 plug-ins), the instantiation of the first enumerated plug-in (e.g. Waves API-2500) is almost instant, while the instantiation of the bottom listed plug-ins (e.g. Waves Q10) can take more than a minute.
This code update avoids creating an instance of each component handled by a vst3 factory when opening a VST3 module, and instead just checks if the name of the provided description can be found in the enumerated classes of a vst3 factory. It allows a huge speed-up of plug-in instantiation for big VST3 shells such as Waves.