### PR TITLE
Remove message manager lock assert from AudioThumbnail::setDataSource

### DIFF
--- a/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp
+++ b/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp
@@ -642,8 +642,6 @@ void AudioThumbnail::saveTo (OutputStream& output) const
 //==============================================================================
 bool AudioThumbnail::setDataSource (LevelDataSource* newSource)
 {
-    JUCE_ASSERT_MESSAGE_MANAGER_IS_LOCKED
-
     numSamplesFinished = 0;
     auto wasSuccessful = [&] { return sampleRate > 0 && totalSamples > 0; };
 


### PR DESCRIPTION
Digging though the commit history didn't show any reason why this should exist. Reading the code didn't readily indicate any reason it should exist.  It's existence meant I couldn't _cleanly_ make my thumbnails in a separate thread.  So I've been running with the scissors and have removed it from my own copy.

Forum post located at https://forum.juce.com/t/why-does-audiothumbnail-setdatasource-need-the-message-manager-locked/34023