### PR TITLE
Fix compiling juce_core/network/juce_Socket.cpp with MinGW for real

### DIFF
--- a/modules/juce_core/network/juce_Socket.cpp
+++ b/modules/juce_core/network/juce_Socket.cpp
@@ -339,10 +339,10 @@ namespace SocketHelpers
                 break;
             }
         }
-       #endif
 
         if (result < 0)
             return -1;
+       #endif
 
         // we are closing
         if (handle.load() < 0)


### PR DESCRIPTION
Compiling `juce_core/network/juce_Socket.cpp` with MinGW is broken since b857f965ce85aa682f3a3475341026b1b25a1fb2. A fix was attempted in 170ec47a5e3d0ee40763b02ae9a1d4a659331a26, but it was incomplete.

@ed95 please merge, thanks!