### PR TITLE
First pass support for MSVC ARM64

### DIFF
--- a/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.cpp
+++ b/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.cpp
@@ -1033,9 +1033,11 @@ intptr_t JUCE_CALLTYPE FloatVectorOperations::getFpStatusRegister() noexcept
     intptr_t fpsr = 0;
   #if JUCE_INTEL && JUCE_USE_SSE_INTRINSICS
     fpsr = static_cast<intptr_t> (_mm_getcsr());
-  #elif defined (__arm64__) || defined (__aarch64__) || JUCE_USE_ARM_NEON
+  #elif defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64) || JUCE_USE_ARM_NEON
    #if defined (__arm64__) || defined (__aarch64__)
     asm volatile("mrs %0, fpcr" : "=r" (fpsr));
+   #elif defined (_M_ARM64)
+    fpsr = _ReadStatusReg(ARM64_FPSR);
    #elif JUCE_USE_ARM_NEON
     asm volatile("vmrs %0, fpscr" : "=r" (fpsr));
    #endif
@@ -1053,9 +1055,11 @@ void JUCE_CALLTYPE FloatVectorOperations::setFpStatusRegister (intptr_t fpsr) no
   #if JUCE_INTEL && JUCE_USE_SSE_INTRINSICS
     auto fpsr_w = static_cast<uint32_t> (fpsr);
     _mm_setcsr (fpsr_w);
-  #elif defined (__arm64__) || defined (__aarch64__) || JUCE_USE_ARM_NEON
+  #elif defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64) || JUCE_USE_ARM_NEON
    #if defined (__arm64__) || defined (__aarch64__)
     asm volatile("msr fpcr, %0" : : "ri" (fpsr));
+   #elif defined (_M_ARM64)
+    _WriteStatusReg(ARM64_FPSR, fpsr);
    #elif JUCE_USE_ARM_NEON
     asm volatile("vmsr fpscr, %0" : : "ri" (fpsr));
    #endif
