### PR TITLE
add an internal MIDI out node

### DIFF
--- a/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
+++ b/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
@@ -357,6 +357,11 @@ InternalPluginFormat::InternalPluginFormat()
         AudioProcessorGraph::AudioGraphIOProcessor p (AudioProcessorGraph::AudioGraphIOProcessor::midiInputNode);
         p.fillInPluginDescription (midiInDesc);
     }
+
+    {
+        AudioProcessorGraph::AudioGraphIOProcessor p(AudioProcessorGraph::AudioGraphIOProcessor::midiOutputNode);
+        p.fillInPluginDescription(midiOutDesc);
+    }
 }
 
 std::unique_ptr<AudioPluginInstance> InternalPluginFormat::createInstance (const String& name)
@@ -364,6 +369,7 @@ std::unique_ptr<AudioPluginInstance> InternalPluginFormat::createInstance (const
     if (name == audioOutDesc.name) return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::audioOutputNode);
     if (name == audioInDesc.name)  return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::audioInputNode);
     if (name == midiInDesc.name)   return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::midiInputNode);
+    if (name == midiOutDesc.name)   return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor>(AudioProcessorGraph::AudioGraphIOProcessor::midiOutputNode);
 
     if (name == SineWaveSynth::getIdentifier()) return std::make_unique<SineWaveSynth> (SineWaveSynth::getPluginDescription());
     if (name == ReverbPlugin::getIdentifier())  return std::make_unique<ReverbPlugin>  (ReverbPlugin::getPluginDescription());
@@ -388,7 +394,7 @@ bool InternalPluginFormat::requiresUnblockedMessageThreadDuringCreation (const P
 
 void InternalPluginFormat::getAllTypes (Array<PluginDescription>& results)
 {
-    results.add (audioInDesc, audioOutDesc, midiInDesc,
+    results.add (audioInDesc, audioOutDesc, midiInDesc, midiOutDesc,
                  SineWaveSynth::getPluginDescription(),
                  ReverbPlugin::getPluginDescription());
 }

--- a/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
+++ b/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
@@ -369,7 +369,7 @@ std::unique_ptr<AudioPluginInstance> InternalPluginFormat::createInstance (const
     if (name == audioOutDesc.name) return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::audioOutputNode);
     if (name == audioInDesc.name)  return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::audioInputNode);
     if (name == midiInDesc.name)   return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor> (AudioProcessorGraph::AudioGraphIOProcessor::midiInputNode);
-    if (name == midiOutDesc.name)   return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor>(AudioProcessorGraph::AudioGraphIOProcessor::midiOutputNode);
+    if (name == midiOutDesc.name)  return std::make_unique<AudioProcessorGraph::AudioGraphIOProcessor>(AudioProcessorGraph::AudioGraphIOProcessor::midiOutputNode);
 
     if (name == SineWaveSynth::getIdentifier()) return std::make_unique<SineWaveSynth> (SineWaveSynth::getPluginDescription());
     if (name == ReverbPlugin::getIdentifier())  return std::make_unique<ReverbPlugin>  (ReverbPlugin::getPluginDescription());

--- a/extras/AudioPluginHost/Source/Plugins/InternalPlugins.h
+++ b/extras/AudioPluginHost/Source/Plugins/InternalPlugins.h
@@ -41,7 +41,7 @@ public:
     ~InternalPluginFormat() override {}
 
     //==============================================================================
-    PluginDescription audioInDesc, audioOutDesc, midiInDesc;
+    PluginDescription audioInDesc, audioOutDesc, midiInDesc, midiOutDesc;
     void getAllTypes (Array<PluginDescription>&);
 
     //==============================================================================

--- a/extras/AudioPluginHost/Source/Plugins/PluginGraph.cpp
+++ b/extras/AudioPluginHost/Source/Plugins/PluginGraph.cpp
@@ -202,6 +202,7 @@ void PluginGraph::newDocument()
     addPlugin (internalFormat.audioInDesc,  { 0.5,  0.1 });
     addPlugin (internalFormat.midiInDesc,   { 0.25, 0.1 });
     addPlugin (internalFormat.audioOutDesc, { 0.5,  0.9 });
+    addPlugin (internalFormat.midiOutDesc,  { 0.25, 0.9 });
 
     MessageManager::callAsync ([this] () {
         setChangedFlag (false);


### PR DESCRIPTION
I love the AudioPluginHost to test plugins but it lacks of a midi output node. So I added it.