### PR TITLE
Added ControllableProcessorBase to recycle AudioProcessorParameters

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp
+++ b/modules/juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp
@@ -42,28 +42,29 @@ class LegacyAudioParameter :   public AudioProcessorParameter
 {
 public:
     LegacyAudioParameter (AudioProcessor& audioProcessorToUse, int audioParameterIndex)
+      : audioProcessor (audioProcessorToUse)
     {
         processor = &audioProcessorToUse;
 
         parameterIndex = audioParameterIndex;
-        jassert (parameterIndex < processor->getNumParameters());
+        jassert (parameterIndex < audioProcessor.getNumParameters());
     }
 
     //==============================================================================
-    float getValue() const override                    { return processor->getParameter (parameterIndex); }
-    void setValue (float newValue) override            { processor->setParameter (parameterIndex, newValue); }
-    float getDefaultValue() const override             { return processor->getParameterDefaultValue (parameterIndex); }
-    String getName (int maxLen) const override         { return processor->getParameterName (parameterIndex, maxLen); }
-    String getLabel() const override                   { return processor->getParameterLabel (parameterIndex); }
-    int getNumSteps() const override                   { return processor->getParameterNumSteps (parameterIndex); }
-    bool isDiscrete() const override                   { return processor->isParameterDiscrete (parameterIndex); }
+    float getValue() const override                    { return audioProcessor.getParameter (parameterIndex); }
+    void setValue (float newValue) override            { audioProcessor.setParameter (parameterIndex, newValue); }
+    float getDefaultValue() const override             { return audioProcessor.getParameterDefaultValue (parameterIndex); }
+    String getName (int maxLen) const override         { return audioProcessor.getParameterName (parameterIndex, maxLen); }
+    String getLabel() const override                   { return audioProcessor.getParameterLabel (parameterIndex); }
+    int getNumSteps() const override                   { return audioProcessor.getParameterNumSteps (parameterIndex); }
+    bool isDiscrete() const override                   { return audioProcessor.isParameterDiscrete (parameterIndex); }
     bool isBoolean() const override                    { return false; }
-    bool isOrientationInverted() const override        { return processor->isParameterOrientationInverted (parameterIndex); }
-    bool isAutomatable() const override                { return processor->isParameterAutomatable (parameterIndex); }
-    bool isMetaParameter() const override              { return processor->isMetaParameter (parameterIndex); }
-    Category getCategory() const override              { return processor->getParameterCategory (parameterIndex); }
-    String getCurrentValueAsText() const override      { return processor->getParameterText (parameterIndex); }
-    String getParamID() const                          { return processor->getParameterID (parameterIndex); }
+    bool isOrientationInverted() const override        { return audioProcessor.isParameterOrientationInverted (parameterIndex); }
+    bool isAutomatable() const override                { return audioProcessor.isParameterAutomatable (parameterIndex); }
+    bool isMetaParameter() const override              { return audioProcessor.isMetaParameter (parameterIndex); }
+    Category getCategory() const override              { return audioProcessor.getParameterCategory (parameterIndex); }
+    String getCurrentValueAsText() const override      { return audioProcessor.getParameterText (parameterIndex); }
+    String getParamID() const                          { return audioProcessor.getParameterID (parameterIndex); }
 
     //==============================================================================
     float getValueForText (const String&) const override
@@ -121,6 +122,9 @@ public:
 
         return String (param->getParameterIndex());
     }
+
+private:
+    AudioProcessor& audioProcessor;
 };
 
 //==============================================================================

--- a/modules/juce_audio_processors/juce_audio_processors.cpp
+++ b/modules/juce_audio_processors/juce_audio_processors.cpp
@@ -152,6 +152,7 @@ struct AutoResizingNSViewComponentWithParent  : public AutoResizingNSViewCompone
 #include "scanning/juce_KnownPluginList.cpp"
 #include "scanning/juce_PluginDirectoryScanner.cpp"
 #include "scanning/juce_PluginListComponent.cpp"
+#include "processors/juce_ControllableProcessorBase.cpp"
 #include "processors/juce_AudioProcessorParameterGroup.cpp"
 #include "utilities/juce_AudioProcessorParameterWithID.cpp"
 #include "utilities/juce_RangedAudioParameter.cpp"

--- a/modules/juce_audio_processors/juce_audio_processors.h
+++ b/modules/juce_audio_processors/juce_audio_processors.h
@@ -110,6 +110,7 @@
 #include "processors/juce_AudioProcessorListener.h"
 #include "processors/juce_AudioProcessorParameter.h"
 #include "processors/juce_AudioProcessorParameterGroup.h"
+#include "processors/juce_ControllableProcessorBase.h"
 #include "processors/juce_AudioProcessor.h"
 #include "processors/juce_PluginDescription.h"
 #include "processors/juce_AudioPluginInstance.h"

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -52,19 +52,6 @@ AudioProcessor::AudioProcessor (const BusesProperties& ioConfig)
 
 AudioProcessor::~AudioProcessor()
 {
-    // ooh, nasty - the editor should have been deleted before its AudioProcessor.
-    jassert (activeEditor == nullptr);
-
-   #if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
-    // This will fail if you've called beginParameterChangeGesture() for one
-    // or more parameters without having made a corresponding call to endParameterChangeGesture...
-    jassert (changingParams.countNumberOfSetBits() == 0);
-   #endif
-
-    // The parameters are owned by an AudioProcessorParameterGroup, but we need
-    // to keep the managedParameters array populated to maintain backwards
-    // compatibility.
-    managedParameters.clearQuick (false);
 }
 
 //==============================================================================
@@ -371,10 +358,6 @@ void AudioProcessor::setRateAndBufferSizeDetails (double newSampleRate, int newB
 {
     currentSampleRate = newSampleRate;
     blockSize = newBlockSize;
-
-   #ifdef JUCE_DEBUG
-    checkForDupedParamIDs();
-   #endif
 }
 
 //==============================================================================
@@ -420,148 +403,7 @@ void AudioProcessor::setLatencySamples (const int newLatency)
 }
 
 //==============================================================================
-#if JUCE_GCC
- #pragma GCC diagnostic push
- #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif JUCE_CLANG
- #pragma clang diagnostic push
- #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif JUCE_MSVC
- #pragma warning (push, 0)
- #pragma warning (disable: 4996)
-#endif
 
