### PR TITLE
added default constructor to AudioProcessorGraph

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
@@ -164,6 +164,7 @@ public:
         //==============================================================================
         Connection (NodeAndChannel source, NodeAndChannel destination) noexcept;
 
+        Connection() = default;
         Connection (const Connection&) = default;
         Connection& operator= (const Connection&) = default;
 


### PR DESCRIPTION
default constructor added, so the class can work with juce-arrays.