### PR TITLE
Added float CallOutBox::LookAndFeelMethods::getCallOutBoxCornerSize(c…

### DIFF
--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -2513,6 +2513,11 @@ int LookAndFeel_V2::getCallOutBoxBorderSize (const CallOutBox&)
     return 20;
 }
 
+float LookAndFeel_V2::getCallOutBoxCornerSize (const CallOutBox&)
+{
+    return 9.0f;
+}
+
 //==============================================================================
 AttributedString LookAndFeel_V2::createFileChooserHeaderText (const String& title,
                                                            const String& instructions)

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
@@ -327,6 +327,7 @@ public:
     //==============================================================================
     void drawCallOutBoxBackground (CallOutBox&, Graphics&, const Path& path, Image& cachedImage) override;
     int getCallOutBoxBorderSize (const CallOutBox&) override;
+    float getCallOutBoxCornerSize (const CallOutBox&) override;
 
     //==============================================================================
     void drawLevelMeter (Graphics&, int width, int height, float level) override;

--- a/modules/juce_gui_basics/windows/juce_CallOutBox.cpp
+++ b/modules/juce_gui_basics/windows/juce_CallOutBox.cpp
@@ -254,7 +254,7 @@ void CallOutBox::refreshPath()
     outline.addBubble (content.getBounds().toFloat().expanded (gap, gap),
                        getLocalBounds().toFloat(),
                        targetPoint - getPosition().toFloat(),
-                       9.0f, arrowSize * 0.7f);
+                       getLookAndFeel().getCallOutBoxCornerSize(*this), arrowSize * 0.7f);
 }
 
 void CallOutBox::timerCallback()

--- a/modules/juce_gui_basics/windows/juce_CallOutBox.h
+++ b/modules/juce_gui_basics/windows/juce_CallOutBox.h
@@ -145,6 +145,7 @@ public:
 
         virtual void drawCallOutBoxBackground (CallOutBox&, Graphics&, const Path&, Image&) = 0;
         virtual int getCallOutBoxBorderSize (const CallOutBox&) = 0;
+        virtual float getCallOutBoxCornerSize (const CallOutBox&) = 0;
     };
 
     //==============================================================================


### PR DESCRIPTION
…onst CallOutBox&) so that the corner radius of the CallOutBox bubble can be customised and an implementation in LookAndFeel_V2 that preserves the current behaviour.