-void AudioProcessor::setParameterNotifyingHost (int parameterIndex, float newValue)
-{
-    if (auto* param = getParameters()[parameterIndex])
-    {
-        param->setValueNotifyingHost (newValue);
-    }
-    else if (isPositiveAndBelow (parameterIndex, getNumParameters()))
-    {
-        setParameter (parameterIndex, newValue);
-        sendParamChangeMessageToListeners (parameterIndex, newValue);
-    }
-}
-
-void AudioProcessor::sendParamChangeMessageToListeners (int parameterIndex, float newValue)
-{
-    if (auto* param = getParameters()[parameterIndex])
-    {
-        param->sendValueChangedMessageToListeners (newValue);
-    }
-    else
-    {
-        if (isPositiveAndBelow (parameterIndex, getNumParameters()))
-        {
-            for (int i = listeners.size(); --i >= 0;)
-                if (auto* l = getListenerLocked (i))
-                    l->audioProcessorParameterChanged (this, parameterIndex, newValue);
-        }
-        else
-        {
-            jassertfalse; // called with an out-of-range parameter index!
-        }
-    }
-}
-
-void AudioProcessor::beginParameterChangeGesture (int parameterIndex)
-{
-    if (auto* param = getParameters()[parameterIndex])
-    {
-        param->beginChangeGesture();
-    }
-    else
-    {
-        if (isPositiveAndBelow (parameterIndex, getNumParameters()))
-        {
-           #if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
-            // This means you've called beginParameterChangeGesture twice in succession without a matching
-            // call to endParameterChangeGesture. That might be fine in most hosts, but better to avoid doing it.
-            jassert (! changingParams[parameterIndex]);
-            changingParams.setBit (parameterIndex);
-           #endif
-
-            for (int i = listeners.size(); --i >= 0;)
-                if (auto* l = getListenerLocked (i))
-                    l->audioProcessorParameterChangeGestureBegin (this, parameterIndex);
-        }
-        else
-        {
-            jassertfalse; // called with an out-of-range parameter index!
-        }
-    }
-}
-
-void AudioProcessor::endParameterChangeGesture (int parameterIndex)
-{
-    if (auto* param = getParameters()[parameterIndex])
-    {
-        param->endChangeGesture();
-    }
-    else
-    {
-        if (isPositiveAndBelow (parameterIndex, getNumParameters()))
-        {
-           #if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
-            // This means you've called endParameterChangeGesture without having previously called
-            // beginParameterChangeGesture. That might be fine in most hosts, but better to keep the
-            // calls matched correctly.
-            jassert (changingParams[parameterIndex]);
-            changingParams.clearBit (parameterIndex);
-           #endif
-
-            for (int i = listeners.size(); --i >= 0;)
-                if (auto* l = getListenerLocked (i))
-                    l->audioProcessorParameterChangeGestureEnd (this, parameterIndex);
-        }
-        else
-        {
-            jassertfalse; // called with an out-of-range parameter index!
-        }
-    }
-}
-
-String AudioProcessor::getParameterName (int index, int maximumStringLength)
-{
-    if (auto* p = managedParameters[index])
-        return p->getName (maximumStringLength);
-
-    return isPositiveAndBelow (index, getNumParameters()) ? getParameterName (index).substring (0, maximumStringLength)
-                                                          : String();
-}
-
-const String AudioProcessor::getParameterText (int index)
-{
-   #if JUCE_DEBUG
-    // if you hit this, then you're probably using the old parameter control methods,
-    // but have forgotten to implement either of the getParameterText() methods.
-    jassert (! textRecursionCheck);
-    ScopedValueSetter<bool> sv (textRecursionCheck, true, false);
-   #endif
-
-    return isPositiveAndBelow (index, getNumParameters()) ? getParameterText (index, 1024)
-                                                          : String();
-}
-
-String AudioProcessor::getParameterText (int index, int maximumStringLength)
-{
-    if (auto* p = managedParameters[index])
-        return p->getText (p->getValue(), maximumStringLength);
-
-    return isPositiveAndBelow (index, getNumParameters()) ? getParameterText (index).substring (0, maximumStringLength)
-                                                          : String();
-}
-
-#if JUCE_GCC
- #pragma GCC diagnostic pop
-#elif JUCE_CLANG
- #pragma clang diagnostic pop
-#elif JUCE_MSVC
- #pragma warning (pop)
-#endif
-
-//==============================================================================
 AudioProcessorListener* AudioProcessor::getListenerLocked (int index) const noexcept
 {
     const ScopedLock sl (listenerLock);
@@ -575,61 +417,25 @@ void AudioProcessor::updateHostDisplay()
             l->audioProcessorChanged (this);
 }
 
-const OwnedArray<AudioProcessorParameter>& AudioProcessor::getParameters() const noexcept
+void AudioProcessor::sendParamChangeMessageToListeners (int parameterIndex, float newValue)
 {
-    return managedParameters;
+    for (int i = listeners.size(); --i >= 0;)
+        if (auto* l = getListenerLocked (i))
+            l->audioProcessorParameterChanged (this, parameterIndex, newValue);
 }
 
-int AudioProcessor::getNumParameters()
+void AudioProcessor::sendParamChangeGestureBeginToListeners (int parameterIndex)
 {
-    return managedParameters.size();
+    for (int i = listeners.size(); --i >= 0;)
+        if (auto* l = getListenerLocked (i))
+            l->audioProcessorParameterChangeGestureBegin (this, parameterIndex);
 }
 
-float AudioProcessor::getParameter (int index)
+void AudioProcessor::sendParamChangeGestureEndToListeners (int parameterIndex)
 {
-    if (auto* p = getParamChecked (index))
-        return p->getValue();
-
-    return 0;
-}
-
-void AudioProcessor::setParameter (int index, float newValue)
-{
-    if (auto* p = getParamChecked (index))
-        p->setValue (newValue);
-}
-
-float AudioProcessor::getParameterDefaultValue (int index)
-{
-    if (auto* p = managedParameters[index])
-        return p->getDefaultValue();
-
-    return 0;
-}
-
-const String AudioProcessor::getParameterName (int index)
-{
-    if (auto* p = getParamChecked (index))
-        return p->getName (512);
-
-    return {};
-}
-
-String AudioProcessor::getParameterID (int index)
-{
-    // Don't use getParamChecked here, as this must also work for legacy plug-ins
-    if (auto* p = dynamic_cast<AudioProcessorParameterWithID*> (managedParameters[index]))
-        return p->paramID;
-
-    return String (index);
-}
-
-int AudioProcessor::getParameterNumSteps (int index)
-{
-    if (auto* p = managedParameters[index])
-        return p->getNumSteps();
-
-    return AudioProcessor::getDefaultNumParameterSteps();
+    for (int i = listeners.size(); --i >= 0;)
+        if (auto* l = getListenerLocked (i))
+            l->audioProcessorParameterChangeGestureEnd (this, parameterIndex);
 }
 
 int AudioProcessor::getDefaultNumParameterSteps() noexcept
