### PR TITLE
Wrong comments in KeyPress::createFromDescription().

### DIFF
--- a/modules/juce_gui_basics/keyboard/juce_KeyPress.h
+++ b/modules/juce_gui_basics/keyboard/juce_KeyPress.h
@@ -135,14 +135,14 @@ public:
     //==============================================================================
     /** Converts a textual key description to a KeyPress.
 
-        This attempts to decode a textual version of a keypress, e.g. "CTRL + C" or "SPACE".
+        This attempts to decode a textual version of a keypress, e.g. "CTRL + C" or "spacebar".
 
         This isn't designed to cope with any kind of input, but should be given the
         strings that are created by the getTextDescription() method.
 
         If the string can't be parsed, the object returned will be invalid.
 
-        @see getTextDescription
+        @see getTextDescription, KeyPressHelpers::translations
     */
     static KeyPress createFromDescription (const String& textVersion);
 


### PR DESCRIPTION
"SPACE" didn't work. 
It should be "spacebar".
And I don't know it's good comment or not, but I had to "@see" KeyPressHelpers::translations.
So I added that at last.