### PR TITLE
trigger check for external drag when JUCE is no longer the foreground…

### DIFF
--- a/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp
+++ b/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp
@@ -156,7 +156,7 @@ public:
         {
             auto now = Time::getCurrentTime();
 
-            if (getCurrentlyOver() != nullptr)
+            if (getCurrentlyOver () != nullptr &&  Process::isForegroundProcess ())
                 lastTimeOverTarget = now;
             else if (now > lastTimeOverTarget + RelativeTime::milliseconds (700))
                 checkForExternalDrag (details, screenPos);


### PR DESCRIPTION
see: https://forum.juce.com/t/switch-to-external-drag-and-drop-issue-on-mac-suggested-fix/34120
