### PR TITLE
Fix a potential X11 BadWindow error

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
@@ -1500,6 +1500,9 @@ public:
         ScopedXLock xlock (display);
         XGetInputFocus (display, &focusedWindow, &revert);
 
+        if (focusedWindow == PointerRoot)
+            return false;
+
         return isParentWindowOf (focusedWindow);
     }
 


### PR DESCRIPTION
Hi, this fixes a somewhat rare X window error which may crash plugin and host.

The Xlib function [XGetInputFocus](https://tronche.com/gui/x/xlib/input/XGetInputFocus.html) may return the special result `PointerRoot` which is neither 0 not a valid Window ID.
When this is passed to `XQueryTree` by the function call `isParentWindowOf` following, it will raise the error, so it's necessary to take special care this particular case.