### PR TITLE
add disableDefaultMouseEvents flag in juce_Component

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -1338,6 +1338,16 @@ void Component::getInterceptsMouseClicks (bool& allowsClicksOnThisComponent,
     allowsClicksOnChildComponents = flags.allowChildMouseClicksFlag;
 }
 
+void Component::setDisableDefaultMouseEvents(bool value) noexcept
+{
+	flags.disableDefaultMouseEvents = value;
+}
+
+bool Component::getDisableDefaultMouseEvents() const noexcept
+{
+	return (bool)flags.disableDefaultMouseEvents;
+}
+
 bool Component::contains (Point<int> point)
 {
     if (ComponentHelpers::hitTest (*this, point))
@@ -2313,7 +2323,7 @@ void Component::internalMouseEnter (MouseInputSource source, Point<float> relati
                          MouseInputSource::invalidOrientation, MouseInputSource::invalidRotation,
                          MouseInputSource::invalidTiltX, MouseInputSource::invalidTiltY,
                          this, this, time, relativePos, time, 0, false);
-    mouseEnter (me);
+	if (!flags.disableDefaultMouseEvents) mouseEnter (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2342,7 +2352,7 @@ void Component::internalMouseExit (MouseInputSource source, Point<float> relativ
                          MouseInputSource::invalidTiltX, MouseInputSource::invalidTiltY,
                          this, this, time, relativePos, time, 0, false);
 
-    mouseExit (me);
+	if (!flags.disableDefaultMouseEvents) mouseExit (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2407,7 +2417,7 @@ void Component::internalMouseDown (MouseInputSource source, Point<float> relativ
     const MouseEvent me (source, relativePos, source.getCurrentModifiers(), pressure,
                          orientation, rotation, tiltX, tiltY, this, this, time, relativePos,
                          time, source.getNumberOfMultipleClicks(), false);
-    mouseDown (me);
+    if(!flags.disableDefaultMouseEvents) mouseDown (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2434,7 +2444,7 @@ void Component::internalMouseUp (MouseInputSource source, Point<float> relativeP
                          source.getLastMouseDownTime(),
                          source.getNumberOfMultipleClicks(),
                          source.isLongPressOrDrag());
-    mouseUp (me);
+	if (!flags.disableDefaultMouseEvents) mouseUp (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2450,7 +2460,7 @@ void Component::internalMouseUp (MouseInputSource source, Point<float> relativeP
     // check for double-click
     if (me.getNumberOfClicks() >= 2)
     {
-        mouseDoubleClick (me);
+		if (!flags.disableDefaultMouseEvents) mouseDoubleClick (me);
 
         if (checker.shouldBailOut())
             return;
@@ -2473,7 +2483,7 @@ void Component::internalMouseDrag (MouseInputSource source, Point<float> relativ
                              source.getLastMouseDownTime(),
                              source.getNumberOfMultipleClicks(),
                              source.isLongPressOrDrag());
-        mouseDrag (me);
+		if (!flags.disableDefaultMouseEvents) mouseDrag (me);
 
         if (checker.shouldBailOut())
             return;
@@ -2501,7 +2511,7 @@ void Component::internalMouseMove (MouseInputSource source, Point<float> relativ
                              MouseInputSource::invalidOrientation, MouseInputSource::invalidRotation,
                              MouseInputSource::invalidTiltX, MouseInputSource::invalidTiltY,
                              this, this, time, relativePos, time, 0, false);
-        mouseMove (me);
+		if (!flags.disableDefaultMouseEvents) mouseMove (me);
 
         if (checker.shouldBailOut())
             return;
@@ -2530,7 +2540,7 @@ void Component::internalMouseWheel (MouseInputSource source, Point<float> relati
     }
     else
     {
-        mouseWheelMove (me, wheel);
+		if (!flags.disableDefaultMouseEvents) mouseWheelMove (me, wheel);
 
         if (checker.shouldBailOut())
             return;

--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -901,6 +901,29 @@ public:
                                    bool& allowsClicksOnChildComponents) const noexcept;
 
 
+	/** Changes the default behaviour with mouse events
+
+	  Setting this to true disables sending mouseEnter(), mouseExit(), mouseDown(), mouseUp(), mouseDrag()... events.
+	  It is useful when using addMouseListener(this, true) from the same component, to prevent sending mouse event twice.
+
+	  When a component is created, the default setting for this is false.
+
+	  @param value   if true, mouse events will not be passed straight away, only mouseListeners will be called
+
+	  @see hitTest, getDisableDefaultMouseEvents
+  */
+	void setDisableDefaultMouseEvents(bool value) noexcept;
+
+	/** Retrieves the current state of the disableDefaultMouseEvent flag.
+
+		On return, the value is set to the state used in the last call to
+		setDisableDefaultMouseEvents()
+
+		@see setDisableDefaultMouseEvents
+	*/
+	bool getDisableDefaultMouseEvents() const noexcept;
+
+
     /** Returns true if a given point lies within this component or one of its children.
 
         Never override this method! Use hitTest to create custom hit regions.
@@ -912,6 +935,7 @@ public:
                     which might be in the way - for that, see reallyContains()
         @see hitTest, reallyContains, getComponentAt
     */
+
     bool contains (Point<int> localPoint);
 
     /** Returns true if a given point lies in this component, taking any overlapping
@@ -2317,6 +2341,7 @@ private:
        #if JUCE_DEBUG
         bool isInsidePaintCall          : 1;
        #endif
+		bool disableDefaultMouseEvents	: 1;
     };
 
     union


### PR DESCRIPTION
This allows to use only mouseListeners as trigger for mouseEnter(), mouseExit().. callbacks.
This is especially useful when doing on a component addMouseListener(this,true) to itself.
The default behaviour is that this component will get mouse events from children and from himself through listeners, but will also have the event triggered from internalMouseEnter(), internalMouseExit()...
this flags allows to disable the this internal call and only relies on mouseListener, effectively getting only one event for this component as well as its children.