@@ -637,117 +443,7 @@ int AudioProcessor::getDefaultNumParameterSteps() noexcept
     return 0x7fffffff;
 }
 
-bool AudioProcessor::isParameterDiscrete (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->isDiscrete();
-
-    return false;
-}
-
-String AudioProcessor::getParameterLabel (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->getLabel();
-
-    return {};
-}
-
-bool AudioProcessor::isParameterAutomatable (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->isAutomatable();
-
-    return true;
-}
-
-bool AudioProcessor::isParameterOrientationInverted (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->isOrientationInverted();
-
-    return false;
-}
-
-bool AudioProcessor::isMetaParameter (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->isMetaParameter();
-
-    return false;
-}
-
-AudioProcessorParameter::Category AudioProcessor::getParameterCategory (int index) const
-{
-    if (auto* p = managedParameters[index])
-        return p->getCategory();
-
-    return AudioProcessorParameter::genericParameter;
-}
-
-AudioProcessorParameter* AudioProcessor::getParamChecked (int index) const noexcept
-{
-    AudioProcessorParameter* p = managedParameters[index];
-
-    // If you hit this, then you're either trying to access parameters that are out-of-range,
-    // or you're not using addParameter and the managed parameter list, but have failed
-    // to override some essential virtual methods and implement them appropriately.
-    jassert (p != nullptr);
-    return p;
-}
-
-void AudioProcessor::addParameterInternal (AudioProcessorParameter* param)
-{
-    param->processor = this;
-    param->parameterIndex = managedParameters.size();
-    managedParameters.add (param);
-
-   #ifdef JUCE_DEBUG
-    shouldCheckParamsForDupeIDs = true;
-   #endif
-}
-
-void AudioProcessor::addParameter (AudioProcessorParameter* param)
-{
-    addParameterInternal (param);
-    parameterTree.addChild (std::unique_ptr<AudioProcessorParameter> (param));
-}
-
-void AudioProcessor::addParameterGroup (std::unique_ptr<AudioProcessorParameterGroup> group)
-{
-    for (auto* param : group->getParameters (true))
-        addParameterInternal (param);
-
-    parameterTree.addChild (std::move (group));
-}
-
-const AudioProcessorParameterGroup& AudioProcessor::getParameterTree()
-{
-    return parameterTree;
-}
-
-#ifdef JUCE_DEBUG
-void AudioProcessor::checkForDupedParamIDs()
-{
-    if (shouldCheckParamsForDupeIDs)
-    {
-        shouldCheckParamsForDupeIDs = false;
-        StringArray ids;
-
-        for (auto p : managedParameters)
-            if (auto* withID = dynamic_cast<AudioProcessorParameterWithID*> (p))
-                ids.add (withID->paramID);
-
-        ids.sort (false);
-
-        for (int i = 1; i < ids.size(); ++i)
-        {
-            // This is triggered if you have two or more parameters with the same ID!
-            jassert (ids[i - 1] != ids[i]);
-        }
-    }
-}
-#endif
+//==============================================================================
 
 void AudioProcessor::suspendProcessing (const bool shouldBeSuspended)
 {
@@ -1048,37 +744,6 @@ void AudioProcessor::audioIOChanged (bool busNumberChanged, bool channelNumChang
         numChannelsChanged();
 
     processorLayoutsChanged();
-}
-
-//==============================================================================
-void AudioProcessor::editorBeingDeleted (AudioProcessorEditor* const editor) noexcept
-{
-    const ScopedLock sl (callbackLock);
-
-    if (activeEditor == editor)
-        activeEditor = nullptr;
-}
-
-AudioProcessorEditor* AudioProcessor::createEditorIfNeeded()
-{
-    if (activeEditor != nullptr)
-        return activeEditor;
-
-    auto* ed = createEditor();
-
-    if (ed != nullptr)
-    {
-        // you must give your editor comp a size before returning it..
-        jassert (ed->getWidth() > 0 && ed->getHeight() > 0);
-
-        const ScopedLock sl (callbackLock);
-        activeEditor = ed;
-    }
-
-    // You must make your hasEditor() method return a consistent result!
-    jassert (hasEditor() == (ed != nullptr));
-
-    return ed;
 }
 
 //==============================================================================
@@ -1463,13 +1128,10 @@ void AudioProcessorParameter::beginChangeGesture()
         if (auto* l = listeners[i])
             l->parameterGestureChanged (getParameterIndex(), true);
 
-    if (processor != nullptr && parameterIndex >= 0)
+    if (parameterIndex >= 0)
     {
-        // audioProcessorParameterChangeGestureBegin callbacks will shortly be deprecated and
-        // this code will be removed.
-        for (int i = processor->listeners.size(); --i >= 0;)
-            if (auto* l = processor->listeners[i])
-                l->audioProcessorParameterChangeGestureBegin (processor, getParameterIndex());
+        if (processor != nullptr)
+            processor->sendParamChangeGestureBeginToListeners (getParameterIndex());
     }
 }
 
@@ -1492,13 +1154,10 @@ void AudioProcessorParameter::endChangeGesture()
         if (auto* l = listeners[i])
             l->parameterGestureChanged (getParameterIndex(), false);
 
-    if (processor != nullptr && parameterIndex >= 0)
+    if (parameterIndex >= 0)
     {
-        // audioProcessorParameterChangeGestureEnd callbacks will shortly be deprecated and
-        // this code will be removed.
-        for (int i = processor->listeners.size(); --i >= 0;)
-            if (auto* l = processor->listeners[i])
-                l->audioProcessorParameterChangeGestureEnd (processor, getParameterIndex());
+        if (processor != nullptr)
+            processor->sendParamChangeGestureEndToListeners (getParameterIndex());
     }
 }
 
@@ -1510,13 +1169,12 @@ void AudioProcessorParameter::sendValueChangedMessageToListeners (float newValue
         if (auto* l = listeners [i])
             l->parameterValueChanged (getParameterIndex(), newValue);
 
-    if (processor != nullptr && parameterIndex >= 0)
+    if (parameterIndex >= 0)
     {
         // audioProcessorParameterChanged callbacks will shortly be deprecated and
         // this code will be removed.
-        for (int i = processor->listeners.size(); --i >= 0;)
-            if (auto* l = processor->listeners[i])
-                l->audioProcessorParameterChanged (processor, getParameterIndex(), newValue);
+        if (processor != nullptr)
+            processor->sendParamChangeMessageToListeners (getParameterIndex(), newValue);
     }
 }
 

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -55,9 +55,6 @@ AudioProcessor::~AudioProcessor()
 }
 
 //==============================================================================
