### PR TITLE
Linux: fix scaling factor computation

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
@@ -962,7 +962,7 @@ static double getScaleForDisplay (const String& name, double dpi)
     // If no scale factor is set by GNOME or Ubuntu then calculate from monitor dpi
     // We use the same approach as chromium which simply divides the dpi by 96
     // and then rounds the result
-    return round (dpi / 150.0);
+    return round (dpi / 96.0);
 }
 
 //=============================== X11 - Pixmap =================================


### PR DESCRIPTION
Correcting the constant value from 150 to 96, as mentioned in the comment, was enough for me to get the resolution fixed on a HiDPI screen.