@@ -1069,7 +1073,7 @@ void JUCE_CALLTYPE FloatVectorOperations::setFpStatusRegister (intptr_t fpsr) no
 
 void JUCE_CALLTYPE FloatVectorOperations::enableFlushToZeroMode (bool shouldEnable) noexcept
 {
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
    #if JUCE_USE_SSE_INTRINSICS
     intptr_t mask = _MM_FLUSH_ZERO_MASK;
    #else /*JUCE_USE_ARM_NEON*/
@@ -1086,7 +1090,7 @@ void JUCE_CALLTYPE FloatVectorOperations::enableFlushToZeroMode (bool shouldEnab
 
 void JUCE_CALLTYPE FloatVectorOperations::disableDenormalisedNumberSupport (bool shouldDisable) noexcept
 {
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
    #if JUCE_USE_SSE_INTRINSICS
     intptr_t mask = 0x8040;
    #else /*JUCE_USE_ARM_NEON*/
@@ -1105,7 +1109,7 @@ void JUCE_CALLTYPE FloatVectorOperations::disableDenormalisedNumberSupport (bool
 
 bool JUCE_CALLTYPE FloatVectorOperations::areDenormalsDisabled() noexcept
 {
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
    #if JUCE_USE_SSE_INTRINSICS
     intptr_t mask = 0x8040;
    #else /*JUCE_USE_ARM_NEON*/
@@ -1120,7 +1124,7 @@ bool JUCE_CALLTYPE FloatVectorOperations::areDenormalsDisabled() noexcept
 
 ScopedNoDenormals::ScopedNoDenormals() noexcept
 {
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
    #if JUCE_USE_SSE_INTRINSICS
     intptr_t mask = 0x8040;
    #else /*JUCE_USE_ARM_NEON*/
@@ -1134,7 +1138,7 @@ ScopedNoDenormals::ScopedNoDenormals() noexcept
 
 ScopedNoDenormals::~ScopedNoDenormals() noexcept
 {
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
     FloatVectorOperations::setFpStatusRegister (fpsr);
   #endif
 }

--- a/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h
+++ b/modules/juce_audio_basics/buffers/juce_FloatVectorOperations.h
@@ -249,7 +249,7 @@ public:
     ~ScopedNoDenormals() noexcept;
 
 private:
-  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__))
+  #if JUCE_USE_SSE_INTRINSICS || (JUCE_USE_ARM_NEON || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64))
     intptr_t fpsr;
   #endif
 };

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/os.h
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.2/lib/os.h
@@ -145,7 +145,7 @@ static __inline void vorbis_fpu_restore(vorbis_fpu_control fpu){
 
 /* Optimized code path for x86_64 builds. Uses SSE2 intrinsics. This can be
    done safely because all x86_64 CPUs supports SSE2. */
-#if ! JUCE_PROJUCER_LIVE_BUILD && ((JUCE_MSVC && JUCE_64BIT) || (JUCE_GCC && defined (__x86_64__)))
+#if (! JUCE_PROJUCER_LIVE_BUILD) && ((defined(_MSC_VER) && defined(_WIN64) && ! JUCE_ARM) || (defined(__GNUC__) && defined (__x86_64__)))
 #  define VORBIS_FPU_CONTROL
 
 typedef ogg_int16_t vorbis_fpu_control;

--- a/modules/juce_core/system/juce_TargetPlatform.h
+++ b/modules/juce_core/system/juce_TargetPlatform.h
@@ -57,7 +57,7 @@
 #endif
 
 //==============================================================================
-#if defined (_WIN32) || defined (_WIN64)
+#if defined (_WIN32) || defined (_WIN64) || defined (_M_ARM) || defined (_M_ARM64)
   #define       JUCE_WIN32 1
   #define       JUCE_WINDOWS 1
 #elif defined (JUCE_ANDROID)
@@ -85,8 +85,9 @@
 //==============================================================================
 #if JUCE_WINDOWS
   #ifdef _MSC_VER
-    #ifdef _WIN64
+    #if defined (_WIN64) || defined (_M_ARM64)
       #define JUCE_64BIT 1
+      #define JUCE_USE_ARM_NEON 1
     #else
       #define JUCE_32BIT 1
     #endif
@@ -108,7 +109,18 @@
   /** If defined, this indicates that the processor is little-endian. */
   #define JUCE_LITTLE_ENDIAN 1
 
+  #if defined (_M_ARM) || defined (_M_ARM64)
+    #define JUCE_ARM 1
+    #if defined (__LITTLE_ENDIAN__) || ! defined (JUCE_BIG_ENDIAN)
+        #define JUCE_LITTLE_ENDIAN 1
+        #undef JUCE_BIG_ENDIAN
+    #else
+        #undef JUCE_LITTLE_ENDIAN
+        #define JUCE_BIG_ENDIAN 1
+    #endif
+  #else
   #define JUCE_INTEL 1
+  #endif
 #endif
 
 //==============================================================================

--- a/modules/juce_dsp/containers/juce_AudioBlock_test.cpp
+++ b/modules/juce_dsp/containers/juce_AudioBlock_test.cpp
@@ -492,8 +492,10 @@ private:
 
 static AudioBlockUnitTests<float> audioBlockFloatUnitTests;
 static AudioBlockUnitTests<double> audioBlockDoubleUnitTests;
+#if JUCE_USE_SIMD
 static AudioBlockUnitTests<SIMDRegister<float>> audioBlockSIMDFloatUnitTests;
 static AudioBlockUnitTests<SIMDRegister<double>> audioBlockSIMDDoubleUnitTests;
+#endif
 
 } // namespace dsp
 } // namespace juce

--- a/modules/juce_dsp/juce_dsp.cpp
+++ b/modules/juce_dsp/juce_dsp.cpp
@@ -74,7 +74,7 @@
   #else
    #include "native/juce_sse_SIMDNativeOps.cpp"
   #endif
- #elif defined(__arm__) || defined(_M_ARM) || defined (__arm64__) || defined (__aarch64__)
+ #elif defined(__arm__) || defined(_M_ARM) || defined (__arm64__) || defined (__aarch64__) || defined(_M_ARM64)
   #include "native/juce_neon_SIMDNativeOps.cpp"
  #else
   #error "SIMD register support not implemented for this platform"

--- a/modules/juce_dsp/juce_dsp.h
+++ b/modules/juce_dsp/juce_dsp.h
@@ -81,7 +81,7 @@
   #include <immintrin.h>
  #endif
 
-#elif defined (__ARM_NEON__) || defined (__ARM_NEON) || defined (__arm64__) || defined (__aarch64__)
+#elif defined (__ARM_NEON__) || defined (__ARM_NEON) || defined (__arm64__) || defined (__aarch64__) //TODO || defined (_M_ARM64)
 
  #ifndef JUCE_USE_SIMD
   #define JUCE_USE_SIMD 1
@@ -236,7 +236,7 @@ namespace juce
   #else
    #include "native/juce_sse_SIMDNativeOps.h"
   #endif
- #elif defined(__arm__) || defined(_M_ARM) || defined (__arm64__) || defined (__aarch64__)
+ #elif defined(__arm__) || defined(_M_ARM) || defined (__arm64__) || defined (__aarch64__) || defined (_M_ARM64)
   #include "native/juce_neon_SIMDNativeOps.h"
  #else
   #error "SIMD register support not implemented for this platform"


### PR DESCRIPTION
I have a first pass on support for MSVC ARM64.  Less Native SIMD support; as the code need some work.  MSFT ARM64 compiler doesn't like the subscript access without type  being defined as such.

Target tested on:  Surface ProX
Projucer runs fine.  DemoRunner launches, and the Demo List does not populate.

MSVC ARM64 supports OpenGL via ANGLE (OpenGL32 -> DirectX shim)
https://chromium.googlesource.com/angle/angle/+/refs/heads/master

Using FRUT:
c:\dev\repos\FRUT\prefix\FRUT\bin\Jucer2Reprojucer.exe Projucer.jucer c:\dev\repos\FRUT\cmake\Reprojucer.cmake
cmake .. -G"Visual Studio 16 2019" -AARM64