### PR TITLE
Let Projucer request microphone and camera access on Mojave

### DIFF
--- a/extras/Projucer/Builds/MacOSX/Info-App.plist
+++ b/extras/Projucer/Builds/MacOSX/Info-App.plist
@@ -40,6 +40,10 @@
     <string>ROLI Ltd.</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSCameraUsageDescription</key>
+    <string>The Live Build engine requires access to the Camera.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>The Live Build engine requires access to the Microphone.</string>
     <key>CFBundleDocumentTypes</key>
     <array>
       <dict>

--- a/extras/Projucer/Builds/MacOSX/Info-App.plist
+++ b/extras/Projucer/Builds/MacOSX/Info-App.plist
@@ -41,9 +41,9 @@
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSCameraUsageDescription</key>
-    <string>The Live Build engine requires access to the Camera.</string>
+    <string>Projucer requires access to the Camera.</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>The Live Build engine requires access to the Microphone.</string>
+    <string>Projucer requires access to the Microphone.</string>
     <key>CFBundleDocumentTypes</key>
     <array>
       <dict>


### PR DESCRIPTION
Regarding [this issue](https://forum.juce.com/t/no-prompt-for-microphone-access-using-live-build-on-osx-mojave/34798).

For JUCE apps built with Live Build on macOS Mojave (10.14+) to be able to request microphone + camera access (for audio + video input), Projucer needs to have microphone + camera access as well.