### PR TITLE
Fixed MSVC warnings when using generated code from Projucer's component editor

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/PaintElements/jucer_PaintElementImage.cpp
+++ b/extras/Projucer/Source/ComponentEditor/PaintElements/jucer_PaintElementImage.cpp
@@ -147,7 +147,7 @@ void PaintElementImage::fillInGeneratedCode (GeneratedCode& code, String& paintM
 
                 r << "    jassert (" << imageVariable << " != 0);\n"
                   << "    if (" << imageVariable << " != 0)\n"
-                  << "        " << imageVariable  << "->drawWithin (g, Rectangle<float> (x, y, width, height),\n"
+                  << "        " << imageVariable  << "->drawWithin (g, Rectangle<int> (x, y, width, height).toFloat(),\n"
                   << "    " << String::repeatedString (" ", imageVariable.length() + 18)
                   << (mode == stretched ? "RectanglePlacement::stretchToFit"
                                         : (mode == proportionalReducingOnly ? "RectanglePlacement::centred | RectanglePlacement::onlyReduceInSize"


### PR DESCRIPTION
This fixes this warning from being spammed when building files generated with this code.

```
warning C4244:  'argument': conversion from 'int' to 'ValueType', possible loss of data
warning C4244:         with
warning C4244:         [
warning C4244:             ValueType=float
warning C4244:         ]
```