-StringArray AudioProcessor::getAlternateDisplayNames() const     { return StringArray (getName()); }
-
-//==============================================================================
 bool AudioProcessor::addBus (bool isInput)
 {
     if (! canAddBus (isInput))

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
@@ -84,19 +84,6 @@ public:
     virtual ~AudioProcessor();
 
     //==============================================================================
-    /** Returns the name of this processor. */
-    virtual const String getName() const = 0;
-
-    /** Returns a list of alternative names to use for this processor.
-
-        Some hosts truncate the name of your AudioProcessor when there isn't enough
-        space in the GUI to show the full name. Overriding this method, allows the host
-        to choose an alternative name (such as an abbreviation) to better fit the
-        available space.
-    */
-    virtual StringArray getAlternateDisplayNames() const;
-
-    //==============================================================================
     /** Called before playback starts, to let the processor prepare itself.
 
         The sample rate is the target sample rate, and will remain constant until

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.cpp
@@ -27,12 +27,12 @@
 namespace juce
 {
 
-AudioProcessorEditor::AudioProcessorEditor (AudioProcessor& p) noexcept  : processor (p)
+AudioProcessorEditor::AudioProcessorEditor (ControllableProcessorBase& p) noexcept  : processor (p)
 {
     initialise();
 }
 
-AudioProcessorEditor::AudioProcessorEditor (AudioProcessor* p) noexcept  : processor (*p)
+AudioProcessorEditor::AudioProcessorEditor (ControllableProcessorBase* p) noexcept  : processor (*p)
 {
     // the filter must be valid..
     jassert (p != nullptr);

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
@@ -27,6 +27,7 @@
 namespace juce
 {
 
+    class ControllableProcessorBase;
 class AudioProcessor;
 class AudioProcessorEditorListener;
 
@@ -46,10 +47,10 @@ class JUCE_API  AudioProcessorEditor  : public Component
 protected:
     //==============================================================================
     /** Creates an editor for the specified processor. */
-    AudioProcessorEditor (AudioProcessor&) noexcept;
+    AudioProcessorEditor (ControllableProcessorBase&) noexcept;
 
     /** Creates an editor for the specified processor. */
-    AudioProcessorEditor (AudioProcessor*) noexcept;
+    AudioProcessorEditor (ControllableProcessorBase*) noexcept;
 
 public:
     /** Destructor. */
@@ -57,14 +58,14 @@ public:
 
 
     //==============================================================================
-    /** The AudioProcessor that this editor represents. */
-    AudioProcessor& processor;
+    /** The Processor that this editor represents. */
+    ControllableProcessorBase& processor;
 
     /** Returns a pointer to the processor that this editor represents.
         This method is here to support legacy code, but it's easier to just use the
         AudioProcessorEditor::processor member variable directly to get this object.
     */
-    AudioProcessor* getAudioProcessor() const noexcept        { return &processor; }
+    ControllableProcessorBase* getAudioProcessor() const noexcept  { return &processor; }
 
     //==============================================================================
     /** Used by the setParameterHighlighting() method. */

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
@@ -286,9 +286,10 @@ public:
 
 private:
     //==============================================================================
+    friend class ControllableProcessorBase;
     friend class AudioProcessor;
     friend class LegacyAudioParameter;
-    AudioProcessor* processor = nullptr;
+    ControllableProcessorBase* processor = nullptr;
     int parameterIndex = -1;
     CriticalSection listenerLock;
     Array<Listener*> listeners;

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
@@ -287,7 +287,6 @@ public:
 private:
     //==============================================================================
     friend class ControllableProcessorBase;
-    friend class AudioProcessor;
     friend class LegacyAudioParameter;
     ControllableProcessorBase* processor = nullptr;
     int parameterIndex = -1;

--- a/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.cpp
+++ b/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.cpp
@@ -49,7 +49,9 @@ ControllableProcessorBase::~ControllableProcessorBase()
 }
 
 //==============================================================================
+StringArray ControllableProcessorBase::getAlternateDisplayNames() const     { return StringArray (getName()); }
 
