### PR TITLE
Added static assert to check if FloatType is really a float

### DIFF
--- a/modules/juce_core/maths/juce_MathsFunctions.h
+++ b/modules/juce_core/maths/juce_MathsFunctions.h
@@ -336,6 +336,9 @@ inline float juce_hypot (float a, float b) noexcept
 template <typename FloatType>
 struct MathConstants
 {
+    // if you hit this, you're probably accidentally passing an integer to a function like degreesToRadians() which would result in degraded output.
+    static_assert(!std::is_integral<FloatType>::value, "FloatType cannot be an integer");
+
     /** A predefined value for Pi */
     static constexpr FloatType pi = static_cast<FloatType> (3.141592653589793238L);
 


### PR DESCRIPTION
(not an int actually - to allow usage with Fixed Point types) - this is to prevent accidental precision loss when users pass integers to function like degreesToRadians()

see https://forum.juce.com/t/fr-add-static-assert-to-degreestoradians-and-radianstodegrees-to-check-if-floattype-is-indeed-a-floating-point-type/34629/2