### PR TITLE
Feature propagate choice via attachment

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
@@ -638,6 +638,12 @@ struct AudioProcessorValueTreeState::ComboBoxAttachment::Pimpl  : private Attach
     Pimpl (AudioProcessorValueTreeState& s, const String& p, ComboBox& c)
         : AttachedControlBase (s, p), combo (c), ignoreCallbacks (false)
     {
+        if (auto* parameterChoice = dynamic_cast<AudioParameterChoice*>(state.getParameter (paramID)))
+        {
+            combo.clear();
+            combo.addItemList (parameterChoice->choices, 1);
+        }
+
         sendInitialUpdate();
         combo.addListener (this);
     }

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
@@ -713,6 +713,7 @@ struct AudioProcessorValueTreeState::ButtonAttachment::Pimpl  : private Attached
     Pimpl (AudioProcessorValueTreeState& s, const String& p, Button& b)
         : AttachedControlBase (s, p), button (b), ignoreCallbacks (false)
     {
+        button.setClickingTogglesState (true);
         sendInitialUpdate();
         button.addListener (this);
     }


### PR DESCRIPTION
This lets the ComboBoxAttachment automatically propagate the choices from AudioParameterChoice.
It also switches a button connected via a ButtonAttachment to clickingTogglesState, makes no sense otherwise IMHO.