### PR TITLE
Implemented caching of components to an CGImageContext

### DIFF
--- a/modules/juce_gui_basics/juce_gui_basics.h
+++ b/modules/juce_gui_basics/juce_gui_basics.h
@@ -118,6 +118,18 @@
  #define JUCE_WIN_PER_MONITOR_DPI_AWARE 1
 #endif
 
+/** Config: JUCE_ENABLE_IOS_REPAINT_CACHE
+ If this option is turned on, Components will be painted into a bitmap context on iOS
+ and only the portions requested by repaint() will be repainted (instead of everything!).
+ If this option is off, all components are repainted regardless the rectangle passed to
+ repaint(). Enabling this option can significantly speed up drawing if you're doing CPU
+ intensive things in your paint() calls or if you have a lot of components. it may
+ however slow things down, if your drawing code is simple.
+ */
+#ifndef JUCE_ENABLE_IOS_REPAINT_CACHE
+ #define JUCE_ENABLE_IOS_REPAINT_CACHE 0
+#endif
+
 //==============================================================================
 namespace juce
 {

--- a/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
@@ -108,6 +108,11 @@ using namespace juce;
 @public
     UIViewComponentPeer* owner;
     UITextView* hiddenTextView;
+#if JUCE_ENABLE_IOS_REPAINT_CACHE
+@private
+    CGContextRef bitmapContext;
+    RectangleList<int> dirtyRects;
+#endif /* JUCE_ENABLE_IOS_REPAINT_CACHE */
 }
 
 - (JuceUIView*) initWithOwner: (UIViewComponentPeer*) owner withFrame: (CGRect) frame;
@@ -456,15 +461,69 @@ MultiTouchMapper<UITouch*> UIViewComponentPeer::currentTouches;
 {
     [hiddenTextView removeFromSuperview];
     [hiddenTextView release];
+    
+    #if JUCE_ENABLE_IOS_REPAINT_CACHE
+    if(bitmapContext)
+    {
+        CGContextRelease(bitmapContext);
+    }
+    #endif /* JUCE_ENABLE_IOS_REPAINT_CACHE */
 
     [super dealloc];
 }
+
+#if JUCE_ENABLE_IOS_REPAINT_CACHE
+- (void) setNeedsDisplay
+{
+    dirtyRects.clear();
+    dirtyRects.add(convertToRectInt(self.frame));
+    [super setNeedsDisplay];
+}
+
+- (void) setNeedsDisplayInRect: (CGRect) r
+{
+    dirtyRects.add(convertToRectInt(r));
+    [super setNeedsDisplayInRect:r];
+}
+#endif /* JUCE_ENABLE_IOS_REPAINT_CACHE */
 
 //==============================================================================
 - (void) drawRect: (CGRect) r
 {
     if (owner != nullptr)
+    {
+        #if JUCE_ENABLE_IOS_REPAINT_CACHE
+            const auto scale = self.contentScaleFactor;
+
+            if(!bitmapContext || CGBitmapContextGetWidth(bitmapContext) != self.frame.size.width || CGBitmapContextGetHeight(bitmapContext) != self.frame.size.height)
+            {
+                if(bitmapContext)
+                {
+                    CGContextRelease(bitmapContext);
+                }
+                bitmapContext = CGBitmapContextCreate(nullptr, self.frame.size.width * scale, self.frame.size.height * scale, 8, 0, CGColorSpaceCreateDeviceRGB(), kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
+            }
+        
+            CGContextRef cg = UIGraphicsGetCurrentContext();
+            UIGraphicsPushContext(bitmapContext);
+        
+            CoreGraphicsContext g (bitmapContext, self.frame.size.height, scale);
+            CGContextConcatCTM (bitmapContext, CGAffineTransformMakeScale(scale, scale));
+            CGContextConcatCTM (bitmapContext, CGAffineTransformMake (1, 0, 0, -1, 0, self.frame.size.height));
+            g.clipToRectangleList(dirtyRects);
+            dirtyRects.clear();
+            CGContextConcatCTM (bitmapContext, CGAffineTransformMake (1, 0, 0, -1, 0, self.frame.size.height));
+        #endif /* JUCE_ENABLE_IOS_REPAINT_CACHE */
+        
         owner->drawRect (r);
+        
+        #if JUCE_ENABLE_IOS_REPAINT_CACHE
+            UIGraphicsPopContext();
+            auto imageOfBitmapContext = CGBitmapContextCreateImage(bitmapContext);
+            CGContextDrawImage(cg, self.frame, imageOfBitmapContext);
+            CGImageRelease(imageOfBitmapContext);
+        #endif /* JUCE_ENABLE_IOS_REPAINT_CACHE */
+ }
 }
 
 //==============================================================================


### PR DESCRIPTION
so that we can our own dirtyRect to determine what needs to be repainted without worrying if the NSBackingStore of the NSView gets discarded by the OS.

This is off by default and needs to be enabled via the JUCE_ENABLE_IOS_REPAINT_CACHE option for the juce_gui_basics_module.

See https://forum.juce.com/t/solved-repaint-ignores-opacity-and-repaints-parent-component/33711/19