+//==============================================================================
 void ControllableProcessorBase::editorBeingDeleted (AudioProcessorEditor* const editor) noexcept
 {
     const ScopedLock sl (getCallbackLock());

--- a/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.cpp
+++ b/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.cpp
@@ -1,0 +1,358 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE library.
+   Copyright (c) 2017 - ROLI Ltd.
+
+   JUCE is an open source library subject to commercial or open-source
+   licensing.
+
+   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+   27th April 2017).
+
+   End User License Agreement: www.juce.com/juce-5-licence
+   Privacy Policy: www.juce.com/juce-5-privacy-policy
+
+   Or: You may also use this code under the terms of the GPL v3 (see
+   www.gnu.org/licenses).
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+ControllableProcessorBase::ControllableProcessorBase()
+{
+}
+
+ControllableProcessorBase::~ControllableProcessorBase()
+{
+    // ooh, nasty - the editor should have been deleted before its ControllableProcessorBase.
+    jassert (activeEditor == nullptr);
+
+#if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
+    // This will fail if you've called beginParameterChangeGesture() for one
+    // or more parameters without having made a corresponding call to endParameterChangeGesture...
+    jassert (changingParams.countNumberOfSetBits() == 0);
+#endif
+
+    // The parameters are owned by an AudioProcessorParameterGroup, but we need
+    // to keep the managedParameters array populated to maintain backwards
+    // compatibility.
+    managedParameters.clearQuick (false);
+}
+
+//==============================================================================
+
+void ControllableProcessorBase::editorBeingDeleted (AudioProcessorEditor* const editor) noexcept
+{
+    const ScopedLock sl (getCallbackLock());
+
+    if (activeEditor == editor)
+        activeEditor = nullptr;
+}
+
+AudioProcessorEditor* ControllableProcessorBase::createEditorIfNeeded()
+{
+    if (activeEditor != nullptr)
+        return activeEditor;
+
+    auto* ed = createEditor();
+
+    if (ed != nullptr)
+    {
+        // you must give your editor comp a size before returning it..
+        jassert (ed->getWidth() > 0 && ed->getHeight() > 0);
+
+        const ScopedLock sl (getCallbackLock());
+        activeEditor = ed;
+    }
+
+    // You must make your hasEditor() method return a consistent result!
+    jassert (hasEditor() == (ed != nullptr));
+
+    return ed;
+}
+
+//==============================================================================
+
+void ControllableProcessorBase::setParameterNotifyingHost (int parameterIndex, float newValue)
+{
+    if (auto* param = getParameters()[parameterIndex])
+    {
+        param->setValueNotifyingHost (newValue);
+    }
+    else if (isPositiveAndBelow (parameterIndex, getNumParameters()))
+    {
+        setParameter (parameterIndex, newValue);
+        sendParamChangeMessageToListeners (parameterIndex, newValue);
+    }
+}
+
+void ControllableProcessorBase::beginParameterChangeGesture (int parameterIndex)
+{
+    if (auto* param = getParameters()[parameterIndex])
+    {
+        param->beginChangeGesture();
+    }
+    else
+    {
+        if (isPositiveAndBelow (parameterIndex, getNumParameters()))
+        {
+#if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
+            // This means you've called beginParameterChangeGesture twice in succession without a matching
+            // call to endParameterChangeGesture. That might be fine in most hosts, but better to avoid doing it.
+            jassert (! changingParams[parameterIndex]);
+            changingParams.setBit (parameterIndex);
+#endif
+
+            sendParamChangeGestureBeginToListeners (parameterIndex);
+        }
+        else
+        {
+            jassertfalse; // called with an out-of-range parameter index!
+        }
+    }
+}
+
+void ControllableProcessorBase::endParameterChangeGesture (int parameterIndex)
+{
+    if (auto* param = getParameters()[parameterIndex])
+    {
+        param->endChangeGesture();
+    }
+    else
+    {
+        if (isPositiveAndBelow (parameterIndex, getNumParameters()))
+        {
+#if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
+            // This means you've called endParameterChangeGesture without having previously called
+            // beginParameterChangeGesture. That might be fine in most hosts, but better to keep the
+            // calls matched correctly.
+            jassert (changingParams[parameterIndex]);
+            changingParams.clearBit (parameterIndex);
+#endif
+
+            sendParamChangeGestureEndToListeners (parameterIndex);
+        }
+        else
+        {
+            jassertfalse; // called with an out-of-range parameter index!
+        }
+    }
+}
+
+String ControllableProcessorBase::getParameterName (int index, int maximumStringLength)
+{
+    if (auto* p = managedParameters[index])
+        return p->getName (maximumStringLength);
+
+    return isPositiveAndBelow (index, getNumParameters()) ? getParameterName (index).substring (0, maximumStringLength)
+    : String();
+}
+
+const String ControllableProcessorBase::getParameterText (int index)
+{
+#if JUCE_DEBUG
+    // if you hit this, then you're probably using the old parameter control methods,
+    // but have forgotten to implement either of the getParameterText() methods.
+    jassert (! textRecursionCheck);
+    ScopedValueSetter<bool> sv (textRecursionCheck, true, false);
+#endif
+
+    return isPositiveAndBelow (index, getNumParameters()) ? getParameterText (index, 1024)
+    : String();
+}
+
+String ControllableProcessorBase::getParameterText (int index, int maximumStringLength)
+{
+    if (auto* p = managedParameters[index])
+        return p->getText (p->getValue(), maximumStringLength);
+
+    return isPositiveAndBelow (index, getNumParameters()) ? getParameterText (index).substring (0, maximumStringLength)
+    : String();
+}
+
+//==============================================================================
+
+const OwnedArray<AudioProcessorParameter>& ControllableProcessorBase::getParameters() const noexcept
+{
+    return managedParameters;
+}
+
+int ControllableProcessorBase::getNumParameters()
+{
+    return managedParameters.size();
+}
+
+float ControllableProcessorBase::getParameter (int index)
+{
+    if (auto* p = getParamChecked (index))
+        return p->getValue();
+
+    return 0;
+}
+
+void ControllableProcessorBase::setParameter (int index, float newValue)
+{
+    if (auto* p = getParamChecked (index))
+        p->setValue (newValue);
+}
+
+float ControllableProcessorBase::getParameterDefaultValue (int index)
+{
+    if (auto* p = managedParameters[index])
+        return p->getDefaultValue();
+
+    return 0;
+}
+
+const String ControllableProcessorBase::getParameterName (int index)
+{
+    if (auto* p = getParamChecked (index))
+        return p->getName (512);
+
+    return {};
+}
+
+String ControllableProcessorBase::getParameterID (int index)
+{
+    // Don't use getParamChecked here, as this must also work for legacy plug-ins
+    if (auto* p = dynamic_cast<AudioProcessorParameterWithID*> (managedParameters[index]))
+        return p->paramID;
+
+    return String (index);
+}
+
+int ControllableProcessorBase::getParameterNumSteps (int index)
+{
+    if (auto* p = managedParameters[index])
+        return p->getNumSteps();
+
+    return AudioProcessor::getDefaultNumParameterSteps();
+}
+
+int ControllableProcessorBase::getDefaultNumParameterSteps() noexcept
+{
+    return 0x7fffffff;
+}
+
+bool ControllableProcessorBase::isParameterDiscrete (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->isDiscrete();
+
+    return false;
+}
+
+String ControllableProcessorBase::getParameterLabel (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->getLabel();
+
+    return {};
+}
+
+bool ControllableProcessorBase::isParameterAutomatable (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->isAutomatable();
+
+    return true;
+}
+
+bool ControllableProcessorBase::isParameterOrientationInverted (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->isOrientationInverted();
+
+    return false;
+}
+
+bool ControllableProcessorBase::isMetaParameter (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->isMetaParameter();
+
+    return false;
+}
+
+AudioProcessorParameter::Category ControllableProcessorBase::getParameterCategory (int index) const
+{
+    if (auto* p = managedParameters[index])
+        return p->getCategory();
+
+    return AudioProcessorParameter::genericParameter;
+}
+
+AudioProcessorParameter* ControllableProcessorBase::getParamChecked (int index) const noexcept
+{
+    AudioProcessorParameter* p = managedParameters[index];
+
+    // If you hit this, then you're either trying to access parameters that are out-of-range,
+    // or you're not using addParameter and the managed parameter list, but have failed
+    // to override some essential virtual methods and implement them appropriately.
+    jassert (p != nullptr);
+    return p;
+}
+
+void ControllableProcessorBase::addParameterInternal (AudioProcessorParameter* param)
+{
+    param->processor = this;
+    param->parameterIndex = managedParameters.size();
+    managedParameters.add (param);
+
+#ifdef JUCE_DEBUG
+    shouldCheckParamsForDupeIDs = true;
+#endif
+}
+
+void ControllableProcessorBase::addParameter (AudioProcessorParameter* param)
+{
+    addParameterInternal (param);
+    parameterTree.addChild (std::unique_ptr<AudioProcessorParameter> (param));
+}
+
+void ControllableProcessorBase::addParameterGroup (std::unique_ptr<AudioProcessorParameterGroup> group)
+{
+    for (auto* param : group->getParameters (true))
+        addParameterInternal (param);
+
+    parameterTree.addChild (std::move (group));
+}
+
+const AudioProcessorParameterGroup& ControllableProcessorBase::getParameterTree()
+{
+    return parameterTree;
+}
+
+#ifdef JUCE_DEBUG
+void ControllableProcessorBase::checkForDupedParamIDs()
+{
+    if (shouldCheckParamsForDupeIDs)
+    {
+        shouldCheckParamsForDupeIDs = false;
+        StringArray ids;
+
+        for (auto p : managedParameters)
+            if (auto* withID = dynamic_cast<AudioProcessorParameterWithID*> (p))
+                ids.add (withID->paramID);
+
+        ids.sort (false);
+
+        for (int i = 1; i < ids.size(); ++i)
+        {
+            // This is triggered if you have two or more parameters with the same ID!
+            jassert (ids[i - 1] != ids[i]);
+        }
+    }
+}
+#endif
+
+} // namespace juce

