### PR TITLE
Fix -Wreturn-std-move-in-c++11 warnings

### DIFF
--- a/modules/juce_core/javascript/juce_Javascript.cpp
+++ b/modules/juce_core/javascript/juce_Javascript.cpp
@@ -816,7 +816,7 @@ struct JavascriptEngine::RootObject   : public DynamicObject
             for (int i = 0; i < values.size(); ++i)
                 a.add (values.getUnchecked(i)->getResult (s));
 
-            return a;
+            return std::move (a);
         }
 
         OwnedArray<Expression> values;
@@ -1625,7 +1625,7 @@ struct JavascriptEngine::RootObject   : public DynamicObject
                 for (int i = 2; i < a.numArguments; ++i)
                     array->insert (start++, get (a, i));
 
-                return itemsRemoved;
+                return std::move (itemsRemoved);
             }
 
             return var::undefined();


### PR DESCRIPTION
Full Xcode 11 warning (for `splice`):

> warning: prior to the resolution of a defect report against ISO C++11, local variable 'a' would have been copied despite being returned by name, due to its not matching the function return type ('juce::var' vs 'Array\<juce::var\>') [-Wreturn-std-move-in-c++11]