### PR TITLE
Feature/fix clamping of image convolution kernel

### DIFF
--- a/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp
+++ b/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp
@@ -239,9 +239,9 @@ void ImageConvolutionKernel::applyToImage (Image& destImage,
                     }
                 }
 
-                *dest++ = (uint8) roundToInt (c1);
-                *dest++ = (uint8) roundToInt (c2);
-                *dest++ = (uint8) roundToInt (c3);
+                *dest++ = (uint8) jmin (0xff, roundToInt (c1));
+                *dest++ = (uint8) jmin (0xff, roundToInt (c2));
+                *dest++ = (uint8) jmin (0xff, roundToInt (c3));
             }
         }
     }
@@ -288,7 +288,7 @@ void ImageConvolutionKernel::applyToImage (Image& destImage,
                     }
                 }
 
-                *dest++ = (uint8) roundToInt (c1);
+                *dest++ = (uint8) jmin (0xff, roundToInt (c1));
             }
         }
     }

--- a/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp
+++ b/modules/juce_graphics/images/juce_ImageConvolutionKernel.cpp
@@ -177,7 +177,7 @@ void ImageConvolutionKernel::applyToImage (Image& destImage,
                             }
                             else
                             {
-                                src += 4;
+                                src += destData.pixelStride;
                             }
 
                             ++sx;
@@ -231,7 +231,7 @@ void ImageConvolutionKernel::applyToImage (Image& destImage,
                             }
                             else
                             {
-                                src += 3;
+                                src += destData.pixelStride;
                             }
 
                             ++sx;
@@ -280,7 +280,7 @@ void ImageConvolutionKernel::applyToImage (Image& destImage,
                             }
                             else
                             {
-                                src += 3;
+                                src += destData.pixelStride;
                             }
 
                             ++sx;


### PR DESCRIPTION
@julianstorer 
1.) a wrong pixel stride was used for single channel images
2.) The RGB and SingleChannel versions of the filter did not properly clip the output resulting in display artefacts.