--- a/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.h
+++ b/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.h
@@ -1,0 +1,396 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE library.
+   Copyright (c) 2017 - ROLI Ltd.
+
+   JUCE is an open source library subject to commercial or open-source
+   licensing.
+
+   By using JUCE, you agree to the terms of both the JUCE 5 End-User License
+   Agreement and JUCE 5 Privacy Policy (both updated and effective as of the
+   27th April 2017).
+
+   End User License Agreement: www.juce.com/juce-5-licence
+   Privacy Policy: www.juce.com/juce-5-privacy-policy
+
+   Or: You may also use this code under the terms of the GPL v3 (see
+   www.gnu.org/licenses).
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+class AudioProcessorParameter;
+class AudioProcessorParameterGroup;
+class AudioProcessorListener;
+class AudioProcessorEditor;
+
+//==============================================================================
+/** An abstract base class for processors, so an AudioProcessorValueTreeState can
+    be used to controll parameters.
+
+    @tags{Audio}
+*/
+class JUCE_API  ControllableProcessorBase
+{
+public:
+    ControllableProcessorBase();
+
+    /** Destructor. */
+    virtual ~ControllableProcessorBase();
+
+    /** Adds a parameter to the AudioProcessor.
+
+        The parameter object will be managed and deleted automatically by the
+        AudioProcessor when no longer needed.
+     */
+    virtual void addParameter (AudioProcessorParameter*);
+
+    /** Adds a group of parameters to the AudioProcessor.
+
+        All the parameter objects contained within the group will be managed and
+        deleted automatically by the AudioProcessor when no longer needed.
+
+     @see addParameter
+     */
+    virtual void addParameterGroup (std::unique_ptr<AudioProcessorParameterGroup>);
+
+    /** Returns the group of parameters managed by this AudioProcessor. */
+    virtual const AudioProcessorParameterGroup& getParameterTree();
+
+    /** Returns the current list of parameters. */
+    virtual const OwnedArray<AudioProcessorParameter>& getParameters() const noexcept;
+
+    //==============================================================================
+
+    /** The processor can call this when something (apart from a parameter value) has changed.
+
+        It sends a hint to the host that something like the program, number of parameters,
+        etc, has changed, and that it should update itself.
+     */
+    void updateHostDisplay();
+
+    /** Your processor can call this when it needs to change one of its parameters.
+
+        This could happen when the editor or some other internal operation changes
+        a parameter. This method will call the setParameter() method to change the
+        value, and will then send a message to the host telling it about the change.
+
+        Note that to make sure the host correctly handles automation, you should call
+        the beginParameterChangeGesture() and endParameterChangeGesture() methods to
+        tell the host when the user has started and stopped changing the parameter.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::setValueNotifyingHost() instead.
+     */
+    void setParameterNotifyingHost (int parameterIndex, float newValue);
+
+    //==============================================================================
+    /** Creates the processor's GUI.
+
+        This can return nullptr if you want a GUI-less processor, in which case the host
+        may create a generic UI that lets the user twiddle the parameters directly.
+
+        If you do want to pass back a component, the component should be created and set to
+        the correct size before returning it. If you implement this method, you must
+        also implement the hasEditor() method and make it return true.
+
+        Remember not to do anything silly like allowing your processor to keep a pointer to
+        the component that gets created - it could be deleted later without any warning, which
+        would make your pointer into a dangler. Use the getActiveEditor() method instead.
+
+        The correct way to handle the connection between an editor component and its
+        processor is to use something like a ChangeBroadcaster so that the editor can
+        register itself as a listener, and be told when a change occurs. This lets them
+        safely unregister themselves when they are deleted.
+
+        Here are a few things to bear in mind when writing an editor:
+
+        - Initially there won't be an editor, until the user opens one, or they might
+          not open one at all. Your processor mustn't rely on it being there.
+        - An editor object may be deleted and a replacement one created again at any time.
+        - It's safe to assume that an editor will be deleted before its processor.
+
+        @see hasEditor
+     */
+    virtual AudioProcessorEditor* createEditor() = 0;
+
+    /** Your processor subclass must override this and return true if it can create an
+        editor component.
+        @see createEditor
+     */
+    virtual bool hasEditor() const = 0;
+
+    /** Not for public use - this is called before deleting an editor component. */
+    void editorBeingDeleted (AudioProcessorEditor*) noexcept;
+
+    //==============================================================================
+    /** Returns the active editor, if there is one.
+        Bear in mind this can return nullptr, even if an editor has previously been opened.
+     */
+    AudioProcessorEditor* getActiveEditor() const noexcept           { return activeEditor; }
+
+    /** Returns the active editor, or if there isn't one, it will create one.
+        This may call createEditor() internally to create the component.
+     */
+    AudioProcessorEditor* createEditorIfNeeded();
+
+    /** Returns a lock, in case the editor creation needs to be synchronised with the
+        processing. The AudioProcessor will override this to use it's own callbackLock.
+     */
+    virtual const CriticalSection& getCallbackLock() const           { return callbackLock; }
+
+    //==============================================================================
+
+    /** This must return the correct value immediately after the object has been
+        created, and mustn't change the number of parameters later.
+
+        NOTE! This method is deprecated! It's recommended that you use the
+        AudioProcessorParameter class instead to manage your parameters.
+     */
+    JUCE_DEPRECATED (virtual int getNumParameters());
+
+    /** Returns the name of a particular parameter.
+
+        NOTE! This method is deprecated! It's recommended that you use the
+        AudioProcessorParameter class instead to manage your parameters.
+     */
+    JUCE_DEPRECATED (virtual const String getParameterName (int parameterIndex));
+
+    /** Returns the ID of a particular parameter.
+
+        The ID is used to communicate the value or mapping of a particular parameter with
+        the host. By default this method will simply return a string representation of
+        index.
+
+        NOTE! This method is deprecated! It's recommended that you use the
+        AudioProcessorParameterWithID class instead to manage your parameters.
+     */
+    JUCE_DEPRECATED (virtual String getParameterID (int index));
+
+    /** Called by the host to find out the value of one of the processor's parameters.
+
+        The host will expect the value returned to be between 0 and 1.0.
+
+        This could be called quite frequently, so try to make your code efficient.
+        It's also likely to be called by non-UI threads, so the code in here should
+        be thread-aware.
+
+        NOTE! This method is deprecated! It's recommended that you use the
+        AudioProcessorParameter class instead to manage your parameters.
+     */
+    JUCE_DEPRECATED (virtual float getParameter (int parameterIndex));
+
+    /** Returns the name of a parameter as a text string with a preferred maximum length.
+        If you want to provide customised short versions of your parameter names that
+        will look better in constrained spaces (e.g. the displays on hardware controller
+        devices or mixing desks) then you should implement this method.
+        If you don't override it, the default implementation will call getParameterName(int),
+        and truncate the result.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getName() instead.
+     */
+    JUCE_DEPRECATED (virtual String getParameterName (int parameterIndex, int maximumStringLength));
+
+    /** Returns the value of a parameter as a text string.
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getText() instead.
+     */
+    JUCE_DEPRECATED (virtual const String getParameterText (int parameterIndex));
+
+    /** Returns the value of a parameter as a text string with a preferred maximum length.
+        If you want to provide customised short versions of your parameter values that
+        will look better in constrained spaces (e.g. the displays on hardware controller
+        devices or mixing desks) then you should implement this method.
+        If you don't override it, the default implementation will call getParameterText(int),
+        and truncate the result.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getText() instead.
+     */
+    JUCE_DEPRECATED (virtual String getParameterText (int parameterIndex, int maximumStringLength));
+
+    /** Returns the number of discrete steps that this parameter can represent.
+
+        The default return value if you don't implement this method is
+        AudioProcessor::getDefaultNumParameterSteps().
+
+        If your parameter is boolean, then you may want to make this return 2.
+
+        If you want the host to display stepped automation values, rather than a
+        continuous interpolation between successive values, you should ensure that
+        isParameterDiscrete returns true.
+
+        The value that is returned may or may not be used, depending on the host.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getNumSteps() instead.
+
+        @see isParameterDiscrete
+     */
+    JUCE_DEPRECATED (virtual int getParameterNumSteps (int parameterIndex));
+
+    /** Returns the default number of steps for a parameter.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getNumSteps() instead.
+
+        @see getParameterNumSteps
+     */
+    static int getDefaultNumParameterSteps() noexcept;
+
+    /** Returns true if the parameter should take discrete, rather than continuous
+        values.
+
+        If the parameter is boolean, this should return true (with getParameterNumSteps
+        returning 2).
+
+        The value that is returned may or may not be used, depending on the host.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::isDiscrete() instead.
+
+        @see getParameterNumSteps
+     */
+    JUCE_DEPRECATED (virtual bool isParameterDiscrete (int parameterIndex) const);
+
+    /** Returns the default value for the parameter.
+        By default, this just returns 0.
+        The value that is returned may or may not be used, depending on the host.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getDefaultValue() instead.
+     */
+    JUCE_DEPRECATED (virtual float getParameterDefaultValue (int parameterIndex));
+
+    /** Some plugin types may be able to return a label string for a
+        parameter's units.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getLabel() instead.
+     */
+    JUCE_DEPRECATED (virtual String getParameterLabel (int index) const);
+
+    /** This can be overridden to tell the host that particular parameters operate in the
+        reverse direction. (Not all plugin formats or hosts will actually use this information).
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::isOrientationInverted() instead.
+     */
+    JUCE_DEPRECATED (virtual bool isParameterOrientationInverted (int index) const);
+
+    /** The host will call this method to change the value of one of the processor's parameters.
+
+        The host may call this at any time, including during the audio processing
+        callback, so the processor has to process this very fast and avoid blocking.
+
+        If you want to set the value of a parameter internally, e.g. from your
+        editor component, then don't call this directly - instead, use the
+        setParameterNotifyingHost() method, which will also send a message to
+        the host telling it about the change. If the message isn't sent, the host
+        won't be able to automate your parameters properly.
+
+        The value passed will be between 0 and 1.0.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::setValue() instead.
+     */
+    JUCE_DEPRECATED (virtual void setParameter (int parameterIndex, float newValue));
+
+    /** Returns true if the host can automate this parameter.
+        By default, this returns true for all parameters.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::isAutomatable() instead.
+     */
+    JUCE_DEPRECATED (virtual bool isParameterAutomatable (int parameterIndex) const);
+
+    /** Should return true if this parameter is a "meta" parameter.
+        A meta-parameter is a parameter that changes other params. It is used
+        by some hosts (e.g. AudioUnit hosts).
+        By default this returns false.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::isMetaParameter() instead.
+     */
+    JUCE_DEPRECATED (virtual bool isMetaParameter (int parameterIndex) const);
+
+    /** Should return the parameter's category.
+        By default, this returns the "generic" category.
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::getCategory() instead.
+     */
+    JUCE_DEPRECATED (virtual AudioProcessorParameter::Category getParameterCategory (int parameterIndex) const);
+
+    /** Sends a signal to the host to tell it that the user is about to start changing this
+        parameter.
+
+        This allows the host to know when a parameter is actively being held by the user, and
+        it may use this information to help it record automation.
+
+        If you call this, it must be matched by a later call to endParameterChangeGesture().
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::beginChangeGesture() instead.
+     */
+    JUCE_DEPRECATED (void beginParameterChangeGesture (int parameterIndex));
+
+    /** Tells the host that the user has finished changing this parameter.
+
+        This allows the host to know when a parameter is actively being held by the user, and
+        it may use this information to help it record automation.
+
+        A call to this method must follow a call to beginParameterChangeGesture().
+
+        NOTE! This method is deprecated! It's recommended that you use
+        AudioProcessorParameter::endChangeGesture() instead.
+     */
+    JUCE_DEPRECATED (void endParameterChangeGesture (int parameterIndex));
+
+    /** @internal */
+    virtual void sendParamChangeMessageToListeners (int parameterIndex, float newValue) {}
+
+    /** @internal */
+    virtual void sendParamChangeGestureBeginToListeners (int parameterIndex) {}
+
+    /** @internal */
+    virtual void sendParamChangeGestureEndToListeners (int parameterIndex) {}
+
+private:
+    //==============================================================================
+    void addParameterInternal (AudioProcessorParameter*);
+
+    AudioProcessorParameter* getParamChecked (int) const noexcept;
+
+
+#if JUCE_DEBUG
+    bool textRecursionCheck = false;
+    bool shouldCheckParamsForDupeIDs = false;
+    void checkForDupedParamIDs();
+#endif
+
+    AudioProcessorParameterGroup parameterTree { {}, {}, {} };
+
+    OwnedArray<AudioProcessorParameter> managedParameters;
+
+#if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
+    BigInteger changingParams;
+#endif
+
+    CriticalSection callbackLock;
+
+    Component::SafePointer<AudioProcessorEditor> activeEditor;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ControllableProcessorBase)
+};
+
+} // namespace juce

