### PR TITLE
Unload bundle when destroying DLLHandle

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -841,6 +841,8 @@ struct DLLHandle
             if (auto exitFn = (ExitModuleFn) getFunction ("bundleExit"))
                 exitFn();
 
+            CFBundleUnloadExecutable (bundleRef);
+
             CFRelease (bundleRef);
             bundleRef = nullptr;
         }


### PR DESCRIPTION
This PR fixes a crash with Steinberg Retrologue or Padshop when the VST3 is loaded for a second time after a previous instance of the plugin has been unloaded.

The bundle has to be unloaded after `bundleExit` was called. If it is still loaded while a DLLHandle object is created, [`CFBundleLoadExecutableAndReturnError()`](https://github.com/seb-nektar/JUCE/blob/0798513650f26144533068695ff0e600b2dfcf1e/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp#L950) will return false and `bundleEntry` will not be called.

Additionally one could replace the `CFBundleLoadExecutableAndReturnError()` call with a simple `CFBundleLoadExecutable`. Bundle load/unload and calling of `bundleEntry/bundleExit` always has to be done together.