### PR TITLE
Add continuous sample position to CurrentPositionInfo.

### DIFF
--- a/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
+++ b/modules/juce_audio_basics/audio_play_head/juce_AudioPlayHead.h
@@ -81,6 +81,13 @@ public:
         /** For timecode, the position of the start of the timeline, in seconds from 00:00:00:00. */
         double editOriginTime;
 
+        /** The current play position, in samples from the start of processing.
+            Without looping.
+            Note - this value may be unavailable on some hosts.
+            @see isContinuousValid.
+         */
+        int64 continuousTimeInSamples;
+
         /** The current play position, in units of quarter-notes. */
         double ppqPosition;
 
@@ -120,6 +127,9 @@ public:
 
         /** True if the transport is currently looping. */
         bool isLooping;
+
+        /** True if the continuous time is valid/supported. */
+        bool isContinuousValid;
 
         //==============================================================================
         bool operator== (const CurrentPositionInfo& other) const noexcept;

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -2085,8 +2085,14 @@ public:
         info.isRecording                = (processContext.state & Vst::ProcessContext::kRecording) != 0;
         info.isPlaying                  = (processContext.state & Vst::ProcessContext::kPlaying) != 0;
         info.isLooping                  = (processContext.state & Vst::ProcessContext::kCycleActive) != 0;
+        info.isContinuousValid          = (processContext.state & Vst::ProcessContext::kContTimeValid) != 0;
         info.editOriginTime             = 0.0;
         info.frameRate                  = AudioPlayHead::fpsUnknown;
+
+        if (info.isContinuousValid)
+        {
+            info.continuousTimeInSamples = jmax ((juce::int64) 0, processContext.continousTimeSamples);
+        }
 
         if ((processContext.state & Vst::ProcessContext::kSmpteValid) != 0)
         {


### PR DESCRIPTION
Rationale: for syncing multiple plug-in instances especially when host is looping. this way you know absolute sample position from start.
(while looping or user changing playhead cannot identify continuity loss which might be mandatory for some processing concepts).