### PR TITLE
(bugfix) remove const qualifier from Bias::processSample

### DIFF
--- a/modules/juce_dsp/processors/juce_Bias.h
+++ b/modules/juce_dsp/processors/juce_Bias.h
@@ -90,7 +90,7 @@ public:
     //==============================================================================
     /** Returns the result of processing a single sample. */
     template <typename SampleType>
-    SampleType processSample (SampleType inputSample) const noexcept
+    SampleType processSample (SampleType inputSample) noexcept
     {
         return inputSample + bias.getNextValue();
     }


### PR DESCRIPTION
`processSample` is marked `const` but `bias.getNextValue()` modifies internal values of `bias`.  currently i get this error when i call `processSample`:
```
Vendor/JUCE/modules/juce_dsp/processors/juce_Bias.h:95:30: 'this' argument to member function 'getNextValue' has type 'const SmoothedValue<float>', but function is not marked const
JuceLibraryCode/JuceHeader.h:29:10: In file included from ../../JuceLibraryCode/../JuceLibraryCode/JuceHeader.h:29:
Vendor/JUCE/modules/juce_dsp/juce_dsp.h:260:10: In file included from ../../Vendor/JUCE/modules/juce_dsp/juce_dsp.h:260:
Source/Waveshaper.h:55:53: In instantiation of function template specialization 'juce::dsp::Bias<float>::processSample<float>' requested here
Vendor/JUCE/modules/juce_audio_basics/utilities/juce_SmoothedValue.h:297:15: 'getNextValue' declared here
```
removing the `const` qualifier fixes this.