### PR TITLE
Missing "#if JucePlugin_Build_AU" in "juce_audio_plugin_client/juce_a…

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_AU_2.mm
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_AU_2.mm
@@ -24,6 +24,8 @@
   ==============================================================================
 */
 
+#if JucePlugin_Build_AU
+
 #ifdef __clang__
  #pragma clang diagnostic push
  #pragma clang diagnostic ignored "-Wparentheses"
@@ -80,4 +82,6 @@
 
 #ifdef __clang__
  #pragma clang diagnostic pop
+#endif
+
 #endif


### PR DESCRIPTION
Missing "#if JucePlugin_Build_AU" in "juce_audio_plugin_client/juce_audio_plugin_client_AU_2.mm"

https://forum.juce.com/t/missing-if-juceplugin-build-au-in-juce-audio-plugin-client-juce-audio-plugin-client-au-2-mm/35943