### PR TITLE
VST3 plugin should not report any MIDI controller assignments when JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -682,9 +682,12 @@ public:
     tresult PLUGIN_API getMidiControllerAssignment (Steinberg::int32 /*busIndex*/, Steinberg::int16 channel,
                                                     Vst::CtrlNumber midiControllerNumber, Vst::ParamID& resultID) override
     {
-        resultID = midiControllerToParameter[channel][midiControllerNumber];
-
-        return kResultTrue; // Returning false makes some hosts stop asking for further MIDI Controller Assignments
+        #if JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS
+            resultID = midiControllerToParameter[channel][midiControllerNumber];
+            return kResultTrue; // Returning false makes some hosts stop asking for further MIDI Controller Assignments
+        #else
+            return kResultFalse;
+        #endif
     }
 
     // Converts an incoming parameter index to a MIDI controller:


### PR DESCRIPTION
When JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0 the current behaviour is undefined. No Midi mappings should be reported when MIDI CC emulation is disabled.

**Proposed change:** Add #ifdef guard to check if MIDI CC is mapped to parameters, otherwise return kResultFalse to indicate that there are no mappings.