### PR TITLE
Update the AU host parameter cache when kAudioUnitProperty_ParameterList event is received

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1791,7 +1791,10 @@ private:
 
             default:
                 if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_ParameterList)
+                {
+                    refreshParameterList();
                     updateHostDisplay();
+                }
                 else if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_PresentPreset)
                     sendAllParametersChangedEvents();
                 else if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_Latency)


### PR DESCRIPTION
Some plugins (e.g Kontakt) dynamically change their parameters during runtime. The JUCE AU host internally holds a cached list of plugin parameters that has to be updated/refreshed when the plugin sends a kAudioUnitProperty_ParameterList event.