### PR TITLE
Avoid passing nullptr to setBusArrangements()

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -2052,10 +2052,15 @@ public:
             outputArrangements.add (getVst3SpeakerArrangement (requested.isDisabled() ? getBus (false, i)->getLastEnabledLayout() : requested));
         }
 
-        if (processor->setBusArrangements (inputArrangements.getRawDataPointer(), inputArrangements.size(),
-                                           outputArrangements.getRawDataPointer(), outputArrangements.size()) != kResultTrue)
-            return false;
+        // Some plug-ins will crash if you pass a nullptr to setBusArrangements!
+        Vst::SpeakerArrangement nullArrangement = {};
+        auto* inputArrangementData = inputArrangements.isEmpty() ? &nullArrangement : inputArrangements.getRawDataPointer();
+        auto* outputArrangementData = outputArrangements.isEmpty() ? &nullArrangement : outputArrangements.getRawDataPointer();
 
+        if (processor->setBusArrangements(inputArrangementData, inputArrangements.size(),
+                                          outputArrangementData, outputArrangements.size()) != kResultTrue)
+                return false;
+            
         // check if the layout matches the request
         Array<Vst::SpeakerArrangement> actualIn, actualOut;
         repopulateArrangements (actualIn, actualOut);


### PR DESCRIPTION
This applies the same fix from commit 5a0d4098 to the second occurence of `setBusArrangements()` a few lines later in `syncBusLayouts()`.

Without the patch we encountered crashes when loading the Aly James VST3 plugins [VSDX ](https://www.alyjameslab.com/alyjameslabvsdsx.html) or [VPRom](https://www.alyjameslab.com/alyjameslabvlinn.html). Applying the patch fixes the crash.
