### PR TITLE
add setBlockingState in read function, like DatagramSocket read function

### DIFF
--- a/modules/juce_core/network/juce_Socket.cpp
+++ b/modules/juce_core/network/juce_Socket.cpp
@@ -460,6 +460,7 @@ StreamingSocket::~StreamingSocket()
 //==============================================================================
 int StreamingSocket::read (void* destBuffer, int maxBytesToRead, bool shouldBlock)
 {
+	SocketHelpers::setSocketBlockingState(handle, shouldBlock);
     return (connected && ! isListener) ? SocketHelpers::readSocket (handle, destBuffer, maxBytesToRead,
                                                                     connected, shouldBlock, readLock)
                                        : -1;


### PR DESCRIPTION
When doing a read() on a StreamingSocket with shouldBlock set to false, it will still be blocking : the debug becomes untraceable at juce_Socket.cpp line 213 (goes to native code I guess) :

``` bytesThisTime = ::recv (handle, buffer, numToRead, 0) ```

 but the code won't process until at least one byte is received.

A post on the forum suggest this modification and it works, maybe not the best but as it is used the same in DatagramSocket, I guess it's not that bad.

i'm on Win10 x64