### PR TITLE
AU, improved support for kAudioUnitProperty_PresentPreset

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1823,7 +1823,10 @@ private:
                 if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_ParameterList)
                     updateHostDisplay();
                 else if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_PresentPreset)
+                {
                     sendAllParametersChangedEvents();
+                    updateHostDisplay();
+                }
                 else if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_Latency)
                     updateLatency();
                 else if (event.mArgument.mProperty.mPropertyID == kAudioUnitProperty_BypassEffect)

--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1270,7 +1270,20 @@ public:
         CFArrayRef presets;
         UInt32 sz = sizeof (CFArrayRef);
 
-        if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_FactoryPresets,
+        if (index == -1)
+        {
+            AUPreset current;
+            current.presetNumber = -1;
+            current.presetName = CFSTR("");
+            
+            UInt32 prstsz = sizeof (AUPreset);
+            
+            AudioUnitGetProperty (audioUnit, kAudioUnitProperty_PresentPreset,
+                                  kAudioUnitScope_Global, 0, &current, &prstsz);
+            
+            s = String::fromCFString (current.presetName);
+        }
+        else if (AudioUnitGetProperty (audioUnit, kAudioUnitProperty_FactoryPresets,
                                   kAudioUnitScope_Global, 0, &presets, &sz) == noErr)
         {
             for (CFIndex i = 0; i < CFArrayGetCount (presets); ++i)


### PR DESCRIPTION
This PR consists of two parts:

1. Call `updateHostDisplay()` when `kAudioUnitProperty_PresentPreset` has changed

2. Return `kAudioUnitProperty_PresentPreset` name when querying `getProgramName(-1)`

Many **AU** plugins report their currently active preset name (`kAudioUnitProperty_PresentPreset`) although they have an empty factory program list (`kAudioUnitProperty_FactoryPresets`).  At the same time they consistently report a current program index of -1.

These are for example: 

- U-He products
- Novation V-station + BassStation
- Audjoo Helix
- KV331 Synthmaster products
- Sonic Charge products

It would be nice if JUCE hosts could retrieve the name of `kAudioUnitProperty_PresentPreset` by querying the -1 program index.