--- a/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.h
+++ b/modules/juce_audio_processors/processors/juce_ControllableProcessorBase.h
@@ -46,6 +46,20 @@ public:
     /** Destructor. */
     virtual ~ControllableProcessorBase();
 
+    //==============================================================================
+    /** Returns the name of this processor. */
+    virtual const String getName() const = 0;
+
+    /** Returns a list of alternative names to use for this processor.
+
+        Some hosts truncate the name of your AudioProcessor when there isn't enough
+        space in the GUI to show the full name. Overriding this method, allows the host
+        to choose an alternative name (such as an abbreviation) to better fit the
+        available space.
+     */
+    virtual StringArray getAlternateDisplayNames() const;
+
+    //==============================================================================
     /** Adds a parameter to the AudioProcessor.
 
         The parameter object will be managed and deleted automatically by the

--- a/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
+++ b/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
@@ -511,7 +511,7 @@ struct GenericAudioProcessorEditor::Pimpl
     Pimpl (GenericAudioProcessorEditor& parent)
         : owner (parent)
     {
-        auto* p = parent.getAudioProcessor();
+        auto* p = dynamic_cast<AudioProcessor*> (parent.getAudioProcessor());
         jassert (p != nullptr);
 
         juceParameters.update (*p, false);

--- a/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
+++ b/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.cpp
@@ -535,7 +535,7 @@ struct GenericAudioProcessorEditor::Pimpl
 
 
 //==============================================================================
-GenericAudioProcessorEditor::GenericAudioProcessorEditor (AudioProcessor* const p)
+GenericAudioProcessorEditor::GenericAudioProcessorEditor (ControllableProcessorBase* const p)
     : AudioProcessorEditor (p), pimpl (new Pimpl (*this))
 {
     setSize (pimpl->view.getViewedComponent()->getWidth() + pimpl->view.getVerticalScrollBar().getWidth(),

--- a/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.h
+++ b/modules/juce_audio_processors/processors/juce_GenericAudioProcessorEditor.h
@@ -43,7 +43,7 @@ class JUCE_API  GenericAudioProcessorEditor      : public AudioProcessorEditor
 {
 public:
     //==============================================================================
-    GenericAudioProcessorEditor (AudioProcessor* owner);
+    GenericAudioProcessorEditor (ControllableProcessorBase* owner);
     ~GenericAudioProcessorEditor() override;
 
     //==============================================================================

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
@@ -180,7 +180,7 @@ private:
 };
 
 //==============================================================================
-AudioProcessorValueTreeState::AudioProcessorValueTreeState (AudioProcessor& processorToConnectTo,
+AudioProcessorValueTreeState::AudioProcessorValueTreeState (ControllableProcessorBase& processorToConnectTo,
                                                             UndoManager* undoManagerToUse,
                                                             const Identifier& valueTreeType,
                                                             ParameterLayout parameterLayout)
@@ -237,7 +237,7 @@ AudioProcessorValueTreeState::AudioProcessorValueTreeState (AudioProcessor& proc
     state = ValueTree (valueTreeType);
 }
 
-AudioProcessorValueTreeState::AudioProcessorValueTreeState (AudioProcessor& p, UndoManager* um)
+AudioProcessorValueTreeState::AudioProcessorValueTreeState (ControllableProcessorBase& p, UndoManager* um)
     : processor (p), undoManager (um)
 {
     startTimerHz (10);

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
@@ -202,7 +202,7 @@ public:
         @param parameterLayout          An object that holds all parameters and parameter groups that the
                                         AudioProcessor should use.
     */
