### PR TITLE
Some AUv3 plugins seems to register but ignore the kAudioUnitProperty…

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1010,6 +1010,10 @@ public:
         if (auSupportsBypass)
         {
             updateBypass (processBlockBypassedCalled);
+            if (processBlockBypassedCalled)
+            {
+                return;
+            }
         }
         else if (processBlockBypassedCalled)
         {


### PR DESCRIPTION
Hello,

I have noticed that, when hosting AUv3's, some plugins ignore the state of the  `kAudioUnitProperty_BypassEffect` `AUParameter`. This causes these plugin to still process audio even though they should bypass.

A very simple workaround would be to return right after the `AUParameter` is updated through `updateBypass`, just like plugins that don't register or support the `kAudioUnitProperty_BypassEffect` parameter.

The updated code looks like this (`develop` branch)
```
        if (auSupportsBypass)
        {
            updateBypass (processBlockBypassedCalled);
            if (processBlockBypassedCalled)
            {
                return;
            }
        }
```

Cheers,
Mathieu.