### PR TITLE
Check if parameter list is empty when setting haveParameterList flag

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1401,8 +1401,10 @@ public:
         if (audioUnit != nullptr)
         {
             UInt32 paramListSize = 0;
-            haveParameterList = AudioUnitGetPropertyInfo (audioUnit, kAudioUnitProperty_ParameterList, kAudioUnitScope_Global,
-                                                          0, &paramListSize, nullptr) == noErr;
+            auto err = AudioUnitGetPropertyInfo (audioUnit, kAudioUnitProperty_ParameterList, kAudioUnitScope_Global,
+                                                          0, &paramListSize, nullptr);
+            
+            haveParameterList = (paramListSize > 0) && (err == noErr);
 
             if (! haveParameterList)
                 return;


### PR DESCRIPTION
The parameter list of Aly James **AU** plugins [VSDX ](https://www.alyjameslab.com/alyjameslabvsdsx.html) or [Claptrap ](https://www.alyjameslab.com/alyjameslabclaptrap.html) is empty when hosted in JUCE.

These plugins do not report an error when querying `kAudioUnitProperty_ParameterList` but return a `paramListSize` of zero when refreshing the parameter list early in the init sequence. Hence, `haveParameterList`  should be set to false. Later on in [prepareToPlay(), line 989](https://github.com/seb-nektar/JUCE/blob/ce5981c80a3e635479bd2fd7a027c5e4bc20663a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm#L989) the parameter list will be queried again if `haveParameterList` is false. Now the plugins return a non-empty parameter list.