### PR TITLE
Make NetworkServiceDiscovery::Advertiser::sendBroadcast() broadcast on all NICs

### DIFF
--- a/modules/juce_events/interprocess/juce_NetworkServiceDiscovery.cpp
+++ b/modules/juce_events/interprocess/juce_NetworkServiceDiscovery.cpp
@@ -67,11 +67,13 @@ void NetworkServiceDiscovery::Advertiser::run()
 
 void NetworkServiceDiscovery::Advertiser::sendBroadcast()
 {
-    auto localAddress = IPAddress::getLocalAddress();
-    message.setAttribute ("address", localAddress.toString());
-    auto broadcastAddress = IPAddress::getInterfaceBroadcastAddress (localAddress);
-    auto data = message.toString (XmlElement::TextFormat().singleLine().withoutHeader());
-    socket.write (broadcastAddress.toString(), broadcastPort, data.toRawUTF8(), (int) data.getNumBytesAsUTF8());
+    auto&& localAddresses = IPAddress::getAllAddresses();
+    for (auto& localAddress : localAddresses) {
+        message.setAttribute ("address", localAddress.toString());
+        auto broadcastAddress = IPAddress::getInterfaceBroadcastAddress (localAddress);
+        auto data = message.toString (XmlElement::TextFormat().singleLine().withoutHeader());
+        socket.write (broadcastAddress.toString(), broadcastPort, data.toRawUTF8(), (int) data.getNumBytesAsUTF8());
+    }
 }
 
 //==============================================================================

--- a/modules/juce_events/interprocess/juce_NetworkServiceDiscovery.cpp
+++ b/modules/juce_events/interprocess/juce_NetworkServiceDiscovery.cpp
@@ -69,6 +69,7 @@ void NetworkServiceDiscovery::Advertiser::sendBroadcast()
 {
     auto&& localAddresses = IPAddress::getAllAddresses();
     for (auto& localAddress : localAddresses) {
+        if(localAddress == IPAddress::local()) continue;
         message.setAttribute ("address", localAddress.toString());
         auto broadcastAddress = IPAddress::getInterfaceBroadcastAddress (localAddress);
         auto data = message.toString (XmlElement::TextFormat().singleLine().withoutHeader());


### PR DESCRIPTION
I couldn't get `NetworkServiceDiscovery` to work when the device was only accessible via the second ethernet card.

I found, that `NetworkServiceDiscovery::Advertiser::sendBroadcast()` only broadcasts to the first ethernet card. That's hardcoded by [using `IPAddress::getLocalAddress()`](https://github.com/WeAreROLI/JUCE/blob/develop/modules/juce_events/interprocess/juce_NetworkServiceDiscovery.cpp#L70), which by the [description](https://docs.juce.com/master/classIPAddress.html#a1c01e16de47b2969ffbcf072d683c72c) only returns "the first 'real' address for the local machine".

The proposed change makes `NetworkServiceDiscovery::Advertiser::sendBroadcast()` iterate over all available local addresses and sends a broadcastmessage on each interface.

This solves the issue for me.