### PR TITLE
Fix compiling juce_core/network/juce_Socket.cpp with MinGW

### DIFF
--- a/modules/juce_core/native/juce_BasicNativeHeaders.h
+++ b/modules/juce_core/native/juce_BasicNativeHeaders.h
@@ -126,7 +126,7 @@
  #define STRICT 1
  #define WIN32_LEAN_AND_MEAN 1
  #if JUCE_MINGW
-  #define _WIN32_WINNT 0x0501
+  #define _WIN32_WINNT 0x0600
  #else
   #define _WIN32_WINNT 0x0602
  #endif


### PR DESCRIPTION
Compiling `juce_core/network/juce_Socket.cpp` stopped working with MinGW
in b857f965ce85aa682f3a3475341026b1b25a1fb2 because `WSAPOLLFD` requires
Windows Vista (or Windows Server 2008) (see https://docs.microsoft.com/en-us/windows/win32/api/winsock2/ns-winsock2-wsapollfd#requirements).

Setting `_WIN32_WINNT` to `0x501` means targeting Windows XP (and Windows
Server 2003), while setting it to `0x600` means targeting Windows Vista
(and Windows Server 2008) (see https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers) .

@ed95 please merge, thanks!