### PR TITLE
fixes delivery of UTF-8 encoded strings via OSC

### DIFF
--- a/modules/juce_osc/osc/juce_OSCSender.cpp
+++ b/modules/juce_osc/osc/juce_OSCSender.cpp
@@ -69,7 +69,7 @@ namespace
             if (! output.writeString (value))
                 return false;
 
-            const size_t numPaddingZeros = ~value.length() & 3;
+            const size_t numPaddingZeros = ~value.getNumBytesAsUTF8() & 3;
 
             return output.writeRepeatedByte ('\0', numPaddingZeros);
         }


### PR DESCRIPTION
When sending strings via OSC that contain non-ASCII characters, "OSC input stream format error: missing padding zeros" was thrown in the OSCReceiver. This patch fixes this problem.