### PR TITLE
Make isListener atomic

### DIFF
--- a/modules/juce_core/network/juce_Socket.h
+++ b/modules/juce_core/network/juce_Socket.h
@@ -181,7 +181,7 @@ private:
     String hostName;
     std::atomic<int> portNumber { 0 }, handle { -1 };
     std::atomic<bool> connected { false };
-    bool isListener = false;
+    std::atomic<bool> isListener = false;
     mutable CriticalSection readLock;
 
     StreamingSocket (const String& hostname, int portNumber, int handle);


### PR DESCRIPTION
isListener could be modified by:

StreamingSocket::close()
InterprocessConnectionServer::stop()

and read by:

StreamingSocket::waitForNextConnection()
InterprocessConnectionServer::run()