-    AudioProcessorValueTreeState (AudioProcessor& processorToConnectTo,
+    AudioProcessorValueTreeState (ControllableProcessorBase& processorToConnectTo,
                                   UndoManager* undoManagerToUse,
                                   const Identifier& valueTreeType,
                                   ParameterLayout parameterLayout);
@@ -217,7 +217,7 @@ public:
         AudioProcessorValueTreeState should be attached to only one processor, and must have
         the same lifetime as the processor, as they will have dependencies on each other.
     */
-    AudioProcessorValueTreeState (AudioProcessor& processorToConnectTo, UndoManager* undoManagerToUse);
+    AudioProcessorValueTreeState (ControllableProcessorBase& processorToConnectTo, UndoManager* undoManagerToUse);
 
     /** Destructor. */
     ~AudioProcessorValueTreeState() override;
@@ -347,7 +347,7 @@ public:
 
     //==============================================================================
     /** A reference to the processor with which this state is associated. */
-    AudioProcessor& processor;
+    ControllableProcessorBase& processor;
 
     /** The state of the whole processor.
 


### PR DESCRIPTION
In order to control other Processors in a processing pipeline, a separate interface is needed, so the AudioProcessorParameters, the AudioProcessorValueTreeState and the GenericAudioProcessorEditor can be used. A use case is e.g. a VideoProcessor in a NLE.

This PR adds this base `ControllableProcessorBase` and moves all addParameter etc. functionality into this bae.
The AudioProcessorParameter was changed to use the interface of ControllableProcessorBase instead of AudioProcessor.
The GenericAudioProcessorEditor uses the LegacyAudioParameter and the AudioProcessorListener, so it remains unchanged (but intact of course). A new GenericProcessorEditor will be added later, that will only use the new interface of AudioProcessorParameter and AudioParameterGroup as well.

If wished, the names AudioProcessorParameter and AudioProcessorValueTreeState could be changed for consistency to ProcessorParameter and ProcessorValueTreeState and an alias provided with the old names.

Disclaimer: all copyright of this PR is hereby waived to JUCE and its legal owners.