### PR TITLE
Only add "Launch Images Source" when no "Launch Screen File" is defined

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Xcode.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Xcode.h
@@ -1308,7 +1308,8 @@ public:
             if (owner.iOS)
             {
                 s.set ("ASSETCATALOG_COMPILER_APPICON_NAME", "AppIcon");
-                s.set ("ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME", "LaunchImage");
+                if (! owner.shouldAddStoryboardToProject())
+                    s.set ("ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME", "LaunchImage");
             }
             else
             {


### PR DESCRIPTION
This change solves a conflict that prevents apps from building successfully when there is a `LaunchScreen` storyboard defined but no `LaunchImage` defined within the `Images.xcassets` folder.

In **Xcode 10** users are able to remove `Launch Images Source` reference by hand and fix this issue. However, in **Xcode 11** it's no possible due to the deprecation of `UILaunchImages` ([source](https://stackoverflow.com/questions/57084407/xcode-11-uilaunchimages-has-been-deprecated-use-launch-storyboards-instead-warn/57084471)).

### Xcode 10
<img width="683" alt="xcode10" src="https://user-images.githubusercontent.com/435351/65898608-e1df5980-e3a9-11e9-88df-6907983d08c9.png">

### Xcode 11
<img width="686" alt="xcode11" src="https://user-images.githubusercontent.com/435351/65898625-e60b7700-e3a9-11e9-9682-5fa83a8c79ee.png">