### PR TITLE
VST2 synth plugins always want MIDI input

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -1269,7 +1269,7 @@ struct VSTPluginInstance     : public AudioPluginInstance,
         if (getVstCategory() != Vst2::kPlugCategShell) // (workaround for Waves 5 plugins which crash during this call)
             updateStoredProgramNames();
 
-        wantsMidiMessages = pluginCanDo ("receiveVstMidiEvent") > 0;
+        wantsMidiMessages = (pluginCanDo ("receiveVstMidiEvent") > 0) || ((vstEffect != nullptr) && ((vstEffect->flags & Vst2::effFlagsIsSynth) != 0));
 
        #if JUCE_MAC && JUCE_SUPPORT_CARBON
         usesCocoaNSView = ((unsigned int) pluginCanDo ("hasCockosViewAsConfig") & 0xffff0000ul) == 0xbeef0000ul;
@@ -1369,7 +1369,9 @@ struct VSTPluginInstance     : public AudioPluginInstance,
 
         if (initialised)
         {
-            wantsMidiMessages = wantsMidiMessages || (pluginCanDo ("receiveVstMidiEvent") > 0);
+            wantsMidiMessages = wantsMidiMessages ||
+                                (pluginCanDo ("receiveVstMidiEvent") > 0) ||
+                                ((vstEffect != nullptr) && ((vstEffect->flags & Vst2::effFlagsIsSynth) != 0));
 
             if (wantsMidiMessages)
                 midiEventsToSend.ensureSize (256);


### PR DESCRIPTION
Some VST2 synth plugins report that they do not want MIDI input. But any synth needs MIDI input so one can implicitly assume that every VST2 synth wants MIDI.

If `wantsMidiMessages` is false, no MIDI data is forwarded in the VST2 wrapper code and the plugin does not receive any input and cannot be used. We encountered this problem with the KORG Gadget VST2 plugins on OSX but probably other plugins show the same behaviour. See this [JUCE forum thread](https://forum.juce.com/t/problems-with-some-vstis/3189/3) where the same fix was probosed before.