### PR TITLE
Fix a data race in OpenGLContext

### DIFF
--- a/modules/juce_opengl/opengl/juce_OpenGLContext.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLContext.cpp
@@ -671,7 +671,7 @@ public:
    #else
     bool shadersAvailable = false;
    #endif
-    bool hasInitialised = false;
+    std::atomic_bool hasInitialised = false;
     Atomic<int> needsUpdate { 1 }, destroying;
     uint32 lastMMLockReleaseTime = 0;
 


### PR DESCRIPTION
I found a data race in `OpenGLContext` when compiling my plug-in with [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html):
`renderFrame()` [(Line 272)](https://github.com/WeAreROLI/JUCE/blob/26027ca9c300553d4633567d8c4e851476f9d941/modules/juce_opengl/opengl/juce_OpenGLContext.cpp#L272) concurrently reads the `bool` member `hasInitialized` which is written to from a different thread in `CachedImage::runJob()` [(Line 462)](https://github.com/WeAreROLI/JUCE/blob/26027ca9c300553d4633567d8c4e851476f9d941/modules/juce_opengl/opengl/juce_OpenGLContext.cpp#L462). There is no form of synchronization between these two threads.

I produced this by hiding and showing again a component that has an `OpenGLContext` attached.

To fix it, I simply changed the type of `hasInitialized` from `bool` to `std::atomic_bool`.

TSAN log:
```
==================
WARNING: ThreadSanitizer: data race (pid=97809)
  Read of size 1 at 0x7b60000872b1 by thread T23 (mutexes: write M50669, write M49667):
    #0 juce::OpenGLContext::CachedImage::renderFrame() juce_OpenGLContext.cpp:272 (CrispyTuner:x86_64+0x1013afcda)
    #1 juce::OpenGLContext::CachedImage::displayLinkCallback(__CVDisplayLink*, CVTimeStamp const*, CVTimeStamp const*, unsigned long long, unsigned long long*, void*) juce_OpenGLContext.cpp:150 (CrispyTuner:x86_64+0x1013af49f)
    #2 CVDisplayLink::performIO(CVTimeStamp*) <null>:9648336 (CoreVideo:x86_64+0x17900)

  Previous write of size 1 at 0x7b60000872b1 by thread T22:
    #0 juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp:462 (CrispyTuner:x86_64+0x1013a905d)
    #1 non-virtual thunk to juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp (CrispyTuner:x86_64+0x1013a920c)
    #2 juce::ThreadPool::runNextJob(juce::ThreadPool::ThreadPoolThread&) juce_ThreadPool.cpp:384 (CrispyTuner:x86_64+0x100ba4d6e)
    #3 juce::ThreadPool::ThreadPoolThread::run() juce_ThreadPool.cpp:36 (CrispyTuner:x86_64+0x100c1ae67)
    #4 juce::Thread::threadEntryPoint() juce_Thread.cpp:96 (CrispyTuner:x86_64+0x100b9fe87)
    #5 juce::juce_threadEntryPoint(void*) juce_Thread.cpp:118 (CrispyTuner:x86_64+0x100ba0608)
    #6 juce::threadEntryProc(void*) juce_posix_SharedCode.h:834 (CrispyTuner:x86_64+0x100beeba9)

  Location is heap block of size 952 at 0x7b6000087000 allocated by main thread:
    #0 operator new(unsigned long) <null>:9648368 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x6f00b)
    #1 juce::OpenGLContext::Attachment::attach() juce_OpenGLContext.cpp:811 (CrispyTuner:x86_64+0x1013a77ef)
    #2 juce::OpenGLContext::Attachment::componentVisibilityChanged() juce_OpenGLContext.cpp:752 (CrispyTuner:x86_64+0x1013a7d52)
    #3 juce::OpenGLContext::Attachment::componentPeerChanged() juce_OpenGLContext.cpp:740 (CrispyTuner:x86_64+0x1013a7ca7)
    #4 juce::ComponentMovementWatcher::componentParentHierarchyChanged(juce::Component&) juce_ComponentMovementWatcher.cpp:60 (CrispyTuner:x86_64+0x100f8dc63)
    #5 juce::Component::internalHierarchyChanged()::$_5::operator()(juce::ComponentListener&) const juce_Component.cpp:1616 (CrispyTuner:x86_64+0x1011c61cf)
    #6 void juce::ListenerList<juce::ComponentListener, juce::Array<juce::ComponentListener*, juce::DummyCriticalSection, 0> >::callChecked<juce::Component::internalHierarchyChanged()::$_5, juce::Component::BailOutChecker>(juce::Component::BailOutChecker const&, juce::Component::internalHierarchyChanged()::$_5&&) juce_ListenerList.h:153 (CrispyTuner:x86_64+0x100f29687)
    #7 juce::Component::internalHierarchyChanged() juce_Component.cpp:1616 (CrispyTuner:x86_64+0x100f20538)
    #8 juce::Component::addChildComponent(juce::Component&, int) juce_Component.cpp:1429 (CrispyTuner:x86_64+0x100f28be9)
    #9 juce::Component::addAndMakeVisible(juce::Component&, int) juce_Component.cpp:1437 (CrispyTuner:x86_64+0x100f28d36)
    #10 crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp:27 (CrispyTuner:x86_64+0x100091d28)
    #11 non-virtual thunk to crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp (CrispyTuner:x86_64+0x100091f5f)
    #12 juce::Value::callListeners()::$_0::operator()(juce::Value::Listener&) const juce_Value.cpp:233 (CrispyTuner:x86_64+0x100ce51f8)
    #13 void juce::ListenerList<juce::Value::Listener, juce::Array<juce::Value::Listener*, juce::DummyCriticalSection, 0> >::call<juce::Value::callListeners()::$_0>(juce::Value::callListeners()::$_0&&) juce_ListenerList.h:124 (CrispyTuner:x86_64+0x100cc6507)
    #14 juce::Value::callListeners() juce_Value.cpp:233 (CrispyTuner:x86_64+0x100cc488f)
    #15 juce::Value::ValueSource::sendChangeMessage(bool) juce_Value.cpp:58 (CrispyTuner:x86_64+0x100cc462b)
    #16 juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp:41 (CrispyTuner:x86_64+0x100cc453d)
    #17 non-virtual thunk to juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp (CrispyTuner:x86_64+0x100cc46fc)
    #18 juce::AsyncUpdater::AsyncUpdaterMessage::messageCallback() juce_AsyncUpdater.cpp:34 (CrispyTuner:x86_64+0x100d031c3)
    #19 juce::MessageQueue::deliverNextMessage() juce_osx_MessageQueue.h:82 (CrispyTuner:x86_64+0x100d128c6)
    #20 juce::MessageQueue::runLoopCallback() juce_osx_MessageQueue.h:93 (CrispyTuner:x86_64+0x100d127e9)
    #21 juce::MessageQueue::runLoopSourceCallback(void*) juce_osx_MessageQueue.h:101 (CrispyTuner:x86_64+0x100d125b8)
    #22 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ <null>:9648368 (CoreFoundation:x86_64h+0x57de2)
    #23 juce::JUCEApplicationBase::main() juce_ApplicationBase.cpp:262 (CrispyTuner:x86_64+0x100cefb57)
    #24 juce::JUCEApplicationBase::main(int, char const**) juce_ApplicationBase.cpp:240 (CrispyTuner:x86_64+0x100cef8b5)
    #25 main juce_audio_plugin_client_Standalone.cpp:46 (CrispyTuner:x86_64+0x1000017cc)

  Mutex M50669 (0x7b6800051038) created at:
    #0 pthread_mutex_init <null>:9648224 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2b153)
    #1 CVDisplayLink::init() <null>:9648224 (CoreVideo:x86_64+0x16379)
    #2 juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp:455 (CrispyTuner:x86_64+0x1013a900a)
    #3 non-virtual thunk to juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp (CrispyTuner:x86_64+0x1013a920c)
    #4 juce::ThreadPool::runNextJob(juce::ThreadPool::ThreadPoolThread&) juce_ThreadPool.cpp:384 (CrispyTuner:x86_64+0x100ba4d6e)
    #5 juce::ThreadPool::ThreadPoolThread::run() juce_ThreadPool.cpp:36 (CrispyTuner:x86_64+0x100c1ae67)
    #6 juce::Thread::threadEntryPoint() juce_Thread.cpp:96 (CrispyTuner:x86_64+0x100b9fe87)
    #7 juce::juce_threadEntryPoint(void*) juce_Thread.cpp:118 (CrispyTuner:x86_64+0x100ba0608)
    #8 juce::threadEntryProc(void*) juce_posix_SharedCode.h:834 (CrispyTuner:x86_64+0x100beeba9)

  Mutex M49667 (0x7ba00000dea8) created at:
    #0 pthread_mutex_init <null>:9648224 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2b153)
    #1 CGLCreateContext <null>:9648224 (OpenGL:x86_64+0x4b5e)
    #2 juce::OpenGLContext::NativeContext::NativeContext(juce::Component&, juce::OpenGLPixelFormat const&, void*, bool, juce::OpenGLContext::OpenGLVersion) juce_OpenGL_osx.h:44 (CrispyTuner:x86_64+0x1013a8a32)
    #3 juce::OpenGLContext::CachedImage::CachedImage(juce::OpenGLContext&, juce::Component&, juce::OpenGLPixelFormat const&, void*) juce_OpenGLContext.cpp:79 (CrispyTuner:x86_64+0x1013a85a3)
    #4 juce::OpenGLContext::CachedImage::CachedImage(juce::OpenGLContext&, juce::Component&, juce::OpenGLPixelFormat const&, void*) juce_OpenGLContext.cpp:78 (CrispyTuner:x86_64+0x1013a8038)
    #5 juce::OpenGLContext::Attachment::attach() juce_OpenGLContext.cpp:811 (CrispyTuner:x86_64+0x1013a7882)
    #6 juce::OpenGLContext::Attachment::componentVisibilityChanged() juce_OpenGLContext.cpp:752 (CrispyTuner:x86_64+0x1013a7d52)
    #7 juce::OpenGLContext::Attachment::componentPeerChanged() juce_OpenGLContext.cpp:740 (CrispyTuner:x86_64+0x1013a7ca7)
    #8 juce::ComponentMovementWatcher::componentParentHierarchyChanged(juce::Component&) juce_ComponentMovementWatcher.cpp:60 (CrispyTuner:x86_64+0x100f8dc63)
    #9 juce::Component::internalHierarchyChanged()::$_5::operator()(juce::ComponentListener&) const juce_Component.cpp:1616 (CrispyTuner:x86_64+0x1011c61cf)
    #10 void juce::ListenerList<juce::ComponentListener, juce::Array<juce::ComponentListener*, juce::DummyCriticalSection, 0> >::callChecked<juce::Component::internalHierarchyChanged()::$_5, juce::Component::BailOutChecker>(juce::Component::BailOutChecker const&, juce::Component::internalHierarchyChanged()::$_5&&) juce_ListenerList.h:153 (CrispyTuner:x86_64+0x100f29687)
    #11 juce::Component::internalHierarchyChanged() juce_Component.cpp:1616 (CrispyTuner:x86_64+0x100f20538)
    #12 juce::Component::addChildComponent(juce::Component&, int) juce_Component.cpp:1429 (CrispyTuner:x86_64+0x100f28be9)
    #13 juce::Component::addAndMakeVisible(juce::Component&, int) juce_Component.cpp:1437 (CrispyTuner:x86_64+0x100f28d36)
    #14 crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp:27 (CrispyTuner:x86_64+0x100091d28)
    #15 non-virtual thunk to crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp (CrispyTuner:x86_64+0x100091f5f)
    #16 juce::Value::callListeners()::$_0::operator()(juce::Value::Listener&) const juce_Value.cpp:233 (CrispyTuner:x86_64+0x100ce51f8)
    #17 void juce::ListenerList<juce::Value::Listener, juce::Array<juce::Value::Listener*, juce::DummyCriticalSection, 0> >::call<juce::Value::callListeners()::$_0>(juce::Value::callListeners()::$_0&&) juce_ListenerList.h:124 (CrispyTuner:x86_64+0x100cc6507)
    #18 juce::Value::callListeners() juce_Value.cpp:233 (CrispyTuner:x86_64+0x100cc488f)
    #19 juce::Value::ValueSource::sendChangeMessage(bool) juce_Value.cpp:58 (CrispyTuner:x86_64+0x100cc462b)
    #20 juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp:41 (CrispyTuner:x86_64+0x100cc453d)
    #21 non-virtual thunk to juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp (CrispyTuner:x86_64+0x100cc46fc)
    #22 juce::AsyncUpdater::AsyncUpdaterMessage::messageCallback() juce_AsyncUpdater.cpp:34 (CrispyTuner:x86_64+0x100d031c3)
    #23 juce::MessageQueue::deliverNextMessage() juce_osx_MessageQueue.h:82 (CrispyTuner:x86_64+0x100d128c6)
    #24 juce::MessageQueue::runLoopCallback() juce_osx_MessageQueue.h:93 (CrispyTuner:x86_64+0x100d127e9)
    #25 juce::MessageQueue::runLoopSourceCallback(void*) juce_osx_MessageQueue.h:101 (CrispyTuner:x86_64+0x100d125b8)
    #26 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ <null>:9648224 (CoreFoundation:x86_64h+0x57de2)
    #27 juce::JUCEApplicationBase::main() juce_ApplicationBase.cpp:262 (CrispyTuner:x86_64+0x100cefb57)
    #28 juce::JUCEApplicationBase::main(int, char const**) juce_ApplicationBase.cpp:240 (CrispyTuner:x86_64+0x100cef8b5)
    #29 main juce_audio_plugin_client_Standalone.cpp:46 (CrispyTuner:x86_64+0x1000017cc)

  Thread T23 (tid=2200690, running) created by thread T22 at:
    #0 pthread_create <null>:9648416 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2a17d)
    #1 CVDisplayLink::start() <null>:9648416 (CoreVideo:x86_64+0x16ae5)
    #2 juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp:455 (CrispyTuner:x86_64+0x1013a900a)
    #3 non-virtual thunk to juce::OpenGLContext::CachedImage::runJob() juce_OpenGLContext.cpp (CrispyTuner:x86_64+0x1013a920c)
    #4 juce::ThreadPool::runNextJob(juce::ThreadPool::ThreadPoolThread&) juce_ThreadPool.cpp:384 (CrispyTuner:x86_64+0x100ba4d6e)
    #5 juce::ThreadPool::ThreadPoolThread::run() juce_ThreadPool.cpp:36 (CrispyTuner:x86_64+0x100c1ae67)
    #6 juce::Thread::threadEntryPoint() juce_Thread.cpp:96 (CrispyTuner:x86_64+0x100b9fe87)
    #7 juce::juce_threadEntryPoint(void*) juce_Thread.cpp:118 (CrispyTuner:x86_64+0x100ba0608)
    #8 juce::threadEntryProc(void*) juce_posix_SharedCode.h:834 (CrispyTuner:x86_64+0x100beeba9)

  Thread T22 (tid=2200689, running) created by main thread at:
    #0 pthread_create <null>:9648416 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2a17d)
    #1 juce::Thread::launchThread() juce_posix_SharedCode.h:891 (CrispyTuner:x86_64+0x100ba0849)
    #2 juce::Thread::startThread() juce_Thread.cpp:130 (CrispyTuner:x86_64+0x100ba06b8)
    #3 juce::ThreadPool::createThreads(int, unsigned long) juce_ThreadPool.cpp:117 (CrispyTuner:x86_64+0x100ba284b)
    #4 juce::ThreadPool::ThreadPool(int, unsigned long) juce_ThreadPool.cpp:97 (CrispyTuner:x86_64+0x100ba2626)
    #5 juce::ThreadPool::ThreadPool(int, unsigned long) juce_ThreadPool.cpp:94 (CrispyTuner:x86_64+0x100ba29d4)
    #6 juce::OpenGLContext::CachedImage::start() juce_OpenGLContext.cpp:98 (CrispyTuner:x86_64+0x1013b20c7)
    #7 juce::OpenGLContext::Attachment::start() juce_OpenGLContext.cpp:839 (CrispyTuner:x86_64+0x1013a80c7)
    #8 juce::OpenGLContext::Attachment::attach() juce_OpenGLContext.cpp:816 (CrispyTuner:x86_64+0x1013a78aa)
    #9 juce::OpenGLContext::Attachment::componentVisibilityChanged() juce_OpenGLContext.cpp:752 (CrispyTuner:x86_64+0x1013a7d52)
    #10 juce::OpenGLContext::Attachment::componentPeerChanged() juce_OpenGLContext.cpp:740 (CrispyTuner:x86_64+0x1013a7ca7)
    #11 juce::ComponentMovementWatcher::componentParentHierarchyChanged(juce::Component&) juce_ComponentMovementWatcher.cpp:60 (CrispyTuner:x86_64+0x100f8dc63)
    #12 juce::Component::internalHierarchyChanged()::$_5::operator()(juce::ComponentListener&) const juce_Component.cpp:1616 (CrispyTuner:x86_64+0x1011c61cf)
    #13 void juce::ListenerList<juce::ComponentListener, juce::Array<juce::ComponentListener*, juce::DummyCriticalSection, 0> >::callChecked<juce::Component::internalHierarchyChanged()::$_5, juce::Component::BailOutChecker>(juce::Component::BailOutChecker const&, juce::Component::internalHierarchyChanged()::$_5&&) juce_ListenerList.h:153 (CrispyTuner:x86_64+0x100f29687)
    #14 juce::Component::internalHierarchyChanged() juce_Component.cpp:1616 (CrispyTuner:x86_64+0x100f20538)
    #15 juce::Component::addChildComponent(juce::Component&, int) juce_Component.cpp:1429 (CrispyTuner:x86_64+0x100f28be9)
    #16 juce::Component::addAndMakeVisible(juce::Component&, int) juce_Component.cpp:1437 (CrispyTuner:x86_64+0x100f28d36)
    #17 crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp:27 (CrispyTuner:x86_64+0x100091d28)
    #18 non-virtual thunk to crispy_audio::Tabs::valueChanged(juce::Value&) Tabs.cpp (CrispyTuner:x86_64+0x100091f5f)
    #19 juce::Value::callListeners()::$_0::operator()(juce::Value::Listener&) const juce_Value.cpp:233 (CrispyTuner:x86_64+0x100ce51f8)
    #20 void juce::ListenerList<juce::Value::Listener, juce::Array<juce::Value::Listener*, juce::DummyCriticalSection, 0> >::call<juce::Value::callListeners()::$_0>(juce::Value::callListeners()::$_0&&) juce_ListenerList.h:124 (CrispyTuner:x86_64+0x100cc6507)
    #21 juce::Value::callListeners() juce_Value.cpp:233 (CrispyTuner:x86_64+0x100cc488f)
    #22 juce::Value::ValueSource::sendChangeMessage(bool) juce_Value.cpp:58 (CrispyTuner:x86_64+0x100cc462b)
    #23 juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp:41 (CrispyTuner:x86_64+0x100cc453d)
    #24 non-virtual thunk to juce::Value::ValueSource::handleAsyncUpdate() juce_Value.cpp (CrispyTuner:x86_64+0x100cc46fc)
    #25 juce::AsyncUpdater::AsyncUpdaterMessage::messageCallback() juce_AsyncUpdater.cpp:34 (CrispyTuner:x86_64+0x100d031c3)
    #26 juce::MessageQueue::deliverNextMessage() juce_osx_MessageQueue.h:82 (CrispyTuner:x86_64+0x100d128c6)
    #27 juce::MessageQueue::runLoopCallback() juce_osx_MessageQueue.h:93 (CrispyTuner:x86_64+0x100d127e9)
    #28 juce::MessageQueue::runLoopSourceCallback(void*) juce_osx_MessageQueue.h:101 (CrispyTuner:x86_64+0x100d125b8)
    #29 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ <null>:9648416 (CoreFoundation:x86_64h+0x57de2)
    #30 juce::JUCEApplicationBase::main() juce_ApplicationBase.cpp:262 (CrispyTuner:x86_64+0x100cefb57)
    #31 juce::JUCEApplicationBase::main(int, char const**) juce_ApplicationBase.cpp:240 (CrispyTuner:x86_64+0x100cef8b5)
    #32 main juce_audio_plugin_client_Standalone.cpp:46 (CrispyTuner:x86_64+0x1000017cc)

SUMMARY: ThreadSanitizer: data race juce_OpenGLContext.cpp:272 in juce::OpenGLContext::CachedImage::renderFrame()
==================
```