### PR TITLE
Fixes inefficient repainting on iOS.

### DIFF
--- a/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
@@ -326,6 +326,8 @@ private:
                 peer->repaint (rect);
         }
     };
+    
+    RectangleList<int> dirtyRects;
 };
 
 static void sendScreenBoundsUpdate (JuceUIViewController* c)
@@ -1042,6 +1044,8 @@ void UIViewComponentPeer::drawRect (CGRect r)
     // NB the CTM on iOS already includes a factor for the display scale, so
     // we'll tell the context that the scale is 1.0 to avoid it using it twice
     CoreGraphicsContext g (cg, getComponent().getHeight(), 1.0f);
+    g.clipToRectangleList(dirtyRects);
+    dirtyRects.clear();
 
     insideDrawRect = true;
     handlePaint (g);
@@ -1095,6 +1099,8 @@ void Desktop::allowedOrientationsChanged()
 //==============================================================================
 void UIViewComponentPeer::repaint (const Rectangle<int>& area)
 {
+    dirtyRects.add(area);
+    
     if (insideDrawRect || ! MessageManager::getInstance()->isThisTheMessageThread())
         (new AsyncRepaintMessage (this, area))->post();
     else


### PR DESCRIPTION
CGContextGetClipBoundingBox() does NOT return the area requested by "[view setNeedsDisplayInRect ...]". This commit implements handling of our own dirty rect list to rectify this problem.

Also see https://forum.juce.com/t/solved-repaint-ignores-opacity-and-repaints-parent-component/33711/16 