### PR TITLE
Fix vst program access

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -2239,8 +2239,15 @@ public:
 
     //==============================================================================
     int getNumPrograms() override                        { return programNames.size(); }
-    const String getProgramName (int index) override     { return programNames[index]; }
-
+    
+    const String getProgramName (int index) override     
+    { 
+        if (index >= 0)
+            return programNames[index]; 
+        else
+            return String();
+    }
+    
     int getCurrentProgram() override
     {
         if (programNames.size() > 0 && editController != nullptr)

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -2240,7 +2240,15 @@ public:
     //==============================================================================
     int getNumPrograms() override                        { return programNames.size(); }
     const String getProgramName (int index) override     { return programNames[index]; }
-    int getCurrentProgram() override                     { return jmax (0, (int) editController->getParamNormalized (programParameterID) * (programNames.size() - 1)); }
+
+    int getCurrentProgram() override
+    {
+        if (programNames.size() > 0 && editController != nullptr)
+            return jmax (0, (int) editController->getParamNormalized (programParameterID) * (programNames.size() - 1));
+        else
+            return 0;
+    }
+
     void changeProgramName (int, const String&) override {}
 
     void setCurrentProgram (int program) override

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -1593,7 +1593,7 @@ struct VSTPluginInstance     : public AudioPluginInstance,
             }
         }
 
-        return programNames [index];
+        return String();
     }
 
     void changeProgramName (int index, const String& newName) override


### PR DESCRIPTION
This PR contains two fixes to VST2 and VST3 program handling.

- First part fixes a crash when trying to retrieve the current program index from a VST3 plugin that does not have a program list, e.g. Slate Virtual Mix Rack or Eiosis AirEQ

- Second part makes sure an empty string is returned when the supplied index is invalid  for VST2 and VST3

One could argue that the caller should check `getNumPrograms()` before accessing any of these methods. However, some AU plugins report 0 programs but can still report the current program name at index -1 (see #646). So from the hosting code it is difficult to filter valid program indexes without adding branches for the various plugin formats. IMO it makes more sense to simply make the respective plugin wrapper code more roubust instead.