### PR TITLE
fix infinite loop bug

### DIFF
--- a/modules/juce_core/juce_core.h
+++ b/modules/juce_core/juce_core.h
@@ -214,6 +214,7 @@ namespace juce
 
     extern JUCE_API bool JUCE_CALLTYPE juce_isRunningUnderDebugger() noexcept;
     extern JUCE_API void JUCE_CALLTYPE logAssertion (const char* file, int line) noexcept;
+    extern JUCE_API void JUCE_CALLTYPE logAssertion (const wchar_t* file, int line) noexcept;
 }
 
 #include "memory/juce_Memory.h"

--- a/modules/juce_core/logging/juce_Logger.cpp
+++ b/modules/juce_core/logging/juce_Logger.cpp
@@ -57,6 +57,17 @@ void JUCE_API JUCE_CALLTYPE logAssertion (const char* const filename, const int 
     DBG (m);
    #endif
 }
+void JUCE_API JUCE_CALLTYPE logAssertion(const wchar_t* const filename, const int lineNum) noexcept
+{
+	String m("JUCE Assertion failure in ");
+	m << File::createFileWithoutCheckingPath(filename).getFileName() << ':' << lineNum;
+
+#if JUCE_LOG_ASSERTIONS
+	Logger::writeToLog(m);
+#else
+	DBG(m);
+#endif
+}
 #endif
 
 } // namespace juce

--- a/modules/juce_core/system/juce_PlatformDefs.h
+++ b/modules/juce_core/system/juce_PlatformDefs.h
@@ -48,9 +48,12 @@ namespace juce
 //==============================================================================
 // Debugging and assertion macros
 
+#define JUCE_LOG_WIDE_STR_EXPRESSION(exp) L ## exp 
+#define JUCE_LOG_WIDE_STR(exp) JUCE_LOG_WIDE_STR_EXPRESSION(exp)
+
 #ifndef JUCE_LOG_CURRENT_ASSERTION
  #if JUCE_LOG_ASSERTIONS || JUCE_DEBUG
-  #define JUCE_LOG_CURRENT_ASSERTION    juce::logAssertion (__FILE__, __LINE__);
+  #define JUCE_LOG_CURRENT_ASSERTION    juce::logAssertion (JUCE_LOG_WIDE_STR(__FILE__), __LINE__);
  #else
   #define JUCE_LOG_CURRENT_ASSERTION
  #endif


### PR DESCRIPTION
# problem
If the path containing the JUCE source code contains non-ASCII characters (such as Japanese), juce::logAssertion is called recursively to exhaust the stack.
Example: `C:\ジュース\JUCE\  <-JUCE Directory`

# Cause
1. jassertfalse is called
2. `juce::logAssertion(__ FILE__, __LINE__)` is called inside jassertfalse
3. Convert `__FILE__` to `juce::String` type inside `juce::logAssertion`
4. At this time, among the multiple `juce::String` constructors, the one whose argument is `(const char * const t)` is executed
5. Inside this constructor, if the argument t contains non-ASCII characters, jassert will be called
6. JAsert is called because the file path of JUCE contains non-ASCII characters
7. jassert is called inside jassert
8. Back to 2 (infinite loop)

# How to reproduce
1. Place the JUCE source code in a path that contains non-ASCII characters.

Example: `C:\あああ\JUCE`

2. Create a new console application using that JUCE.
3. Add the following line in the main function of the application.

`new juce::String("🐸");`

4. Run the created application in Debug mode.  <- Where `juce::logAssertion` causes an infinite loop

# Beginning of things
The Windows home directory name will automatically use the Microsoft account's real name.
This problem occurs when placing JUCE source code on the home directory.
This issue is important for people with non-ASCII characters in their names, such as Asia.