### PR TITLE
Update juce_PerformanceCounter.cpp

### DIFF
--- a/modules/juce_core/time/juce_PerformanceCounter.cpp
+++ b/modules/juce_core/time/juce_PerformanceCounter.cpp
@@ -43,7 +43,7 @@ PerformanceCounter::PerformanceCounter (const String& name, int runsPerPrintout,
 
 PerformanceCounter::~PerformanceCounter()
 {
-    printStatistics();
+    if (stats.numRuns) printStatistics();
 }
 
 PerformanceCounter::Statistics::Statistics() noexcept


### PR DESCRIPTION
Only printStatistics on destruction if there's something to print.

Otherwise, there's always an extra log entry added, that looks like:

Performance count for "my test" over 0 run(s)
Average = 0 microsecs, minimum = 0 microsecs, maximum = 0 microsecs, total = 0 microsecs